### PR TITLE
fix(patchViaPropertyDescriptor): disable if properties are not configurable

### DIFF
--- a/zone.js
+++ b/zone.js
@@ -375,6 +375,14 @@ Zone.patch = function patch () {
 
 //
 Zone.canPatchViaPropertyDescriptor = function () {
+  if (!Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'onclick') &&
+      typeof Element !== 'undefined') {
+    // WebKit https://bugs.webkit.org/show_bug.cgi?id=134364
+    // IDL interface attributes are not configurable
+    var desc = Object.getOwnPropertyDescriptor(Element.prototype, 'onclick');
+    if (desc && !desc.configurable) return false;
+  }
+
   Object.defineProperty(HTMLElement.prototype, 'onclick', {
     get: function () {
       return true;


### PR DESCRIPTION
Relevant WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=134364

closes #42