### PR TITLE
fix: only fork on zone.fork()

### DIFF
--- a/test/long-stack-trace-zone.spec.js
+++ b/test/long-stack-trace-zone.spec.js
@@ -15,8 +15,8 @@ describe('longStackTraceZone', function () {
 
   it('should produce long stack traces', function (done) {
     lstz.run(function () {
-      setTimeout(function () {
-        setTimeout(function () {
+      zone.fork().run(function () {
+        zone.fork().run(function () {
           setTimeout(function () {
             expect(log[0]).toBe('Error: hello');
             expect(log[1].split('--- ').length).toBe(4);
@@ -35,8 +35,8 @@ describe('longStackTraceZone', function () {
         return line.indexOf('jasmine.js') === -1;
       }
     }).run(function () {
-      setTimeout(function () {
-        setTimeout(function () {
+      zone.fork().run(function () {
+        zone.fork().run(function () {
           setTimeout(function () {
             expect(log[1]).not.toContain('jasmine.js');
             done();

--- a/test/patch/element.spec.js
+++ b/test/patch/element.spec.js
@@ -14,14 +14,16 @@ describe('element', function () {
     button.remove();
   });
 
-  it('should work with addEventListener', function () {
-    var zoneHasParent;
-    button.addEventListener('click', function () {
-      zoneHasParent = !!window.zone.parent;
+  it('should work with addEventListener', function (done) {
+    var outerZone = zone;
+    zone.fork().run(function() {
+       button.addEventListener('click', function () {
+         expect(zone.parent).toBe(outerZone);
+         done();
+       })
     });
 
     button.click();
-    expect(zoneHasParent).toEqual(true);
   });
 
   it('should respect removeEventListener', function () {

--- a/test/patch/registerElement.spec.js
+++ b/test/patch/registerElement.spec.js
@@ -17,30 +17,36 @@ describe('document.registerElement', ifEnvSupports(registerElement, function () 
 
   var callbacks = {};
 
-  var customElements = callbackNames.map(function (callbackName) {
-    var fullCallbackName = callbackName + 'Callback';
-    var proto = Object.create(HTMLElement.prototype);
-    proto[fullCallbackName] = function (arg) {
-      callbacks[callbackName](arg);
-    };
-    return document.registerElement('x-' + callbackName.toLowerCase(), {
-      prototype: proto
+  var outerZone = zone;
+
+  var customElements;
+
+  zone.fork().run(function () {
+    customElements = callbackNames.map(function (callbackName) {
+      var fullCallbackName = callbackName + 'Callback';
+      var proto = Object.create(HTMLElement.prototype);
+      proto[fullCallbackName] = function (arg) {
+        callbacks[callbackName](arg);
+      };
+      return document.registerElement('x-' + callbackName.toLowerCase(), {
+        prototype: proto
+      });
     });
   });
 
 
   it('should work with createdCallback', function (done) {
     callbacks.created = function () {
-      expect(window.zone.parent).toBeDefined();
+      expect(zone.parent).toBe(outerZone);
       done();
     };
-    var elt = document.createElement('x-created');
+    document.createElement('x-created');
   });
 
 
   it('should work with attachedCallback', function (done) {
     callbacks.attached = function () {
-      expect(window.zone.parent).toBeDefined();
+      expect(zone.parent).toBe(outerZone);
       done();
     };
     var elt = document.createElement('x-attached');
@@ -51,7 +57,7 @@ describe('document.registerElement', ifEnvSupports(registerElement, function () 
 
   it('should work with detachedCallback', function (done) {
     callbacks.detached = function () {
-      expect(window.zone.parent).toBeDefined();
+      expect(zone.parent).toBe(outerZone);
       done();
     };
     var elt = document.createElement('x-detached');
@@ -62,7 +68,7 @@ describe('document.registerElement', ifEnvSupports(registerElement, function () 
 
   it('should work with attributeChanged', function (done) {
     callbacks.attributeChanged = function () {
-      expect(window.zone.parent).toBeDefined();
+      expect(zone.parent).toBe(outerZone);
       done();
     };
     var elt = document.createElement('x-attributechanged');
@@ -83,7 +89,7 @@ describe('document.registerElement', ifEnvSupports(registerElement, function () 
     var elt = document.createElement('x-prop-desc');
 
     function checkZone() {
-      expect(window.zone.parent).toBeDefined();
+      expect(zone.parent).toBe(outerZone);
       done();
     }
   });
@@ -104,7 +110,7 @@ describe('document.registerElement', ifEnvSupports(registerElement, function () 
     var elt = document.createElement('x-props-desc');
 
     function checkZone() {
-      expect(window.zone.parent).toBeDefined();
+      expect(zone.parent).toBe(outerZone);
       done();
     }
   });

--- a/test/patch/requestAnimationFrame.spec.js
+++ b/test/patch/requestAnimationFrame.spec.js
@@ -11,9 +11,12 @@ describe('requestAnimationFrame', function () {
     // if they are offscreen. We can disable this test for those browsers and
     // assume the patch works if setTimeout works, since they are mechanically
     // the same
-    window.requestAnimationFrame(function () {
-      expect(window.zone.parent).toBeDefined();
-      done();
+    var outerZone = zone;
+    zone.fork().run(function() {
+      window.requestAnimationFrame(function () {
+        expect(zone.parent).toBe(outerZone);
+        done();
+      });
     });
   });
 });
@@ -29,9 +32,12 @@ describe('mozRequestAnimationFrame', function () {
     // if they are offscreen. We can disable this test for those browsers and
     // assume the patch works if setTimeout works, since they are mechanically
     // the same
-    window.mozRequestAnimationFrame(function () {
-      expect(window.zone.parent).toBeDefined();
-      done();
+    var outerZone = zone;
+    zone.fork().run(function() {
+      window.mozRequestAnimationFrame(function () {
+        expect(zone.parent).toBe(outerZone);
+        done();
+      });
     });
   });
 });
@@ -47,9 +53,12 @@ describe('webkitRequestAnimationFrame', function () {
     // if they are offscreen. We can disable this test for those browsers and
     // assume the patch works if setTimeout works, since they are mechanically
     // the same
-    window.webkitRequestAnimationFrame(function () {
-      expect(window.zone.parent).toBeDefined();
-      done();
+    var outerZone = zone;
+    zone.fork().run(function() {
+      window.webkitRequestAnimationFrame(function () {
+        expect(zone.parent).toBe(outerZone);
+        done();
+      });
     });
   });
 });

--- a/test/patch/setInterval.spec.js
+++ b/test/patch/setInterval.spec.js
@@ -17,12 +17,9 @@ describe('setInterval', function () {
       expect(zone.mark).toEqual('child');
       expect(zone).toEqual(childZone);
 
-      var cancelId = window.setInterval(function() {
-        // creates implied zone in all callbacks.
-        expect(zone).not.toBe(childZone);
-        expect(zone.parent).toBe(childZone);
-        expect(zone.mark).toBe('child'); // proto inherited
-
+      var cancelId = setInterval(function() {
+        // the callback runs in the same zone
+        expect(zone).toBe(childZone);
         clearInterval(cancelId);
         done();
       }, 10);

--- a/test/patch/setTimeout.spec.js
+++ b/test/patch/setTimeout.spec.js
@@ -18,11 +18,9 @@ describe('setTimeout', function () {
       expect(zone.mark).toEqual('child');
       expect(zone).toEqual(childZone);
 
-      window.setTimeout(function() {
-        // creates implied zone in all callbacks.
-        expect(zone).not.toEqual(childZone);
-        expect(zone.parent).toEqual(childZone);
-        expect(zone.mark).toEqual('child'); // proto inherited
+      setTimeout(function() {
+        // the callback runs in the same zone
+        expect(zone).toEqual(childZone);
         done();
       }, 0);
 

--- a/test/zone.spec.js
+++ b/test/zone.spec.js
@@ -44,32 +44,16 @@ describe('Zone', function () {
     });
 
 
-    it('should fire onZoneCreated when a zone is forked', function (done) {
-      var createdSpy = jasmine.createSpy();
+    it('should fire onZoneCreated when a zone is forked', function () {
       var counter = 0;
       var myZone = zone.fork({
         onZoneCreated: function () {
-          counter += 1;
-        },
-        afterTask: function () {
-          counter -= 1;
+          counter++;
         }
       });
 
-      myZone.run(function () {
-
-        expect(counter).toBe(0);
-
-        setTimeout(function () {}, 0);
-        expect(counter).toBe(1);
-
-        setTimeout(function () {
-          expect(counter).toBe(0);
-          setTimeout(done, 5);
-          expect(counter).toBe(1);
-        }, 0);
-        expect(counter).toBe(2);
-      });
+      myZone.fork();
+      expect(counter).toBe(1);
     });
 
 

--- a/zone.js
+++ b/zone.js
@@ -61,9 +61,9 @@ Zone.prototype = {
 
   bind: function (fn, skipEnqueue) {
     skipEnqueue || this.enqueueTask(fn);
-    var zone = this.fork();
+    var currentZone = this;
     return function zoneBoundFn() {
-      return zone.run(fn, this, arguments);
+      return currentZone.run(fn, this, arguments);
     };
   },
 


### PR DESCRIPTION
fixes #38

previously a zone was created for any callback executed in a zone

@btford could you please check the changes - I am still learning and not 100% confident on the test updates.

Also please not that I have only updating passing tests - WS tests still fail in Chrome/Firefox/Travis and are left untouched by this PR.