### PR TITLE
Fix failing spec

### DIFF
--- a/test/long-stack-trace-zone.spec.js
+++ b/test/long-stack-trace-zone.spec.js
@@ -28,6 +28,6 @@ describe('Zone.patch', function () {
 
     expect(log[0]).toBe('Error: hello');
     dump(log[1])
-    expect(log[1].split('--- ').length).toBe(3);
+    expect(log[1].split('--- ').length).toBe(4);
   });
 });


### PR DESCRIPTION
I noticed that one test fails, and it appears that line 31 in long-stack-trace-zone.spec.js should be `expect(log[1].split('--- ').length).toBe(4);`, and not `expect(log[1].split('--- ').length).toBe(3);`, due to the first element being the stack trace constructed by `Zone.Stacktrace.prototype.get`, and one element for each level of nesting in the async chain run via `lstz.run`.
