### PR TITLE
fix(PatchClass): copy static properties

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -146,7 +146,13 @@ function patchClass(className) {
         });
       }
     }(prop));
-  };
+  }
+
+  for (prop in OriginalClass) {
+    if (prop !== 'prototype' && OriginalClass.hasOwnProperty(prop)) {
+      global[className][prop] = OriginalClass[prop];
+    }
+  }
 };
 
 module.exports = {

--- a/test/patch/XMLHttpRequest.spec.js
+++ b/test/patch/XMLHttpRequest.spec.js
@@ -21,11 +21,11 @@ describe('XMLHttpRequest', function () {
     req.send();
   });
 
-  var supportsOnProgress = function() { 
+  var supportsOnProgress = function() {
     return 'onprogress' in new XMLHttpRequest();
   }
   supportsOnProgress.message = "XMLHttpRequest.onprogress";
-  
+
   describe('onprogress', ifEnvSupports(supportsOnProgress, function () {
     it('should work with onprogress', function (done) {
       var req;
@@ -52,5 +52,12 @@ describe('XMLHttpRequest', function () {
     expect(req.responseType).toBe('document');
   });
 
+  it('should preserve static constants', function() {
+    expect(XMLHttpRequest.UNSENT).toEqual(0);
+    expect(XMLHttpRequest.OPENED).toEqual(1);
+    expect(XMLHttpRequest.HEADERS_RECEIVED).toEqual(2);
+    expect(XMLHttpRequest.LOADING).toEqual(3);
+    expect(XMLHttpRequest.DONE).toEqual(4);
+  });
 });
 


### PR DESCRIPTION
fixes #127

Without the fix, the added test would fail on Safari where `patchClass` is used to patch MLHttpRequest`