### PR TITLE
Foreign window handlers must be ignored.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -88,35 +88,47 @@ function patchEventTargetMethods(obj) {
   var addDelegate = obj.addEventListener;
   obj.addEventListener = function (eventName, handler) {
     var fn;
-    
-    if (handler.handleEvent) {
-      // Have to pass in 'handler' reference as an argument here, otherwise it gets clobbered in
-      // IE9 by the arguments[1] assignment at end of this function.
-      fn = (function(handler) {
-        return function() {
-          handler.handleEvent.apply(handler, arguments);
-        };
-      })(handler);
-    } else {
-      fn = handler;
+    try {
+        if (handler.handleEvent) {
+          // Have to pass in 'handler' reference as an argument here, otherwise it gets clobbered in
+          // IE9 by the arguments[1] assignment at end of this function.
+          fn = (function(handler) {
+            return function() {
+              handler.handleEvent.apply(handler, arguments);
+            };
+          })(handler);
+        } else {
+          fn = handler;
+        }
+
+        handler._fn = fn;
+        handler._bound = handler._bound || {};
+        arguments[1] = handler._bound[eventName] = zone.bind(fn);
+    } catch(e) {
+        console.error('addEventListener: ', eventName, e);
     }
 
-    handler._fn = fn;
-    handler._bound = handler._bound || {};
-    arguments[1] = handler._bound[eventName] = zone.bind(fn);
     return addDelegate.apply(this, arguments);
   };
 
   var removeDelegate = obj.removeEventListener;
   obj.removeEventListener = function (eventName, handler) {
-    if(handler._bound && handler._bound[eventName]) {
-      var _bound = handler._bound;
-      
-      arguments[1] = _bound[eventName];
-      delete _bound[eventName];
+    var boundFn;
+    try {
+        if(handler._bound && handler._bound[eventName]) {
+          var _bound = handler._bound;
+          
+          arguments[1] = _bound[eventName];
+          delete _bound[eventName];
+          boundFn = handler._fn;
+        }
+    } catch(e) {
+        console.error('removeEventListener: ', eventName, e);
     }
     var result = removeDelegate.apply(this, arguments);
-    global.zone.dequeueTask(handler._fn);
+    if (boundFn) {
+        global.zone.dequeueTask(boundFn);
+    }
     return result;
   };
 };


### PR DESCRIPTION
For example the Firefox's WebDriver extension seems to pass in a
handler that resides outside of the zone.js window. Appears to be
this one:
https://github.com/SeleniumHQ/selenium/blob/6dae6c1c19246e5955b04a463b8e99952d6e691b/javascript/firefox-driver/js/utils.js#L1068

Such handlers cannot be modified nor inspected and therefore must be
ignored otherwise selenium reports `Avoid permission denied on
handler 'handleEvent'`