### PR TITLE
feat(utils): add/removeEventListener interceptor hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Transforms a function to run within the given zone.
 ### `zone.fork`
 
 ```javascript
-zone.fork({
+var myZone = zone.fork({
   onZoneCreated: function () {},
   beforeTask: function () {},
   afterTask: function () {},
@@ -190,7 +190,8 @@ zone.fork({
   setInterval: function () {},
   alert: function () {},
   prompt: function () {},
-  addEventListener: function () {}
+  addEventListener: function () {},
+  removeEventListener: function () {}
 });
 myZone.run(function () {
   // woo!
@@ -236,6 +237,31 @@ While in this zone, calls to `window.setTimeout` will redirect to `zone.setTimeo
 
 This hook allows you to intercept calls to `EventTarget.addEventListener`.
 
+```javascript
+var myZone = zone.fork({
+  addEventListener: function(delegate) {
+    return function addEventListener(name, listener) {
+      if (name === 'click') clickListeners++;
+      delegate.apply(this, arguments);
+    }
+  }
+});
+```
+
+### `zone.removeEventListener`
+
+This hook allows you to intercept calls to `EventTarget.removeEventListener`.
+
+```javascript
+var myZone = zone.fork({
+  removeEventListener: function(delegate) {
+    return function removeEventListener(name, listener) {
+      if (name === 'click') clickListeners--;
+      delegate.apply(this, arguments);
+    }
+  }
+});
+```
 
 ## Status
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -84,41 +84,76 @@ function patchProperties(obj, properties) {
     });
 };
 
-function patchEventTargetMethods(obj) {
+function patchAddEventListener(obj) {
   var addDelegate = obj.addEventListener;
-  obj.addEventListener = function (eventName, handler) {
+
+  function addEventListenerBase (eventName, listener) {
     var fn;
     
-    if (handler.handleEvent) {
-      // Have to pass in 'handler' reference as an argument here, otherwise it gets clobbered in
+    if (listener.handleEvent) {
+      // Have to pass in 'listener' reference as an argument here, otherwise it gets clobbered in
       // IE9 by the arguments[1] assignment at end of this function.
-      fn = (function(handler) {
+      fn = (function(listener) {
         return function() {
-          handler.handleEvent.apply(handler, arguments);
+          listener.handleEvent.apply(listener, arguments);
         };
-      })(handler);
+      })(listener);
     } else {
-      fn = handler;
+      fn = listener;
     }
 
-    handler._fn = fn;
-    handler._bound = handler._bound || {};
-    arguments[1] = handler._bound[eventName] = zone.bind(fn);
-    return addDelegate.apply(this, arguments);
-  };
+    listener._fn = fn;
+    listener._bound = listener._bound || {};
+    arguments[1] = listener._bound[eventName] = zone.bind(fn);
 
+    return addDelegate.apply(this, arguments);
+  }
+
+  obj.addEventListener = function() {
+    var delegate = addEventListenerBase.bind(this);
+    var interceptedFn = global.zone.addEventListener(delegate, this);
+
+    return interceptedFn.apply(this, arguments);
+  };
+}
+
+function patchRemoveEventListener(obj) {
   var removeDelegate = obj.removeEventListener;
-  obj.removeEventListener = function (eventName, handler) {
-    if(handler._bound && handler._bound[eventName]) {
-      var _bound = handler._bound;
+  
+  function removeEventListenerBase (eventName, listener) {
+    if (listener._bound && listener._bound[eventName]) {
+      var _bound = listener._bound;
       
       arguments[1] = _bound[eventName];
       delete _bound[eventName];
     }
+
     var result = removeDelegate.apply(this, arguments);
-    global.zone.dequeueTask(handler._fn);
+    global.zone.dequeueTask(listener._fn);
+
     return result;
   };
+
+  obj.removeEventListener = function() {
+    var delegate = removeEventListenerBase.bind(this);
+    var interceptedFn = global.zone.removeEventListener(delegate, this);
+
+    return interceptedFn.apply(this, arguments);
+  };
+}
+
+function patchEventTargetMethods(obj) {
+  function defaultInterceptor(delegate) {
+    return function() {
+      return delegate.apply(this, arguments);
+    }
+  }
+
+  global.zone.addEventListener = defaultInterceptor;
+  global.zone.removeEventListener = defaultInterceptor;
+
+  patchAddEventListener(obj);
+  patchRemoveEventListener(obj);
 };
 
 // wrap some native API on `window`


### PR DESCRIPTION
Related to #142.

README.md:
### `zone.addEventListener`

This hook allows you to intercept calls to `EventTarget.addEventListener`.

```javascript
var myZone = zone.fork({
  addEventListener: function(delegate) {
    return function addEventListener(name, listener) {
      if (name === 'click') clickListeners++;
      delegate.apply(this, arguments);
    }
  }
});
```

### `zone.removeEventListener`

This hook allows you to intercept calls to `EventTarget.removeEventListener`.

```javascript
var myZone = zone.fork({
  removeEventListener: function(delegate) {
    return function removeEventListener(name, listener) {
      if (name === 'click') clickListeners--;
      delegate.apply(this, arguments);
    }
  }
});
```

Feedback wanted.

I wonder whether this will pass the IE9 tests...