### PR TITLE
feat(test): serve lib/ files instead of dist/

### DIFF
--- a/karma-browserify.conf.js
+++ b/karma-browserify.conf.js
@@ -5,9 +5,9 @@ module.exports = function (config) {
     basePath: '',
     files: [
       'test/util.js',
-      {pattern: 'lib/zone.js', watched: true, served: false, included: false},
       'test/commonjs.spec.js',
-      {pattern: 'test/assets/**/*.html', watched: true, served: true, included: false}
+      {pattern: 'test/assets/**/*.html', watched: true, served: true, included: false},
+      {pattern: 'lib/**/*.js', watched: true, served: false, included: false}
     ],
 
     reporters: ['progress'],

--- a/karma-microtasks.conf.js
+++ b/karma-microtasks.conf.js
@@ -5,12 +5,17 @@ module.exports = function (config) {
     basePath: '',
     files: [
       'test/util.js',
-      'dist/zone-microtask.js',
+      'test/setup-microtask.js',
       'dist/*-zone.js',
       'test/jasmine-patch.js',
       'test/microtasks.spec.js',
-      {pattern: 'test/assets/**/*.html', watched: true, served: true, included: false}
+      {pattern: 'test/assets/**/*.html', watched: true, served: true, included: false},
+      {pattern: 'lib/**/*.js', watched: true, served: false, included: false}
     ],
+
+    preprocessors: {
+      'test/setup-microtask.js': [ 'browserify' ]
+    },
 
     reporters: ['progress'],
 
@@ -20,7 +25,7 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
 
     browsers: ['Firefox'],
-    frameworks: ['jasmine'],
+    frameworks: ['jasmine', 'browserify'],
 
     captureTimeout: 60000,
 

--- a/karma-microtasks.conf.js
+++ b/karma-microtasks.conf.js
@@ -8,9 +8,13 @@ module.exports = function (config) {
       'test/setup-microtask.js',
       'dist/*-zone.js',
       'test/jasmine-patch.js',
-      'test/microtasks.spec.js',
+      'test/**/*.spec.js',
       {pattern: 'test/assets/**/*.html', watched: true, served: true, included: false},
       {pattern: 'lib/**/*.js', watched: true, served: false, included: false}
+    ],
+
+    exclude: [
+      'test/commonjs.spec.js',
     ],
 
     preprocessors: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,13 +5,18 @@ module.exports = function (config) {
     basePath: '',
     files: [
       'test/util.js',
-      'dist/zone.js',
+      'test/setup.js',
       'dist/*-zone.js',
       'test/jasmine-patch.js',
       //'test/lib/brick.js',
       'test/**/*.spec.js',
-      {pattern: 'test/assets/**/*.html', watched: true, served: true, included: false}
+      {pattern: 'test/assets/**/*.html', watched: true, served: true, included: false},
+      {pattern: 'lib/**/*.js', watched: true, served: false, included: false}
     ],
+
+    preprocessors: {
+      'test/setup.js': [ 'browserify' ]
+    },
 
     exclude: [
       'test/commonjs.spec.js',
@@ -26,7 +31,7 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
 
     browsers: ['Firefox'],
-    frameworks: ['jasmine'],
+    frameworks: ['jasmine', 'browserify'],
 
     captureTimeout: 60000,
 

--- a/test/microtasks.spec.js
+++ b/test/microtasks.spec.js
@@ -53,9 +53,11 @@ describe('Microtasks', function () {
   it('should executed Promise callback in the zone where they are scheduled', function(done) {
     var resolvedPromise = Promise.resolve(null);
 
-    zone.fork({_name: 'foo'}).run(function() {
+    var testZone = window.zone.fork();
+
+    testZone.run(function() {
       resolvedPromise.then(function() {
-        expect(zone._name).toBe('foo');
+        expect(window.zone).toBeDirectChildOf(testZone);
         done();
       });
     });
@@ -65,16 +67,18 @@ describe('Microtasks', function () {
     var resolve;
     var promise = new Promise(function (rs) {
       resolve = rs;
-    })
+    });
 
-    zone.fork({_name: 'foo'}).run(function() {
+    var testZone = window.zone.fork();
+
+    testZone.run(function() {
       promise.then(function() {
-        expect(zone._name).toBe('foo');
+        expect(window.zone).toBeDirectChildOf(testZone);
         done();
       });
     });
 
-    zone.fork({_name: 'bar'}).run(function() {
+    window.zone.fork().run(function() {
       resolve(null);
     });
   });

--- a/test/patch/HTMLImports.spec.js
+++ b/test/patch/HTMLImports.spec.js
@@ -16,7 +16,7 @@ describe('HTML Imports', ifEnvSupports(supportsImports, function () {
       link.rel = 'import';
       link.href = 'someUrl';
       link.addEventListener('error', function () {
-        assertInChildOf(testZone);
+        expect(window.zone).toBeDirectChildOf(testZone);
         document.head.removeChild(link);
         done();
       });
@@ -42,7 +42,7 @@ describe('HTML Imports', ifEnvSupports(supportsImports, function () {
         link.rel = 'import';
         link.href = 'anotherUrl';
         link.onerror = function () {
-          assertInChildOf(testZone);
+          expect(window.zone).toBeDirectChildOf(testZone);
           document.head.removeChild(link);
           done();
         };
@@ -59,7 +59,7 @@ describe('HTML Imports', ifEnvSupports(supportsImports, function () {
         link.rel = 'import';
         link.href = '/base/test/assets/import.html';
         link.onload = function () {
-          assertInChildOf(testZone);
+          expect(window.zone).toBeDirectChildOf(testZone);
           document.head.removeChild(link);
           done();
         };

--- a/test/patch/MutationObserver.spec.js
+++ b/test/patch/MutationObserver.spec.js
@@ -13,7 +13,7 @@ describe('MutationObserver', ifEnvSupports('MutationObserver', function () {
 
     testZone.run(function() {
       ob = new MutationObserver(function () {
-        assertInChildOf(testZone);
+        expect(window.zone).toBeDirectChildOf(testZone);
         done();
       });
 
@@ -91,7 +91,7 @@ describe('WebKitMutationObserver', ifEnvSupports('WebKitMutationObserver', funct
       elt = document.createElement('div');
 
       var ob = new WebKitMutationObserver(function () {
-        assertInChildOf(testZone);
+        expect(window.zone).toBeDirectChildOf(testZone);
         done();
       });
 

--- a/test/patch/Promise.spec.js
+++ b/test/patch/Promise.spec.js
@@ -10,7 +10,7 @@ describe('Promise', ifEnvSupports('Promise', function () {
       new Promise(function (resolveFn) {
         resolve = resolveFn;
       }).then(function () {
-        assertInChildOf(testZone);
+        expect(window.zone).toBeDirectChildOf(testZone);
         done();
       });
     });
@@ -25,7 +25,7 @@ describe('Promise', ifEnvSupports('Promise', function () {
       new Promise(function (resolveFn, rejectFn) {
         reject = rejectFn;
       }).catch(function () {
-        assertInChildOf(testZone);
+        expect(window.zone).toBeDirectChildOf(testZone);
         done();
       });
     });

--- a/test/patch/WebSocket.spec.js
+++ b/test/patch/WebSocket.spec.js
@@ -26,7 +26,7 @@ describe('WebSocket', function () {
   it('should work with addEventListener', function (done) {
     testZone.run(function() {
       socket.addEventListener('message', function (event) {
-        assertInChildOf(testZone);
+        expect(window.zone).toBeDirectChildOf(testZone);
         expect(event.data).toBe('hi');
         done();
       });
@@ -60,7 +60,7 @@ describe('WebSocket', function () {
   it('should work with onmessage', function (done) {
     testZone.run(function() {
       socket.onmessage = function (contents) {
-        assertInChildOf(testZone);
+        expect(window.zone).toBeDirectChildOf(testZone);
         expect(contents.data).toBe('hi');
         done();
       };

--- a/test/patch/XMLHttpRequest.spec.js
+++ b/test/patch/XMLHttpRequest.spec.js
@@ -12,7 +12,7 @@ describe('XMLHttpRequest', function () {
       req.onreadystatechange = function () {
         // Make sure that the callback will only be called once
         req.onreadystatechange = null;
-        assertInChildOf(testZone);
+        expect(window.zone).toBeDirectChildOf(testZone);
         done();
       };
       req.open('get', '/', true);
@@ -29,7 +29,7 @@ describe('XMLHttpRequest', function () {
       req.onprogress = function () {
         // Make sure that the callback will only be called once
         req.onprogress = null;
-        assertInChildOf(testZone);
+        expect(window.zone).toBeDirectChildOf(testZone);
         done();
       };
       req.open('get', '/', true);

--- a/test/patch/element.spec.js
+++ b/test/patch/element.spec.js
@@ -16,16 +16,13 @@ describe('element', function () {
   });
 
   it('should work with addEventListener', function () {
-    var childTestZone;
-
     testZone.run(function() {
       button.addEventListener('click', function () {
-        childTestZone = window.zone;
+        expect(window.zone).toBeDirectChildOf(testZone);
       });
     });
 
     button.click();
-    expect(childTestZone.parent).toBe(testZone);
   });
 
   it('should respect removeEventListener', function () {
@@ -61,16 +58,13 @@ describe('element', function () {
 
     ifEnvSupports(supportsOnClick, function() {
       it('should spawn new child zones', function () {
-        var childTestZone;
-
         testZone.run(function() {
           button.onclick = function () {
-            childTestZone = window.zone;
+            expect(window.zoneA).toBeDirectChildOf(testZone);
           };
         });
 
         button.click();
-        expect(childTestZone.parent).toBe(testZone);
       });
     });
 

--- a/test/patch/registerElement.spec.js
+++ b/test/patch/registerElement.spec.js
@@ -41,7 +41,7 @@ describe('document.registerElement', ifEnvSupports(registerElement, function () 
 
   it('should work with createdCallback', function (done) {
     callbacks.created = function () {
-      assertInChildOf(testZone);
+      expect(window.zone).toBeDirectChildOf(testZone);
       done();
     };
 
@@ -51,7 +51,7 @@ describe('document.registerElement', ifEnvSupports(registerElement, function () 
 
   it('should work with attachedCallback', function (done) {
     callbacks.attached = function () {
-      assertInChildOf(testZone);
+      expect(window.zone).toBeDirectChildOf(testZone);
       done();
     };
 
@@ -63,7 +63,7 @@ describe('document.registerElement', ifEnvSupports(registerElement, function () 
 
   it('should work with detachedCallback', function (done) {
     callbacks.detached = function () {
-      assertInChildOf(testZone);
+      expect(window.zone).toBeDirectChildOf(testZone);
       done();
     };
 
@@ -75,7 +75,7 @@ describe('document.registerElement', ifEnvSupports(registerElement, function () 
 
   it('should work with attributeChanged', function (done) {
     callbacks.attributeChanged = function () {
-      assertInChildOf(testZone);
+      expect(window.zone).toBeDirectChildOf(testZone);
       done();
     };
 
@@ -97,7 +97,7 @@ describe('document.registerElement', ifEnvSupports(registerElement, function () 
       document.registerElement('x-prop-desc', { prototype: proto });
 
       function checkZone() {
-        assertInChildOf(testZone);
+        expect(window.zone).toBeDirectChildOf(testZone);
         done();
       }
     });
@@ -121,7 +121,7 @@ describe('document.registerElement', ifEnvSupports(registerElement, function () 
       document.registerElement('x-props-desc', { prototype: proto });
 
       function checkZone() {
-        assertInChildOf(testZone);
+        expect(window.zone).toBeDirectChildOf(testZone);
         done();
       }
     });

--- a/test/patch/requestAnimationFrame.spec.js
+++ b/test/patch/requestAnimationFrame.spec.js
@@ -16,7 +16,7 @@ describe('requestAnimationFrame', function () {
         // assume the patch works if setTimeout works, since they are mechanically
         // the same
         window.requestAnimationFrame(function () {
-          assertInChildOf(testZone);
+          expect(window.zone).toBeDirectChildOf(testZone);
           done();
         });
       });
@@ -36,7 +36,7 @@ describe('requestAnimationFrame', function () {
         // assume the patch works if setTimeout works, since they are mechanically
         // the same
         window.mozRequestAnimationFrame(function () {
-          assertInChildOf(testZone);
+          expect(window.zone).toBeDirectChildOf(testZone);
           done();
         });
       });
@@ -56,7 +56,7 @@ describe('requestAnimationFrame', function () {
         // assume the patch works if setTimeout works, since they are mechanically
         // the same
         window.webkitRequestAnimationFrame(function () {
-          assertInChildOf(testZone);
+          expect(window.zone).toBeDirectChildOf(testZone);
           done();
         });
       });

--- a/test/patch/setInterval.spec.js
+++ b/test/patch/setInterval.spec.js
@@ -2,35 +2,18 @@
 
 describe('setInterval', function () {
 
-  beforeEach(function () {
-    zone.mark = 'root';
-  });
-
   it('should work with setInterval', function (done) {
-    var childZone = window.zone.fork({
-      mark: 'child'
-    });
+    var testZone = window.zone.fork();
 
-    expect(zone.mark).toEqual('root');
-
-    childZone.run(function() {
-      expect(zone.mark).toEqual('child');
-      expect(zone).toEqual(childZone);
-
+    testZone.run(function() {
       var cancelId = window.setInterval(function() {
         // creates implied zone in all callbacks.
-        expect(zone).not.toBe(childZone);
-        expect(zone.parent).toBe(childZone);
-        expect(zone.mark).toBe('child'); // proto inherited
+        expect(window.zone).toBeDirectChildOf(testZone);
 
         clearInterval(cancelId);
         done();
       }, 10);
-
-      expect(zone.mark).toEqual('child');
     });
-
-    expect(zone.mark).toEqual('root');
   });
 
 });

--- a/test/patch/setTimeout.spec.js
+++ b/test/patch/setTimeout.spec.js
@@ -2,34 +2,18 @@
 
 describe('setTimeout', function () {
 
-  beforeEach(function () {
-    zone.mark = 'root';
-  });
-
   it('should work with setTimeout', function (done) {
 
-    var childZone = window.zone.fork({
-      mark: 'child'
-    });
+    var testZone = window.zone.fork();
 
-    expect(zone.mark).toEqual('root');
-
-    childZone.run(function() {
-      expect(zone.mark).toEqual('child');
-      expect(zone).toEqual(childZone);
+    testZone.run(function() {
 
       window.setTimeout(function() {
         // creates implied zone in all callbacks.
-        expect(zone).not.toEqual(childZone);
-        expect(zone.parent).toEqual(childZone);
-        expect(zone.mark).toEqual('child'); // proto inherited
+        expect(window.zone).toBeDirectChildOf(testZone);
         done();
       }, 0);
-
-      expect(zone.mark).toEqual('child');
     });
-
-    expect(zone.mark).toEqual('root');
   });
 
   it('should allow canceling of fns registered with setTimeout', function (done) {

--- a/test/setup-microtask.js
+++ b/test/setup-microtask.js
@@ -1,0 +1,2 @@
+// Setup tests for Zone with microtask support
+require('../lib/browser/zone-microtask.js');

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,2 @@
+// Setup tests for Zone without microtask support
+require('../lib/browser/zone.js');

--- a/test/util.js
+++ b/test/util.js
@@ -49,6 +49,23 @@ var customMatchers = {
         };
       }
     }
+  },
+  toBeDirectChildOf: function() {
+    return {
+      compare: function(childZone, parentZone) {
+        if (childZone.parent === parentZone) {
+          return {
+            pass: true,
+            message: 'The zone [' + childZone.$id + '] is a direct child of the zone [' + parentZone.$id + ']'
+          };
+        }
+
+        return {
+          pass: false,
+          message: 'The zone [' + childZone.$id + '] is not a direct child of the zone [' + parentZone.$id + ']'
+        };
+      }
+    }
   }
 }
 

--- a/test/util.js
+++ b/test/util.js
@@ -22,10 +22,6 @@ function ifEnvSupports(test, block) {
   };
 };
 
-function assertInChildOf(parentZone) {
-  expect(window.zone).toBeChildOf(parentZone);
-}
-
 var customMatchers = {
   // Assert that a zone is a child of an other zone
   // usage: `expect(childZone).toBeChildOf(parentZone);`

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -1,0 +1,31 @@
+'use strict';
+
+describe('Util', function () {
+
+  describe('Custom assertions', function() {
+    var child = window.zone.fork();
+    var grandChild = child.fork();
+
+    describe('toBeChildOf', function() {
+      it('should assert that the child zone is a child of the parent zone', function() {
+        expect(child).toBeChildOf(window.zone);
+        expect(grandChild).toBeChildOf(window.zone);
+        expect(grandChild).toBeChildOf(child);
+
+        expect(child).not.toBeChildOf(grandChild);
+        expect(child).not.toBeChildOf(child);
+      });
+    });
+
+    describe('toBeDirectChildOf', function() {
+      it('should assert that the child zone is a direct child of the parent zone', function() {
+        expect(child).toBeDirectChildOf(window.zone);
+        expect(grandChild).toBeDirectChildOf(child);
+
+        expect(grandChild).not.toBeDirectChildOf(window.zone);
+        expect(child).not.toBeDirectChildOf(grandChild);
+        expect(child).not.toBeDirectChildOf(child);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### first commit:

relates to #98 

Previously tests were using the generated JS files in `/dist` which means that we have to rebuild after any modification of source files (in `/lib`).

With this PR tests use the files in `/lib` and are automatically re-run when one of them is changed. This is a step towards not having to `gulp build` for each single commit but only for releases.

### next commits 

test: strengthen assertions & some cleanup.