### PR TITLE
fix(addEventListener patch): ignore FunctionWrapper for IE11 & Edge d…

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -92,22 +92,24 @@ function patchEventTargetMethods(obj) {
   var addDelegate = obj.addEventListener;
   obj.addEventListener = function (eventName, handler) {
     var fn;
-    
-    if (handler.handleEvent) {
-      // Have to pass in 'handler' reference as an argument here, otherwise it gets clobbered in
-      // IE9 by the arguments[1] assignment at end of this function.
-      fn = (function(handler) {
-        return function() {
-          handler.handleEvent.apply(handler, arguments);
-        };
-      })(handler);
-    } else {
-      fn = handler;
-    }
+    //Ignore special listeners of IE11 & Edge dev tools, see https://github.com/angular/zone.js/issues/150
+    if (handler.toString() !== "[object FunctionWrapper]") {
+      if (handler.handleEvent) {
+        // Have to pass in 'handler' reference as an argument here, otherwise it gets clobbered in
+        // IE9 by the arguments[1] assignment at end of this function.
+        fn = (function(handler) {
+          return function() {
+            handler.handleEvent.apply(handler, arguments);
+          };
+        })(handler);
+      } else {
+        fn = handler;
+      }
 
-    handler._fn = fn;
-    handler._bound = handler._bound || {};
-    arguments[1] = handler._bound[eventName] = zone.bind(fn);
+      handler._fn = fn;
+      handler._bound = handler._bound || {};
+      arguments[1] = handler._bound[eventName] = zone.bind(fn);
+    }
     return addDelegate.apply(this, arguments);
   };
 


### PR DESCRIPTION
…ev tools

Fixes the issue described in #150 in the IE and Edge dev tools.
These tools add add event listeners with a special object as a handler, a `FunctionWrapper`. Zone shouldn't interfere with those.