### PR TITLE
fix(utils): fixes event target patch in web workers

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,7 +118,9 @@ function patchEventTargetMethods(obj) {
       arguments[1] = handler[boundFnsKey][eventType];
     }
 
-    return global.zone.addEventListener.apply(this, arguments);
+    var target = isWebWorker() && !this ? self : this;
+
+    return global.zone.addEventListener.apply(target, arguments);
   };
 
   // This is required for the removeEventListener hook on the root zone.
@@ -131,7 +133,8 @@ function patchEventTargetMethods(obj) {
       arguments[1] = _bound[eventType];
       delete _bound[eventType];
     }
-    var result = global.zone.removeEventListener.apply(this, arguments);
+    var target = isWebWorker() && !this ? self : this;
+    var result = global.zone.removeEventListener.apply(target, arguments);
     global.zone.dequeueTask(handler[originalFnKey]);
     return result;
   };


### PR DESCRIPTION
Calling `addEventListener` in a Web Worker was breaking.

No tests, but we should probably run all the zone tests (if possible) inside a web worker as part of the test suite to ensure compatibility.