### PR TITLE
Fix conflict with Polymer elements

### DIFF
--- a/lib/patch/register-element.js
+++ b/lib/patch/register-element.js
@@ -20,7 +20,7 @@ function apply() {
       callbacks.forEach(function (callback) {
         if (opts.prototype.hasOwnProperty(callback)) {
           var descriptor = Object.getOwnPropertyDescriptor(opts.prototype, callback);
-          if (descriptor.value) {
+          if (descriptor && descriptor.value) {
             descriptor.value = global.zone.bind(descriptor.value);
             _redefineProperty(opts.prototype, callback, descriptor);
           } else {


### PR DESCRIPTION
I noticed when including Polymer 1.0 elements in an Angular 2 app, this line throws an error saying it can't find `value` of undefined. I've added a simple workaround which seems to fix the issue and (so far at least) doesn't seem to cause any additional issues with Polymer or Angular.

cc @justinfagnani @addyosmani

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/zone.js/138)
<!-- Reviewable:end -->
