### PR TITLE
Fix path to zone.js. Remove reference to missing patch.js

### DIFF
--- a/example/xml-http-request.html
+++ b/example/xml-http-request.html
@@ -4,8 +4,7 @@
   <meta charset="utf-8">
   <title>HTTP requests with Zones</title>
   <link rel="stylesheet" href="style.css">
-  <script src="zone.js"></script>
-  <script src="patch.js"></script>
+  <script src="../zone.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Playing with the [xml-http-request](http://localhost:3000/example/xml-http-request.html), I fixed the path to `zone.js`. Also it references a `patch.js` which isn't checked into the repo(?).
