### PR TITLE
fix: js path in examples

### DIFF
--- a/example/counting.html
+++ b/example/counting.html
@@ -5,7 +5,7 @@
   <title>Counting Pending Tasks</title>
   <link rel="stylesheet" href="css/style.css">
   <script src="../dist/zone.js"></script>
-  <script src="counting-zone.js"></script>
+  <script src="js/counting-zone.js"></script>
 </head>
 <body>
 

--- a/example/except.html
+++ b/example/except.html
@@ -5,7 +5,7 @@
   <title>Except Zone</title>
   <link rel="stylesheet" href="css/style.css">
   <script src="../dist/zone.js"></script>
-  <script src="except-zone.js"></script>
+  <script src="js/except-zone.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
@btford this commit fixes the path to js files in the examples.

I'm trying to run the examples in Win10 to debug Edge issues.