### PR TITLE
fix(utils): access new XMLHttpRequest().responseBlob error

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -158,7 +158,13 @@ export function patchClass(className) {
   var prop;
   for (prop in instance) {
     (function (prop) {
-      if (typeof instance[prop] === 'function') {
+      var property;
+      try {
+        property = instance[prop];
+      } catch (error) {
+        console.warn(error);
+      }
+      if (typeof property === 'function') {
         global[className].prototype[prop] = function () {
           return this[originalInstanceKey][prop].apply(this[originalInstanceKey], arguments);
         };


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=44721

In some browsers that use webkit, It would fail when patchClass function try to access responseBlob in XMLHttpRequest instance.