### PR TITLE
[WIP] refactor(jasmine patch): add support for microtasks

### DIFF
--- a/lib/jasmine/patch.js
+++ b/lib/jasmine/patch.js
@@ -1,6 +1,6 @@
 'use strict';
-// Patch jasmine's it and fit functions so that the `done` callback always resets the zone
-// to the jasmine zone, which should be the root zone. (angular/zone.js#91)
+// Patch jasmine's it and fit functions so that spec excutes in the root zone with a drained
+// microtask queue
 
 function apply() {
   if (!global.zone) {
@@ -16,33 +16,32 @@ function apply() {
   var originalFit = global.fit;
 
   global.it = function zoneResettingIt(description, specFn) {
-    if (specFn.length) {
-      originalIt(description, function zoneResettingSpecFn(originalDone) {
-        specFn(function zoneResettingDone() {
-          jasmineZone.run(originalDone);
-        });
-      });
-    } else {
-      originalIt(description, specFn);
-    }
+    originalIt(description, function (done) {
+      var jasmineThis = this;
+      // Wrap the spec in a set timeout so that the microtasks queue is drained before the test runs.
+      setTimeout(function() {
+        jasmineZone.run(specFn, jasmineThis, [done]);
+        if (specFn.length == 0) {
+          // Need to manually call done() when the test is sync due to the setTimeout
+          done();
+        }
+      }, 0);
+    });
   };
 
   global.fit = function zoneResettingFit(description, specFn) {
-    if (specFn.length) {
-      originalFit(description, function zoneResettingSpecFn(originalDone) {
-        specFn(function zoneResettingDone() {
-          jasmineZone.run(originalDone);
-        });
-      });
-    } else {
-      originalFit(description, specFn);
-    }
+    originalFit(description, function (done) {
+      var jasmineThis = this;
+      // Wrap the spec in a set timeout so that the microtasks queue is drained before the test runs.
+      setTimeout(function() {
+        jasmineZone.run(specFn, jasmineThis, [done]);
+        if (specFn.length == 0) {
+          // Need to manually call done() when the test is sync due to the setTimeout
+          done();
+        }
+      }, 0);
+    });
   };
-
-  // global beforeEach to check if we always start from the root zone
-  beforeEach(function() {
-    expect(global.zone.isRootZone()).toBe(true);
-  });
 }
 
 if (global.jasmine) {


### PR DESCRIPTION
This makes sure that any pending microtasks is drained before the next test executes.

Specs are explicitly executed in the `jasmineZone` then there is no need to assert that in the `beforeEach` any more.

_Note: this has been tested in Angular2 context_

@IgorMinar could you please review. We should cut a release to update Angular if you're happy with the changes.