### PR TITLE
gitignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 blink-core/
 blink-idl/
 parsed-idl/
+/node_modules


### PR DESCRIPTION
The best practice is probably to have it globally ignored but this doesn't hurt either