### PR TITLE
chore(test): make Microtasks test safer in slow env

### DIFF
--- a/test/microtasks.spec.js
+++ b/test/microtasks.spec.js
@@ -37,7 +37,7 @@ describe('Microtasks', function () {
 
     setTimeout(function() {
       log.push('mat2');
-    }, 20);
+    }, 30);
 
     setTimeout(function() {
       expect(log).toEqual([
@@ -45,7 +45,7 @@ describe('Microtasks', function () {
         '+mat1', '-mat1', 'mat1.mit',
         'mat2']);
       done();
-    }, 30);
+    }, 40);
 
     log.push('-root');
   });


### PR DESCRIPTION
In the failure, 'mat2' is logged before 'mat1.mit', which can happen in a slow environment, like an Android emulator in SauceLabs.
Trying to make the test safer.