### PR TITLE
fix(utils): add the ability to prevent the default action of onEvents

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -48,8 +48,17 @@ export function patchProperty(obj, prop) {
     }
 
     if (typeof fn === 'function') {
-      this[_prop] = fn;
-      this.addEventListener(eventName, fn, false);
+      
+      function wrapFn(event) {
+        var result;
+        result = fn.apply(this, arguments);
+        
+        if (result != undefined && !result)  
+          event.preventDefault();
+      };
+
+      this[_prop] = wrapFn;
+      this.addEventListener(eventName, wrapFn, false);
     } else {
       this[_prop] = null;
     }

--- a/test/patch/element.spec.ts
+++ b/test/patch/element.spec.ts
@@ -269,4 +269,33 @@ describe('element', function () {
     });
   });
 
+  describe('onEvent default behavior', function() {
+    var checkbox;
+    beforeEach(function () {
+      checkbox = document.createElement('input');
+      checkbox.type = "checkbox";
+      document.body.appendChild(checkbox);
+    });
+
+    afterEach(function () {
+      document.body.removeChild(checkbox);
+    });
+    
+    it('should be possible to prevent default behavior by returning false', function() {
+      checkbox.onclick = function() {
+        return false;
+      };
+
+      checkbox.click();
+      expect(checkbox.checked).toBe(false);
+    });
+
+    it('should have no effect on default behavior when not returning anything', function() {
+      checkbox.onclick = function() {};
+
+      checkbox.click();
+      expect(checkbox.checked).toBe(true);
+    });
+  });
+
 });


### PR DESCRIPTION
Add the ability to prevent the default action of onEvent (onclick, onpaste, etc..) from occurring 
by returning false. 

For example, you should be able to stop text from being pasted into a textbox with:
```javascript
textarea.onpaste = function() { 
  return false;
}
```

I discovered this during my investigation of issue #232, which this PR fixes. 
I suspect it will also fix issue https://github.com/meteorhacks/zones/issues/80