### PR TITLE
chore: Fix type definitions

### DIFF
--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -1,4 +1,4 @@
-import '../zone';
+import { TaskData, Zone, Task } from '../zone';
 import {eventTargetPatch} from './event-target';
 import {propertyPatch} from './define-property';
 import {registerElementPatch} from './register-element';
@@ -96,4 +96,3 @@ function patchTimer(
     }
   });
 }
-

--- a/lib/browser/property-descriptor.ts
+++ b/lib/browser/property-descriptor.ts
@@ -1,3 +1,4 @@
+import { Zone } from '../zone';
 import * as webSocketPatch from './websocket';
 import {zoneSymbol, patchOnProperties, patchClass, isBrowser, isNode} from './utils';
 
@@ -7,7 +8,7 @@ export function propertyDescriptorPatch(_global) {
   if (isNode){
     return;
   }
-  
+
   var supportsWebSocket = typeof WebSocket !== 'undefined';
   if (canPatchViaPropertyDescriptor()) {
     // for browsers that we can patch the descriptor:  Chrome & Firefox

--- a/lib/browser/register-element.ts
+++ b/lib/browser/register-element.ts
@@ -1,3 +1,4 @@
+import { Zone } from '../zone';
 import {_redefineProperty} from './define-property';
 import {isBrowser} from './utils';
 

--- a/lib/browser/utils.ts
+++ b/lib/browser/utils.ts
@@ -1,3 +1,4 @@
+import { Zone, TaskData, Task } from '../zone';
 /**
  * Suppress closure compiler errors about unknown 'process' variable
  * @fileoverview
@@ -317,4 +318,3 @@ export function patchMethod(target: any, name: string,
   }
   return delegate;
 }
-

--- a/lib/jasmine/jasmine.ts
+++ b/lib/jasmine/jasmine.ts
@@ -1,4 +1,4 @@
-'use strict';
+import { Zone, ZoneSpec, Task, ZoneDelegate, MicroTask } from '../../lib/zone';
 // Patch jasmine's it and fit functions so that the `done` wrapCallback always resets the zone
 // to the jasmine zone, which should be the root zone. (angular/zone.js#91)
 if (!Zone) {
@@ -30,4 +30,3 @@ const _global = typeof window == 'undefined' ? global : window;
   QueueRunner.prototype = SuperQueueRunner.prototype;
   return QueueRunner;
 })((<any>jasmine).QueueRunner);
-

--- a/lib/zone-spec/async-test.ts
+++ b/lib/zone-spec/async-test.ts
@@ -1,3 +1,5 @@
+import { Zone, ZoneSpec, Task, ZoneDelegate, HasTaskState } from '../zone';
+
 (function() {
   class AsyncTestZoneSpec implements ZoneSpec {
     _finishCallback: Function;

--- a/lib/zone-spec/long-stack-trace.ts
+++ b/lib/zone-spec/long-stack-trace.ts
@@ -1,3 +1,4 @@
+import { Zone, ZoneDelegate, Task, ZoneSpec } from '../zone';
 'use strict';
 (function() {
   const NEWLINE = '\n';

--- a/lib/zone-spec/sync-test.ts
+++ b/lib/zone-spec/sync-test.ts
@@ -1,3 +1,5 @@
+import { Zone, ZoneSpec, Task, ZoneDelegate, MicroTask } from '../zone';
+
 (function() {
   class SyncTestZoneSpec implements ZoneSpec {
     runZone = Zone.current;

--- a/lib/zone-spec/wtf.ts
+++ b/lib/zone-spec/wtf.ts
@@ -1,3 +1,5 @@
+import { Zone, ZoneSpec, Task, ZoneDelegate } from '../zone';
+
 (function(global) {
   interface Wtf { trace: WtfTrace; }
   interface WtfScope {};

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -119,7 +119,7 @@
  * zones are children of the root zone.
  *
  */
-interface Zone {
+export interface Zone {
   /**
    *
    * @returns {Zone} The parent Zone.
@@ -212,7 +212,7 @@ interface Zone {
   cancelTask(task: Task): any;
 }
 
-interface ZoneType {
+export interface ZoneType {
   /**
    * @returns {Zone} Returns the current [Zone]. Returns the current zone. The only way to change
    * the current zone is by invoking a run() method, which will update the current zone for the
@@ -230,7 +230,7 @@ interface ZoneType {
  *
  * Only the `name` property is required (all other are optional).
  */
-interface ZoneSpec {
+export interface ZoneSpec {
   /**
    * The name of the zone. Usefull when debugging Zones.
    */
@@ -359,7 +359,7 @@ interface ZoneSpec {
  *  Note: The ZoneDelegate treats ZoneSpec as class. This allows the ZoneSpec to use its `this` to
  *  store internal state.
  */
-interface ZoneDelegate {
+export interface ZoneDelegate {
   zone: Zone;
   fork(targetZone: Zone, zoneSpec: ZoneSpec): Zone;
   intercept(targetZone: Zone, callback: Function, source: string): Function;
@@ -371,7 +371,7 @@ interface ZoneDelegate {
   hasTask(targetZone: Zone, isEmpty: HasTaskState): void;
 }
 
-type HasTaskState = {
+export type HasTaskState = {
   microTask: boolean,
   macroTask: boolean,
   eventTask: boolean,
@@ -381,11 +381,11 @@ type HasTaskState = {
 /**
  * Task type: `microTask`, `macroTask`, `eventTask`.
  */
-type TaskType = string; /* TS v1.8 => "microTask" | "macroTask" | "eventTask" */;
+export type TaskType = string; /* TS v1.8 => "microTask" | "macroTask" | "eventTask" */;
 
 /**
  */
-interface TaskData {
+export interface TaskData {
   /**
    * A periodic [MacroTask] is such which get automatically rescheduled after it is executed.
    */
@@ -414,7 +414,7 @@ interface TaskData {
  *   queue. This happens when the event fires.
  *
  */
-interface Task {
+export interface Task {
   /**
    * Task type: `microTask`, `macroTask`, `eventTask`.
    */
@@ -464,15 +464,15 @@ interface Task {
   zone: Zone;
 }
 
-interface MicroTask extends Task {
+export interface MicroTask extends Task {
   /* TS v1.8 => type: 'microTask'; */
 }
 
-interface MacroTask extends Task {
+export interface MacroTask extends Task {
   /* TS v1.8 => type: 'macroTask'; */
 }
 
-interface EventTask extends Task {
+export  interface EventTask extends Task {
   /* TS v1.8 => type: 'eventTask'; */
 }
 
@@ -481,7 +481,7 @@ type AmbientZone = Zone;
 /** @internal */
 type AmbientZoneDelegate = ZoneDelegate;
 
-var Zone: ZoneType = (function(global) {
+export var Zone: ZoneType = (function(global) {
   class Zone implements AmbientZone {
     static __symbol__: (name: string) => string = __symbol__;
 

--- a/test/async-test.spec.ts
+++ b/test/async-test.spec.ts
@@ -1,4 +1,5 @@
 import '../lib/zone-spec/async-test';
+import { Zone, ZoneSpec, Task, ZoneDelegate, HasTaskState } from '../lib/zone';
 
 describe('AsyncTestZoneSpec', function() {
   var log;

--- a/test/browser/FileReader.spec.ts
+++ b/test/browser/FileReader.spec.ts
@@ -1,4 +1,5 @@
 import {ifEnvSupports} from '../util';
+import { Zone } from '../../lib/zone';
 
 describe('FileReader', ifEnvSupports('FileReader', function () {
   var fileReader;
@@ -6,7 +7,7 @@ describe('FileReader', ifEnvSupports('FileReader', function () {
   var data = 'Hello, World!';
   var testZone = Zone.current.fork({ name: 'TestZone' });
 
-  // Android 4.3's native browser doesn't implement add/RemoveEventListener for FileReader 
+  // Android 4.3's native browser doesn't implement add/RemoveEventListener for FileReader
   function supportsEventTargetFns () {
     return FileReader.prototype.addEventListener && FileReader.prototype.removeEventListener;
   }

--- a/test/browser/HTMLImports.spec.ts
+++ b/test/browser/HTMLImports.spec.ts
@@ -1,4 +1,5 @@
 import {ifEnvSupports} from '../util';
+import { Zone } from '../../lib/zone';
 
 function supportsImports() {
   return 'import' in document.createElement('link');

--- a/test/browser/MutationObserver.spec.ts
+++ b/test/browser/MutationObserver.spec.ts
@@ -1,3 +1,4 @@
+import { Zone } from '../../lib/zone';
 import {ifEnvSupports} from '../util';
 
 describe('MutationObserver', ifEnvSupports('MutationObserver', function () {

--- a/test/browser/Promise.spec.ts
+++ b/test/browser/Promise.spec.ts
@@ -1,4 +1,5 @@
 import {ifEnvSupports} from '../util';
+import { Zone, ZoneSpec, Task, ZoneDelegate, MicroTask } from '../../lib/zone';
 
 class MicroTaskQueueZoneSpec implements ZoneSpec {
   name: string = 'MicroTaskQueue';
@@ -138,7 +139,7 @@ describe('Promise', ifEnvSupports('Promise', function () {
         });
       });
 
-      
+
       expect(reject()).toBe(undefined);
     });
 

--- a/test/browser/WebSocket.spec.ts
+++ b/test/browser/WebSocket.spec.ts
@@ -1,4 +1,5 @@
 import {ifEnvSupports} from '../util';
+import { Zone } from '../../lib/zone';
 
 var TIMEOUT = 5000;
 

--- a/test/browser/XMLHttpRequest.spec.ts
+++ b/test/browser/XMLHttpRequest.spec.ts
@@ -1,4 +1,5 @@
 import {ifEnvSupports} from '../util';
+import { Zone } from '../../lib/zone';
 
 describe('XMLHttpRequest', function () {
   var testZone = Zone.current.fork({name: 'test'});
@@ -65,4 +66,3 @@ describe('XMLHttpRequest', function () {
     expect(XMLHttpRequest.DONE).toEqual(4);
   });
 });
-

--- a/test/browser/element.spec.ts
+++ b/test/browser/element.spec.ts
@@ -1,4 +1,5 @@
 import {ifEnvSupports} from '../util';
+import { Zone } from '../../lib/zone';
 
 describe('element', function () {
 
@@ -106,7 +107,7 @@ describe('element', function () {
   it('should have no effect while calling addEventListener without listener', function () {
     var onAddEventListenerSpy = jasmine.createSpy('addEventListener')
     var eventListenerZone = Zone.current.fork({
-      name: 'eventListenerZone', 
+      name: 'eventListenerZone',
       onScheduleTask: onAddEventListenerSpy
     });
     expect(function() {
@@ -120,8 +121,8 @@ describe('element', function () {
 
   it('should have no effect while calling removeEventListener without listener', function () {
     var onAddEventListenerSpy =  jasmine.createSpy('removeEventListener');
-    var eventListenerZone = Zone.current.fork({ 
-      name: 'eventListenerZone', 
+    var eventListenerZone = Zone.current.fork({
+      name: 'eventListenerZone',
       onScheduleTask: onAddEventListenerSpy
      });
     expect(function() {
@@ -277,7 +278,7 @@ describe('element', function () {
     afterEach(function () {
       document.body.removeChild(checkbox);
     });
-    
+
     it('should be possible to prevent default behavior by returning false', function() {
       checkbox.onclick = function() {
         return false;

--- a/test/browser/geolocation.spec.manual.ts
+++ b/test/browser/geolocation.spec.manual.ts
@@ -1,4 +1,5 @@
 import {ifEnvSupports} from '../util';
+import { Zone } from '../../lib/zone';
 
 function supportsGeolocation() {
   return 'geolocation' in navigator;

--- a/test/browser/registerElement.spec.ts
+++ b/test/browser/registerElement.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import {ifEnvSupports} from '../util';
+import { Zone } from '../../lib/zone';
 
 function registerElement() {
   return ('registerElement' in document);

--- a/test/browser/requestAnimationFrame.spec.ts
+++ b/test/browser/requestAnimationFrame.spec.ts
@@ -1,4 +1,5 @@
 import {ifEnvSupports} from '../util';
+import { Zone, } from '../../lib/zone';
 
 describe('requestAnimationFrame', function () {
   var functions = [

--- a/test/browser/setInterval.spec.ts
+++ b/test/browser/setInterval.spec.ts
@@ -1,5 +1,6 @@
 'use strict';
 import {zoneSymbol} from "../../lib/browser/utils";
+import { Zone, MacroTask } from '../../lib/zone';
 
 describe('setInterval', function () {
 

--- a/test/browser/setTimeout.spec.ts
+++ b/test/browser/setTimeout.spec.ts
@@ -1,4 +1,5 @@
 import {zoneSymbol} from '../../lib/browser/utils';
+import { Zone, MacroTask } from '../../lib/zone';
 
 describe('setTimeout', function () {
   it('should intercept setTimeout', function (done) {

--- a/test/long-stack-trace-zone.spec.ts
+++ b/test/long-stack-trace-zone.spec.ts
@@ -1,3 +1,5 @@
+import { Zone, ZoneDelegate } from '../lib/zone';
+
 describe('longStackTraceZone', function () {
   var log;
 

--- a/test/microtasks.spec.ts
+++ b/test/microtasks.spec.ts
@@ -1,3 +1,5 @@
+import { Zone, ZoneDelegate, Task } from '../lib/zone';
+
 describe('Microtasks', function () {
   if (!global.Promise) return;
 

--- a/test/sync-test.spec.ts
+++ b/test/sync-test.spec.ts
@@ -1,4 +1,5 @@
 import '../lib/zone-spec/sync-test';
+import { Zone } from '../lib/zone';
 
 describe('SyncTestZoneSpec', () => {
   var SyncTestZoneSpec = Zone['SyncTestZoneSpec'];

--- a/test/ws-webworker-context.ts
+++ b/test/ws-webworker-context.ts
@@ -1,4 +1,5 @@
 importScripts('/base/test/zone_worker_entry_point.ts');
+import { Zone } from '../lib/zone';
 
 Zone.current.fork({name: 'webworker'}).run(() => {
   var websocket = new WebSocket('ws://localhost:8001');
@@ -13,4 +14,3 @@ Zone.current.fork({name: 'webworker'}).run(() => {
     websocket.send('text');
   });
 });
-

--- a/test/zone.spec.ts
+++ b/test/zone.spec.ts
@@ -1,5 +1,6 @@
 import './test-env-setup';
 import {zoneSymbol} from '../lib/browser/utils';
+import { Zone, Task, ZoneDelegate, HasTaskState } from '../lib/zone';
 
 describe('Zone', function () {
   var rootZone = Zone.current;
@@ -97,7 +98,7 @@ describe('Zone', function () {
         zone.run(function() {
           button.addEventListener('click', eventListenerSpy);
         });
-        
+
         button.dispatchEvent(clickEvent);
 
         expect(hookSpy).toHaveBeenCalled();


### PR DESCRIPTION
Fixes exported type definitions so that you can import from typescript using ```import { Zone } from 'zone.js'``` and not have the compiler complain about it not being a module.

Resolves #297, still needs a resolution to access the correct ZoneSpec via import without declaring a module manually.