### PR TITLE
feat(zone.js): support Android browser

### DIFF
--- a/lib/patch/property-descriptor.js
+++ b/lib/patch/property-descriptor.js
@@ -11,6 +11,7 @@ function apply() {
     return;
   }
 
+  var supportsWebSocket = typeof WebSocket !== 'undefined';
   if (canPatchViaPropertyDescriptor()) {
     // for browsers that we can patch the descriptor:  Chrome & Firefox
     var onEventNames = eventNames.map(function (property) {
@@ -18,14 +19,16 @@ function apply() {
     });
     utils.patchProperties(HTMLElement.prototype, onEventNames);
     utils.patchProperties(XMLHttpRequest.prototype);
-    if (typeof WebSocket !== 'undefined') {
+    if (supportsWebSocket) {
       utils.patchProperties(WebSocket.prototype);
     }
   } else {
-    // Safari
+    // Safari, Android browsers (Jelly Bean)
     patchViaCapturingAllTheEvents();
     utils.patchClass('XMLHttpRequest');
-    webSocketPatch.apply();
+    if (supportsWebSocket) {
+      webSocketPatch.apply();
+    }
   }
 }
 

--- a/sauce.conf.js
+++ b/sauce.conf.js
@@ -49,6 +49,12 @@ module.exports = function (config) {
       browserName: 'internet explorer',
       platform: 'Windows 8.1',
       version: '11'
+    },
+    'SL_ANDROID4.3': {
+      base: 'SauceLabs',
+      browserName: 'android',
+      platform: 'Linux',
+      version: '4.3'
     }
   };
 

--- a/test/patch/XMLHttpRequest.spec.js
+++ b/test/patch/XMLHttpRequest.spec.js
@@ -48,8 +48,13 @@ describe('XMLHttpRequest', function () {
     var req = new XMLHttpRequest();
     req.open('get', '/', true);
     req.send();
-    req.responseType = 'document';
-    expect(req.responseType).toBe('document');
+    try {
+      req.responseType = 'document';
+      expect(req.responseType).toBe('document');
+    } catch (e) {
+      //Android browser: using this setter throws, this should be preserved
+      expect(e.message).toBe('INVALID_STATE_ERR: DOM Exception 11');
+    }
   });
 
   it('should preserve static constants', function() {


### PR DESCRIPTION
A small fix to support the Android browser 4.1.x and above.
Only one of them was added to SauceLabs as the issue was the same in all of them.