### PR TITLE
fix(longStackTraceZone): modifies stackFramesFilter to exclude zone.js frames

### DIFF
--- a/lib/zones/long-stack-trace.js
+++ b/lib/zones/long-stack-trace.js
@@ -69,7 +69,7 @@ module.exports = {
   },
 
   stackFramesFilter: function (line) {
-    return /zone(-microtask)?(\.min)?\.js/.test(line);
+    return !/zone(-microtask)?(\.min)?\.js/.test(line);
   },
 
   onError: function (exception) {

--- a/test/long-stack-trace-zone.spec.js
+++ b/test/long-stack-trace-zone.spec.js
@@ -19,6 +19,7 @@ describe('longStackTraceZone', function () {
         setTimeout(function () {
           setTimeout(function () {
             expect(log[0]).toBe('Error: hello');
+
             expect(log[1].split('--- ').length).toBe(4);
             done();
           }, 0);
@@ -28,6 +29,13 @@ describe('longStackTraceZone', function () {
     });
   });
 
+  it('should filter out zone.js frames with default stackFramesFilter impl', function () {
+    var zoneFrame = 'at Zone.bind (http://localhost:8080/node_modules/zone.js/dist/zone.js:84:48)';
+    var nonZoneFrame = 'at a (http://localhost:8080/index.js:7:3)';
+
+    expect(lstz.stackFramesFilter(zoneFrame)).toBe(false);
+    expect(lstz.stackFramesFilter(nonZoneFrame)).toBe(true);
+  });
 
   it('should filter based on stackFramesFilter', function (done) {
     lstz.fork({


### PR DESCRIPTION
Fixes #175.

@vicb 
