### PR TITLE
Fixing crash on attachedCallback of an Polymer element

### DIFF
--- a/zone.js
+++ b/zone.js
@@ -590,7 +590,7 @@ Zone.patchRegisterElement = function () {
     callbacks.forEach(function (callback) {
       if (opts.prototype[callback]) {
         var descriptor = Object.getOwnPropertyDescriptor(opts.prototype, callback);
-        if (descriptor.value) {
+        if (descriptor && descriptor.value) {
           descriptor.value = zone.bind(descriptor.value || opts.prototype[callback]);
           Zone._redefineProperty(opts.prototype, callback, descriptor);
         }


### PR DESCRIPTION
When trying to include polymer paper-button in [Angular 2.0 Projects](https://github.com/angular/projects) it crash when try to register `attachedCallback` callback, `descriptor` is undefined