### PR TITLE
fix(register-element): add check for descriptor being defined

### DIFF
--- a/lib/patch/register-element.js
+++ b/lib/patch/register-element.js
@@ -23,6 +23,8 @@ function apply() {
           descriptor.value = global.zone.bind(descriptor.value || opts.prototype[callback]);
           _redefineProperty(opts.prototype, callback, descriptor);
         }
+      } else if (opts.prototype[callback]) {
+        opts.prototype[callback] = global.zone.bind(opts.prototype[callback]);
       }
     });
     return _registerElement.apply(document, [name, opts]);

--- a/lib/patch/register-element.js
+++ b/lib/patch/register-element.js
@@ -17,7 +17,7 @@ function apply() {
 
   document.registerElement = function (name, opts) {
     callbacks.forEach(function (callback) {
-      if (opts.prototype[callback]) {
+      if (opts.prototype.hasOwnProperty(callback)) {
         var descriptor = Object.getOwnPropertyDescriptor(opts.prototype, callback);
         if (descriptor.value) {
           descriptor.value = global.zone.bind(descriptor.value || opts.prototype[callback]);

--- a/lib/patch/register-element.js
+++ b/lib/patch/register-element.js
@@ -16,17 +16,20 @@ function apply() {
   ];
 
   document.registerElement = function (name, opts) {
-    callbacks.forEach(function (callback) {
-      if (opts.prototype.hasOwnProperty(callback)) {
-        var descriptor = Object.getOwnPropertyDescriptor(opts.prototype, callback);
-        if (descriptor.value) {
-          descriptor.value = global.zone.bind(descriptor.value || opts.prototype[callback]);
-          _redefineProperty(opts.prototype, callback, descriptor);
+    if (opts && opts.prototype) {
+      callbacks.forEach(function (callback) {
+        if (opts.prototype.hasOwnProperty(callback)) {
+          var descriptor = Object.getOwnPropertyDescriptor(opts.prototype, callback);
+          if (descriptor.value) {
+            descriptor.value = global.zone.bind(descriptor.value || opts.prototype[callback]);
+            _redefineProperty(opts.prototype, callback, descriptor);
+          }
+        } else if (opts.prototype[callback]) {
+          opts.prototype[callback] = global.zone.bind(opts.prototype[callback]);
         }
-      } else if (opts.prototype[callback]) {
-        opts.prototype[callback] = global.zone.bind(opts.prototype[callback]);
-      }
-    });
+      });
+    }
+
     return _registerElement.apply(document, [name, opts]);
   };
 }

--- a/test/patch/registerElement.spec.js
+++ b/test/patch/registerElement.spec.js
@@ -130,14 +130,16 @@ describe('document.registerElement', ifEnvSupports(registerElement, function () 
   });
 
 
-  it('should check that callback is own property', function (done) {
+  it('should check bind callback if not own property', function (done) {
     testZone.run(function() {
       var originalProto = {
         createdCallback: function() {}
       }
       var secondaryProto = Object.create(originalProto);
+      expect(secondaryProto.createdCallback).toBe(originalProto.createdCallback);
       expect(function() {
-        document.registerElement('x-no-opts', { prototype: secondaryProto });
+        document.registerElement('x-inherited-callback', { prototype: secondaryProto });
+        expect(secondaryProto.createdCallback).not.toBe(originalProto.createdCallback);
         done();
       }).not.toThrow();
     });

--- a/test/patch/registerElement.spec.js
+++ b/test/patch/registerElement.spec.js
@@ -145,4 +145,11 @@ describe('document.registerElement', ifEnvSupports(registerElement, function () 
     });
   });
 
+
+  it('should not throw if no options passed to registerElement', function () {
+    expect(function() {
+      document.registerElement('x-no-opts');
+    }).not.toThrow();
+  });
+
 }));

--- a/test/patch/registerElement.spec.js
+++ b/test/patch/registerElement.spec.js
@@ -129,4 +129,18 @@ describe('document.registerElement', ifEnvSupports(registerElement, function () 
     var elt = document.createElement('x-props-desc');
   });
 
+
+  it('should check that callback is own property', function (done) {
+    testZone.run(function() {
+      var originalProto = {
+        createdCallback: function() {}
+      }
+      var secondaryProto = Object.create(originalProto);
+      expect(function() {
+        document.registerElement('x-no-opts', { prototype: secondaryProto });
+        done();
+      }).not.toThrow();
+    });
+  });
+
 }));


### PR DESCRIPTION
Using other component libraries, like Polymer, alongside Angular2+zones would
cause errors because the descriptor was undefined when the patched registerElement
was being called.