### PR TITLE
fix(utils): event listener patches break when passed an object implementing EventListener

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -86,21 +86,37 @@ function patchProperties(obj, properties) {
 
 function patchEventTargetMethods(obj) {
   var addDelegate = obj.addEventListener;
-  obj.addEventListener = function (eventName, fn) {
-    fn._bound = fn._bound || {};
-    arguments[1] = fn._bound[eventName] = zone.bind(fn);
+  obj.addEventListener = function (eventName, handler) {
+    var fn;
+    
+    if (handler.handleEvent) {
+      // Have to pass in 'handler' reference as an argument here, otherwise it gets clobbered in
+      // IE9 by the arguments[1] assignment at end of this function.
+      fn = (function(handler) {
+        return function() {
+          handler.handleEvent.apply(handler, arguments);
+        };
+      })(handler);
+    } else {
+      fn = handler;
+    }
+
+    handler._fn = fn;
+    handler._bound = handler._bound || {};
+    arguments[1] = handler._bound[eventName] = zone.bind(fn);
     return addDelegate.apply(this, arguments);
   };
 
   var removeDelegate = obj.removeEventListener;
-  obj.removeEventListener = function (eventName, fn) {
-    if(arguments[1]._bound && arguments[1]._bound[eventName]) {
-      var _bound = arguments[1]._bound;
+  obj.removeEventListener = function (eventName, handler) {
+    if(handler._bound && handler._bound[eventName]) {
+      var _bound = handler._bound;
+      
       arguments[1] = _bound[eventName];
       delete _bound[eventName];
     }
     var result = removeDelegate.apply(this, arguments);
-    global.zone.dequeueTask(fn);
+    global.zone.dequeueTask(handler._fn);
     return result;
   };
 };


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener:

```
listener
The object that receives a notification when an event of the specified type occurs. 
This must be an object implementing the EventListener interface, or simply a JavaScript function.
```

where EventListener is:

```
void handleEvent(
  in Event event
);
```

At present, zonejs breaks if a patched `addEventListener` is passed an object with a `handleEvent` method, because `zone.bind` is called on the handler, which it of course expects to be a function.

