### PR TITLE
fix(setTimeout): allow clearTimeout to be called in setTimeout callback

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -573,6 +573,9 @@ var Zone: ZoneType = (function(global) {
       var oldZone = _currentZone;
       _currentZone = this;
       try {
+        if (task.type == 'macroTask' && task.data && !task.data.isPeriodic) {
+          task.cancelFn = null;
+        }
         try {
           return this._zoneDelegate.invokeTask(this, task, applyThis, applyArgs);
         } catch (error) {
@@ -581,9 +584,6 @@ var Zone: ZoneType = (function(global) {
           }
         }
       } finally {
-        if (task.type == 'macroTask' && task.data && !task.data.isPeriodic) {
-          task.cancelFn = null;
-        }
         _currentZone = oldZone;
         _currentTask = previousTask;
       }

--- a/test/browser/setTimeout.spec.ts
+++ b/test/browser/setTimeout.spec.ts
@@ -31,24 +31,40 @@ describe('setTimeout', function () {
   });
 
   it('should allow canceling of fns registered with setTimeout', function (done) {
-    var spy = jasmine.createSpy('spy');
-    var cancelId = setTimeout(spy, 0);
-    clearTimeout(cancelId);
-    setTimeout(function () {
-      expect(spy).not.toHaveBeenCalled();
-      done();
+    var testZone = Zone.current.fork(Zone['wtfZoneSpec']).fork({ name: 'TestZone' });
+    testZone.run(() => {
+      var spy = jasmine.createSpy('spy');
+      var cancelId = setTimeout(spy, 0);
+      clearTimeout(cancelId);
+      setTimeout(function () {
+        expect(spy).not.toHaveBeenCalled();
+        done();
+      });
     });
   });
 
-  it('should allow double cancelation of fns registered with setTimeout', function (done) {
-    var spy = jasmine.createSpy('spy');
-    var cancelId = setTimeout(spy, 0);
-    setTimeout(function () {
-      expect(spy).toHaveBeenCalled();
+  it('should allow cancelation of fns registered with setTimeout after invocation', function (done) {
+    var testZone = Zone.current.fork(Zone['wtfZoneSpec']).fork({ name: 'TestZone' });
+    testZone.run(() => {
+      var spy = jasmine.createSpy('spy');
+      var cancelId = setTimeout(spy, 0);
       setTimeout(function () {
-        clearTimeout(cancelId);
-        done();
+        expect(spy).toHaveBeenCalled();
+        setTimeout(function () {
+          clearTimeout(cancelId);
+          done();
+        });
       });
+    });
+  });
+
+  it('should allow cancelation of fns registered with setTimeout during invocation', function (done) {
+    var testZone = Zone.current.fork(Zone['wtfZoneSpec']).fork({ name: 'TestZone' });
+    testZone.run(() => {
+      var cancelId = setTimeout(function() {
+        clearTimeout(cancelId);
+        done();       
+      }, 0);
     });
   });
 


### PR DESCRIPTION
This is a fix for #290 - "More tasks executed than were scheduled" error.

The change is to set task.cancelFn  = null *before* invoking a task for non-periodic tasks. As it is no longer possible to cancel the task which is just about to be invoked, I think this should be ok. I also updated the setTimeout tests to create new zones to run the tests in, as initially the test was incorrectly passing due to the task counts not being 0 to begin with.
