### PR TITLE
Use an object to hold zone bound event handlers

### DIFF
--- a/zone.js
+++ b/zone.js
@@ -288,13 +288,16 @@ Zone.patchProperties = function (obj, properties) {
 Zone.patchEventTargetMethods = function (obj) {
   var addDelegate = obj.addEventListener;
   obj.addEventListener = function (eventName, fn) {
-    arguments[1] = fn._bound = zone.bind(fn);
+    fn._bound = fn._bound || {};
+    arguments[1] = fn._bound[eventName] = zone.bind(fn);
     return addDelegate.apply(this, arguments);
   };
 
   var removeDelegate = obj.removeEventListener;
   obj.removeEventListener = function (eventName, fn) {
-    arguments[1] = arguments[1]._bound || arguments[1];
+    if(arguments[1]._bound && arguments[1]._bound[eventName]) {
+      arguments[1] = arguments[1]._bound[eventName];
+    }
     var result = removeDelegate.apply(this, arguments);
     zone.dequeueTask(fn);
     return result;


### PR DESCRIPTION
The bound event handler function gets replaced if the same event handler
function is used to handle multiple event types. This can be common
because it happens when binding events using jquery `$(el).on()`

What happens is that when an event handler gets replaced like this, it
can't be removed using `obj.removeEventListener`.
