### PR TITLE
feat(Node): make zone.js work in Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,11 @@ env:
     - SAUCE_ACCESS_KEY=9b988f434ff8-fbca-8aa4-4ae3-35442987
 
 before_script:
-  - npm install -g karma-cli
+  - npm install -g karma-cli gulp
   - mkdir -p $LOGS_DIR
   - ./scripts/sauce/sauce_connect_setup.sh
   - ./scripts/sauce/sauce_connect_block.sh
 
 script:
+  - gulp test
   - karma start karma-sauce.conf.js

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,14 @@
+var gulp = require('gulp');
+var jasmine = require('gulp-jasmine');
+
+gulp.task('test', function () {
+  require('./test/util');
+  require('./zone.js');
+  require('./long-stack-trace-zone.js');
+  var tests = [
+  	'test/zone.spec.js',
+  	'test/long-stack-trace-zone.spec.js',
+  	'test/patch/*.js'
+  ];
+  return gulp.src(tests).pipe(jasmine({includeStackTrace: true, timeout: 1000, verbose: true}));
+});

--- a/long-stack-trace-zone.js
+++ b/long-stack-trace-zone.js
@@ -4,6 +4,9 @@
  * We need this because in some implementations, constructing a trace is slow
  * and so we want to defer accessing the trace for as long as possible
  */
+var _global = typeof window === 'undefined' ? global : window;
+var Zone = _global.Zone;
+ 
 Zone.Stacktrace = function (e) {
   this._e = e;
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "url": "https://github.com/angular/zone.js/issues"
   },
   "devDependencies": {
+    "gulp": "^3.8.8",
+    "gulp-jasmine": "^1.0.1",
     "jasmine-core": "^2.2.0",
     "karma": "^0.12.31",
     "karma-browserify": "^4.1.2",

--- a/test/patch/HTMLImports.spec.js
+++ b/test/patch/HTMLImports.spec.js
@@ -1,11 +1,13 @@
 'use strict';
 
+var _global = typeof window === 'undefined' ? global : window;
+
 function supportsImports() {
-  return 'import' in document.createElement('link');
+  return typeof document !== 'undefined' && 'import' in document.createElement('link');
 }
 supportsImports.message = 'HTML Imports';
 
-describe('HTML Imports', ifEnvSupports(supportsImports, function () {
+describe('HTML Imports', _global.ifEnvSupports(supportsImports, function () {
 
   it('should work with addEventListener', function (done) {
     var link = document.createElement('link');

--- a/test/patch/MutationObserver.spec.js
+++ b/test/patch/MutationObserver.spec.js
@@ -1,6 +1,8 @@
 'use strict';
 
-describe('MutationObserver', ifEnvSupports('MutationObserver', function () {
+var _global = typeof window === 'undefined' ? global : window;
+
+describe('MutationObserver', _global.ifEnvSupports('MutationObserver', function () {
   var elt;
 
   beforeEach(function () {

--- a/test/patch/Promise.spec.js
+++ b/test/patch/Promise.spec.js
@@ -1,12 +1,14 @@
 'use strict';
 
-describe('Promise', ifEnvSupports('Promise', function () {
+var _global = typeof window === 'undefined' ? global : window;
+
+describe('Promise', _global.ifEnvSupports('Promise', function () {
 
   it('should work with .then', function (done) {
     new Promise(function (resolve) {
       resolve();
     }).then(function () {
-      expect(window.zone.parent).toBeDefined();
+      expect(_global.zone.parent).toBeDefined();
       done();
     });
   });
@@ -15,7 +17,7 @@ describe('Promise', ifEnvSupports('Promise', function () {
     new Promise(function (resolve, reject) {
       reject();
     }).catch(function () {
-      expect(window.zone.parent).toBeDefined();
+      expect(_global.zone.parent).toBeDefined();
       done();
     });
   });

--- a/test/patch/WebSocket.spec.js
+++ b/test/patch/WebSocket.spec.js
@@ -1,6 +1,9 @@
 'use strict';
 
-describe('WebSocket', function () {
+var _global = typeof window === 'undefined' ? global : window;
+
+describe('WebSocket', _global.ifEnvSupports('WebSocket', function () {
+  
   var socket,
       TEST_SERVER_URL = 'ws://localhost:8001',
       flag;
@@ -14,11 +17,11 @@ describe('WebSocket', function () {
     socket.close();
   });
 
-  it('should work with addEventListener', function () {
-    var parent = window.zone;
+  it('should work with addEventListener', function (done) {
+    var parent = _global.zone;
 
     socket.addEventListener('message', function (contents) {
-      expect(window.zone.parent).toBe(parent);
+      expect(_global.zone.parent).toBe(parent);
       expect(contents).toBe('HI');
       done();
     });
@@ -46,9 +49,9 @@ describe('WebSocket', function () {
   });
 
   it('should work with onmessage', function (done) {
-    var parent = window.zone;
+    var parent = _global.zone;
     socket.onmessage = function (contents) {
-      expect(window.zone.parent).toBe(parent);
+      expect(_global.zone.parent).toBe(parent);
       expect(contents.data).toBe('hi');
       done();
     };
@@ -83,4 +86,4 @@ describe('WebSocket', function () {
     expect(log).toEqual('');
   });
 
-});
+}));

--- a/test/patch/XMLHttpRequest.spec.js
+++ b/test/patch/XMLHttpRequest.spec.js
@@ -1,6 +1,8 @@
 'use strict';
 
-describe('XMLHttpRequest', function () {
+var _global = typeof window === 'undefined' ? global : window;
+
+describe('XMLHttpRequest', _global.ifEnvSupports('XMLHttpRequest', function () {
 
   it('should work with onreadystatechange', function (done) {
     var req = new XMLHttpRequest();
@@ -30,4 +32,4 @@ describe('XMLHttpRequest', function () {
     expect(req.responseType).toBe('document');
   });
 
-});
+}));

--- a/test/patch/element.spec.js
+++ b/test/patch/element.spec.js
@@ -1,6 +1,13 @@
 'use strict';
 
-describe('element', function () {
+var _global = typeof window === 'undefined' ? global : window;
+
+function element() {
+  return typeof document !== 'undefined';
+}
+element.message = 'element';
+
+describe('element', _global.ifEnvSupports(element, function () {
 
   var button;
 
@@ -73,4 +80,4 @@ describe('element', function () {
     expect(log).toEqual('');
   });
 
-});
+}));

--- a/test/patch/registerElement.spec.js
+++ b/test/patch/registerElement.spec.js
@@ -5,12 +5,14 @@
 
 'use strict';
 
+var _global = typeof window === 'undefined' ? global : window;
+
 function registerElement() {
-  return ('registerElement' in document);
+  return typeof document !== 'undefined' && ('registerElement' in document);
 }
 registerElement.message = 'document.registerElement';
 
-describe('document.registerElement', ifEnvSupports(registerElement, function () {
+describe('document.registerElement', _global.ifEnvSupports(registerElement, function () {
 
   // register a custom element for each callback
   var callbackNames = [

--- a/test/patch/requestAnimationFrame.spec.js
+++ b/test/patch/requestAnimationFrame.spec.js
@@ -1,8 +1,10 @@
 'use strict';
 
+var _global = typeof window === 'undefined' ? global : window;
+
 describe('requestAnimationFrame', function () {
   it('should run the passed callback in a zone', function (done) {
-    if (!window.requestAnimationFrame) {
+    if (!_global.requestAnimationFrame) {
       console.log('WARNING: skipping requestAnimationFrame test (missing this API)');
       return done();
     }
@@ -11,8 +13,8 @@ describe('requestAnimationFrame', function () {
     // if they are offscreen. We can disable this test for those browsers and
     // assume the patch works if setTimeout works, since they are mechanically
     // the same
-    window.requestAnimationFrame(function () {
-      expect(window.zone.parent).toBeDefined();
+    _global.requestAnimationFrame(function () {
+      expect(_global.zone.parent).toBeDefined();
       done();
     });
   });
@@ -20,7 +22,7 @@ describe('requestAnimationFrame', function () {
 
 describe('mozRequestAnimationFrame', function () {
   it('should run the passed callback in a zone', function (done) {
-    if (!window.mozRequestAnimationFrame) {
+    if (!_global.mozRequestAnimationFrame) {
       console.log('WARNING: skipping mozRequestAnimationFrame test (missing this API)');
       return done();
     }
@@ -29,8 +31,8 @@ describe('mozRequestAnimationFrame', function () {
     // if they are offscreen. We can disable this test for those browsers and
     // assume the patch works if setTimeout works, since they are mechanically
     // the same
-    window.mozRequestAnimationFrame(function () {
-      expect(window.zone.parent).toBeDefined();
+    _global.mozRequestAnimationFrame(function () {
+      expect(_global.zone.parent).toBeDefined();
       done();
     });
   });
@@ -38,7 +40,7 @@ describe('mozRequestAnimationFrame', function () {
 
 describe('webkitRequestAnimationFrame', function () {
   it('should run the passed callback in a zone', function (done) {
-    if (!window.webkitRequestAnimationFrame) {
+    if (!_global.webkitRequestAnimationFrame) {
       console.log('WARNING: skipping webkitRequestAnimationFrame test (missing this API)');
       return done();
     }
@@ -47,8 +49,8 @@ describe('webkitRequestAnimationFrame', function () {
     // if they are offscreen. We can disable this test for those browsers and
     // assume the patch works if setTimeout works, since they are mechanically
     // the same
-    window.webkitRequestAnimationFrame(function () {
-      expect(window.zone.parent).toBeDefined();
+    _global.webkitRequestAnimationFrame(function () {
+      expect(_global.zone.parent).toBeDefined();
       done();
     });
   });

--- a/test/patch/setInterval.spec.js
+++ b/test/patch/setInterval.spec.js
@@ -1,13 +1,14 @@
 'use strict';
 
 describe('setInterval', function () {
+  var _global = typeof window === 'undefined' ? global : window;
 
   beforeEach(function () {
     zone.mark = 'root';
   });
 
   it('should work with setInterval', function (done) {
-    var childZone = window.zone.fork({
+    var childZone = _global.zone.fork({
       mark: 'child'
     });
 
@@ -17,7 +18,7 @@ describe('setInterval', function () {
       expect(zone.mark).toEqual('child');
       expect(zone).toEqual(childZone);
 
-      var cancelId = window.setInterval(function() {
+      var cancelId = _global.setInterval(function() {
         // creates implied zone in all callbacks.
         expect(zone).not.toBe(childZone);
         expect(zone.parent).toBe(childZone);

--- a/test/patch/setTimeout.spec.js
+++ b/test/patch/setTimeout.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 describe('setTimeout', function () {
+  var _global = typeof window === 'undefined' ? global : window;
 
   beforeEach(function () {
     zone.mark = 'root';
@@ -8,7 +9,7 @@ describe('setTimeout', function () {
 
   it('should work with setTimeout', function (done) {
 
-    var childZone = window.zone.fork({
+    var childZone = _global.zone.fork({
       mark: 'child'
     });
 
@@ -18,7 +19,7 @@ describe('setTimeout', function () {
       expect(zone.mark).toEqual('child');
       expect(zone).toEqual(childZone);
 
-      window.setTimeout(function() {
+      _global.setTimeout(function() {
         // creates implied zone in all callbacks.
         expect(zone).not.toEqual(childZone);
         expect(zone.parent).toEqual(childZone);
@@ -34,8 +35,8 @@ describe('setTimeout', function () {
 
   it('should allow canceling of fns registered with setTimeout', function (done) {
     var spy = jasmine.createSpy();
-    var cancelId = window.setTimeout(spy, 0);
-    window.clearTimeout(cancelId);
+    var cancelId = _global.setTimeout(spy, 0);
+    _global.clearTimeout(cancelId);
     setTimeout(function () {
       expect(spy).not.toHaveBeenCalled();
       done();

--- a/test/util.js
+++ b/test/util.js
@@ -9,10 +9,12 @@ describe('whatever', run(function () {
 }, 'does not support whatevs'))
 
  */
+var _global = typeof window === 'undefined' ? global : window;
+
 function ifEnvSupports(test, block) {
   return function () {
     var message = (test.message || test.name || test);
-    if (typeof test === 'string' ? !!window[test] : test()) {
+    if (typeof test === 'string' ? !!_global[test] : test()) {
       block();
     } else {
       it('should skip the test if the API does not exist', function () {
@@ -21,6 +23,7 @@ function ifEnvSupports(test, block) {
     }
   };
 };
+_global.ifEnvSupports = ifEnvSupports;
 
 // useful for testing mocks
-window.__setTimeout = window.setTimeout;
+_global.__setTimeout = _global.setTimeout;

--- a/test/zone.spec.js
+++ b/test/zone.spec.js
@@ -144,7 +144,8 @@ describe('Zone', function () {
     var mockPromise = function() {
       return {
         then: function (a, b) {
-          window.__setTimeout(a, 0);
+          var _global = typeof window === 'undefined' ? global : window;
+          _global.__setTimeout(a, 0);
           return mockPromise();
         }
       };


### PR DESCRIPTION
This PR makes zone.js to work in Node, by setting `zone` and `Zone` as global.
To run tests in Node, do `gulp test`

For sure, all the patches which are DOM related are not applied, and not tested.

The goal behind it is to be able to fully run an Angular2 application in Node.