### PR TITLE
fix(utils): addEventListener patch callback binding

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -108,7 +108,11 @@ function patchEventTargetMethods(obj) {
 
       handler._fn = fn;
       handler._bound = handler._bound || {};
-      arguments[1] = handler._bound[eventName] = zone.bind(fn);
+
+      var listenerZone = global.zone;
+      arguments[1] = handler._bound[eventName] = function() {
+          return listenerZone.bindOnce(fn).apply(this, arguments);
+      }
     }
     return addDelegate.apply(this, arguments);
   };
@@ -117,13 +121,10 @@ function patchEventTargetMethods(obj) {
   obj.removeEventListener = function (eventName, handler) {
     if(handler._bound && handler._bound[eventName]) {
       var _bound = handler._bound;
-      
       arguments[1] = _bound[eventName];
       delete _bound[eventName];
     }
-    var result = removeDelegate.apply(this, arguments);
-    global.zone.dequeueTask(handler._fn);
-    return result;
+    return removeDelegate.apply(this, arguments);
   };
 };
 

--- a/test/patch/element.spec.js
+++ b/test/patch/element.spec.js
@@ -50,6 +50,34 @@ describe('element', function () {
     button.dispatchEvent(clickEvent);
   });
 
+  it('should call listener zone enqueueTask/dequeueTask', function () {
+    var clickEvent = document.createEvent('Event');
+    clickEvent.initEvent('click', true, true);
+
+    var enqueueSpy = jasmine.createSpy('equeueTask')
+    var dequeueSpy = jasmine.createSpy('dequeueTask')
+    var listenerZone = testZone.fork({
+        '+enqueueTask': enqueueSpy,
+        '-dequeueTask': dequeueSpy
+    });
+
+    listenerZone.run(function() {
+      button.addEventListener('click', function (event) {
+        expect(zone).toBeDirectChildOf(listenerZone);
+        expect(event).toBe(clickEvent)
+      });
+    });
+
+    testZone.run(function() {
+        button.dispatchEvent(clickEvent);
+    });
+
+    expect(enqueueSpy).toHaveBeenCalled();
+    expect(dequeueSpy).toHaveBeenCalled();
+    expect(enqueueSpy.calls.count()).toBe(1);
+    expect(dequeueSpy.calls.count()).toBe(1);
+  });
+
   it('should respect removeEventListener when called with a function listener', function () {
     var log = '';
     var logFunction = function logFunction () {


### PR DESCRIPTION
The callback is to be bound to the current zone for every event
occurence using bindOnce (dequeued immediatelly after finishing).