### PR TITLE
fix: use strcit mode for the zone.js code only

### DIFF
--- a/zone.js
+++ b/zone.js
@@ -1,6 +1,6 @@
-'use strict';
-
 (function (exports) {
+
+'use strict';
 
 var zone = null;
 


### PR DESCRIPTION
The problem with using strict mode for the entire files
is that it will propagate for the entire bundled files
if zones.js is concatenated with other code written in
the non-strict mode