### PR TITLE
fix(WebSocket): don't patch EventTarget methods twice

### DIFF
--- a/lib/patch/websocket.ts
+++ b/lib/patch/websocket.ts
@@ -3,7 +3,11 @@ import * as utils from '../utils';
 // we have to patch the instance since the proto is non-configurable
 export function apply() {
   var WS = (<any>global).WebSocket;
-  utils.patchEventTargetMethods(WS.prototype);
+  // On Safari window.EventTarget doesn't exist so need to patch WS add/removeEventListener
+  // On older Chrome, no need since EventTarget was already patched
+  if (!(<any>global).EventTarget) {
+    utils.patchEventTargetMethods(WS.prototype);
+  }
   (<any>global).WebSocket = function(a, b) {
     var socket = arguments.length > 1 ? new WS(a, b) : new WS(a);
     var proxySocket;


### PR DESCRIPTION
On older versions of Chrome, patching via property descriptors isn't available, but unlike Safari, window.EventTarget exists and is already patched, so patching EventTarget methods on WebSocket.prototype again causes them to call the first patched method which then infinitely calls itself.

I didn't provide a test because the tests fail on any older Chrome version (not sure the exact range, tested on 39 and 41).  I don't have access to SauceLabs, but I believe https://github.com/angular/zone.js/pull/192 will cause failure on at least the Android 4.4 case.

This is fairly high priority for Ionic as it seems to crash Android on some devices when using livereload.