### PR TITLE
test: cleanup

### DIFF
--- a/test/patch/HTMLImports.spec.js
+++ b/test/patch/HTMLImports.spec.js
@@ -1,5 +1,10 @@
 'use strict';
 
+function supportsImports() {
+  return 'import' in document.createElement('link');
+}
+supportsImports.message = 'HTML Imports';
+
 describe('HTML Imports', ifEnvSupports(supportsImports, function () {
 
   it('should work with addEventListener', function (done) {
@@ -38,8 +43,3 @@ describe('HTML Imports', ifEnvSupports(supportsImports, function () {
     document.head.appendChild(link);
   });
 }));
-
-function supportsImports() {
-  return 'import' in document.createElement('link');
-}
-supportsImports.message = 'HTML Imports';

--- a/test/patch/Promise.spec.js
+++ b/test/patch/Promise.spec.js
@@ -1,13 +1,8 @@
 'use strict';
 
-describe('Promise', function () {
+describe('Promise', ifEnvSupports('Promise', function () {
 
   it('should work with .then', function (done) {
-    if (!window.Promise) {
-      console.log('WARNING: skipping Promise test (missing this API)');
-      return;
-    }
-
     new Promise(function (resolve) {
       resolve();
     }).then(function () {
@@ -17,10 +12,6 @@ describe('Promise', function () {
   });
 
   it('should work with .catch', function (done) {
-    if (!window.Promise) {
-      return;
-    }
-
     new Promise(function (resolve, reject) {
       reject();
     }).catch(function () {
@@ -29,4 +20,4 @@ describe('Promise', function () {
     });
   });
 
-});
+}));

--- a/test/patch/registerElement.spec.js
+++ b/test/patch/registerElement.spec.js
@@ -5,6 +5,11 @@
 
 'use strict';
 
+function registerElement() {
+  return ('registerElement' in document);
+}
+registerElement.message = 'document.registerElement';
+
 describe('document.registerElement', ifEnvSupports(registerElement, function () {
 
   // register a custom element for each callback
@@ -110,8 +115,3 @@ describe('document.registerElement', ifEnvSupports(registerElement, function () 
   });
 
 }));
-
-function registerElement() {
-  return ('registerElement' in document);
-}
-registerElement.message = 'document.registerElement';


### PR DESCRIPTION
Two minor things:
- define `testFn.message` early, otherwise it is undefined at the moment it is checked and then useless,
- use `ifEnvSupports` for Promise tests