### PR TITLE
zone.js does not support timeouts that are passed as strings for eval.

### DIFF
--- a/dist/zone.js
+++ b/dist/zone.js
@@ -406,7 +406,7 @@ function patchSetClearFunction(obj, fnNames) {
         var id, fnRef = fn;
         arguments[0] = function () {
           delete ids[id];
-          return fnRef.apply(this, arguments);
+          return fnRef instanceof Function ? fnRef.apply(this, arguments) : eval.call(global, fnRef);  
         };
         var args = bindArgs(arguments);
         id = delegate.apply(obj, args);


### PR DESCRIPTION
zone.js patches to window.setTimeout and window.setInterval do not allow strings containing javascript to be eval'd.

Using zone.js in conjunction with a large legacy codebase requires us to allow eval strings be passed to timeout calls.  Currently, as zone.js expects the value to be a function, strings meant for eval fail.  This edit resolves that issue.