### PR TITLE
Fix removeEventListener patch

### DIFF
--- a/test/patch/element.spec.js
+++ b/test/patch/element.spec.js
@@ -26,17 +26,20 @@ describe('element', function () {
 
   it('should respect removeEventListener', function () {
     var log = '';
-    var logOnClick = function logOnClick () {
+    var logFunction = function logFunction () {
       log += 'a';
     };
 
-    button.addEventListener('click', logOnClick);
+    button.addEventListener('click', logFunction);
+    button.addEventListener('focus', logFunction);
     button.click();
     expect(log).toEqual('a');
+    button.dispatchEvent(new Event('focus'));
+    expect(log).toEqual('aa');
 
-    button.removeEventListener('click', logOnClick);
+    button.removeEventListener('click', logFunction);
     button.click();
-    expect(log).toEqual('a');
+    expect(log).toEqual('aa');
   });
 
   it('should work with onclick', function () {

--- a/zone.js
+++ b/zone.js
@@ -340,13 +340,18 @@ Zone.patchProperties = function (obj, properties) {
 Zone.patchEventTargetMethods = function (obj) {
   var addDelegate = obj.addEventListener;
   obj.addEventListener = function (eventName, fn) {
-    arguments[1] = fn._bound = zone.bind(fn);
+    fn._bound = fn._bound || {};
+    arguments[1] = fn._bound[eventName] = zone.bind(fn);
     return addDelegate.apply(this, arguments);
   };
 
   var removeDelegate = obj.removeEventListener;
   obj.removeEventListener = function (eventName, fn) {
-    arguments[1] = arguments[1]._bound || arguments[1];
+    if(arguments[1]._bound && arguments[1]._bound[eventName]) {
+      var _bound = arguments[1]._bound;
+      arguments[1] = _bound[eventName];
+      delete _bound[eventName];
+    }
     var result = removeDelegate.apply(this, arguments);
     zone.dequeueTask(fn);
     return result;


### PR DESCRIPTION
Fix a case where the event handler is not removed when the event handler
function is used to handle multiple events on the same element.

replaces #36:
- add an assertion in tests,
- + `delete _bound[eventName];`

/cc @btford @IgorMinar @mnmtanish