### PR TITLE
Spin up a WS Server, Bonus Safari Edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,6 @@ script:
   - karma start karma-browserify-sauce.conf.js
   - karma start karma-microtasks-sauce.conf.js
 
+addons:
+  hosts:
+    - travis.dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
   - mkdir -p $LOGS_DIR
   - ./scripts/sauce/sauce_connect_setup.sh
   - ./scripts/sauce/sauce_connect_block.sh
+  - node test/ws-server.js &
 
 script:
   - karma start karma-sauce.conf.js

--- a/karma-microtasks.conf.js
+++ b/karma-microtasks.conf.js
@@ -1,4 +1,5 @@
 // Karma configuration
+var os = require('os');
 
 module.exports = function (config) {
   config.set({
@@ -17,7 +18,15 @@ module.exports = function (config) {
     ],
 
     preprocessors: {
-      'test/setup-microtask.js': [ 'browserify' ]
+      'test/setup-microtask.js': [ 'browserify' ],
+      // See browserify block for why WebSocket.spec is needed
+      'test/patch/WebSocket.spec.js': [ 'browserify']
+    },
+
+    browserify: {
+      // 'Hilareously', Safari/Sauce/Localhost make Websockets not work, so we
+      // have to give an explicit hostname
+      transform: [ ['envify', {'WEBSOCKET_HOST': os.hostname()}]]
     },
 
     reporters: ['progress'],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,5 @@
 // Karma configuration
+var os = require('os')
 
 module.exports = function (config) {
   config.set({
@@ -14,7 +15,15 @@ module.exports = function (config) {
     ],
 
     preprocessors: {
-      'test/setup.js': [ 'browserify' ]
+      'test/setup.js': [ 'browserify' ],
+      // See browserify block for why WebSocket.spec is needed
+      'test/patch/WebSocket.spec.js': [ 'browserify']
+    },
+
+    browserify: {
+      // 'Hilareously', Safari/Sauce/Localhost make Websockets not work, so we
+      // have to give an explicit hostname
+      transform: [ ['envify', {'WEBSOCKET_HOST': os.hostname()}]]
     },
 
     exclude: [

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "browserify": "^9.0.8",
+    "envify": "^3.4.0",
     "gulp": "^3.8.11",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.2.0",

--- a/sauce.conf.js
+++ b/sauce.conf.js
@@ -16,20 +16,19 @@ module.exports = function (config) {
       base: 'SauceLabs',
       browserName: 'firefox',
       version: '37'
+    },
+    'SL_Safari7': {
+      base: 'SauceLabs',
+      browserName: 'safari',
+      platform: 'OS X 10.9',
+      version: '7'
+    },
+    'SL_Safari8': {
+      base: 'SauceLabs',
+      browserName: 'safari',
+      platform: 'OS X 10.10',
+      version: '8'
     }
-    // },
-    // 'SL_Safari7': {
-    //   base: 'SauceLabs',
-    //   browserName: 'safari',
-    //   platform: 'OS X 10.9',
-    //   version: '7'
-    // },
-    // 'SL_Safari8': {
-    //   base: 'SauceLabs',
-    //   browserName: 'safari',
-    //   platform: 'OS X 10.10',
-    //   version: '8'
-    // }
   };
 
   config.set({

--- a/sauce.conf.js
+++ b/sauce.conf.js
@@ -1,9 +1,6 @@
 // Sauce configuration
 
 module.exports = function (config) {
-  // The WS server is not available with Sauce
-  config.exclude.push('test/**/WebSocket.spec.js');
-
   var customLaunchers = {
     'SL_Chrome': {
       base: 'SauceLabs',

--- a/sauce.conf.js
+++ b/sauce.conf.js
@@ -16,19 +16,20 @@ module.exports = function (config) {
       base: 'SauceLabs',
       browserName: 'firefox',
       version: '37'
-    },
-    'SL_Safari7': {
-      base: 'SauceLabs',
-      browserName: 'safari',
-      platform: 'OS X 10.9',
-      version: '7'
-    },
-    'SL_Safari8': {
-      base: 'SauceLabs',
-      browserName: 'safari',
-      platform: 'OS X 10.10',
-      version: '8'
     }
+    // },
+    // 'SL_Safari7': {
+    //   base: 'SauceLabs',
+    //   browserName: 'safari',
+    //   platform: 'OS X 10.9',
+    //   version: '7'
+    // },
+    // 'SL_Safari8': {
+    //   base: 'SauceLabs',
+    //   browserName: 'safari',
+    //   platform: 'OS X 10.10',
+    //   version: '8'
+    // }
   };
 
   config.set({

--- a/scripts/sauce/sauce_connect_setup.sh
+++ b/scripts/sauce/sauce_connect_setup.sh
@@ -40,6 +40,8 @@ if [ ! -z "$BROWSER_PROVIDER_READY_FILE" ]; then
   ARGS="$ARGS --readyfile $BROWSER_PROVIDER_READY_FILE"
 fi
 
+# Request a version of Sauce Connect that know how websockets do
+ARGS="$ARGS --vm-version dev-varnish"
 
 echo "Starting Sauce Connect in the background, logging into:"
 echo "  $CONNECT_LOG"

--- a/test/patch/WebSocket.spec.js
+++ b/test/patch/WebSocket.spec.js
@@ -2,7 +2,8 @@
 
 describe('WebSocket', function () {
   var socket;
-  var TEST_SERVER_URL = 'ws://localhost:8001';
+  var hostname = process.env.WEBSOCKET_HOST;
+  var TEST_SERVER_URL = 'ws://' + hostname + ':8001';
   var flag;
   var testZone = window.zone.fork();
 


### PR DESCRIPTION
Add the --vm-version dev-varnish option to Sauce Connect, to spin up an instance capable of doing WebSocket traffic.

Worked around problem Safari has sending localhost traffic through Sauce Connect by adding explicit hostnames.  The `WEBSOCKET_HOST` environment variable will be replaced (with Envify) with the value of `os.hostname` do it should JustWork locally without hosts file wunkery.

Added a hostname entry for `travis.dev` on TravisCI.

This assists with https://github.com/angular/zone.js/pull/104.