### PR TITLE
fix(zone.js): don't make function declaration in block scope

### DIFF
--- a/zone.js
+++ b/zone.js
@@ -246,23 +246,23 @@ Zone.bindPromiseFn = (function() {
         return patchThenable(delegate.apply(this, arguments));
       };
     };
+  }
 
-    function patchThenable(thenable) {
-      var then = thenable.then;
-      thenable.then = function () {
-        var args = Zone.bindArguments(arguments);
-        var nextThenable = then.apply(thenable, args);
-        return patchThenable(nextThenable);
-      };
+  function patchThenable(thenable) {
+    var then = thenable.then;
+    thenable.then = function () {
+      var args = Zone.bindArguments(arguments);
+      var nextThenable = then.apply(thenable, args);
+      return patchThenable(nextThenable);
+    };
 
-      var ocatch = thenable.catch;
-      thenable.catch = function () {
-        var args = Zone.bindArguments(arguments);
-        var nextThenable = ocatch.apply(thenable, args);
-        return patchThenable(nextThenable);
-      };
-      return thenable;
-    }
+    var ocatch = thenable.catch;
+    thenable.catch = function () {
+      var args = Zone.bindArguments(arguments);
+      var nextThenable = ocatch.apply(thenable, args);
+      return patchThenable(nextThenable);
+    };
+    return thenable;
   }
 }());
 


### PR DESCRIPTION
It's breaks JSC =) (https://github.com/WebKit/webkit/blob/54d94f54241efa7b4dab59c88ebf82fb342f4596/Source/JavaScriptCore/parser/Parser.cpp#L1169)

Closes #53
Closes #54