### PR TITLE
fix: window undefined in node environments

### DIFF
--- a/lib/browser/utils.ts
+++ b/lib/browser/utils.ts
@@ -40,7 +40,7 @@ export var isNode: boolean =
   (typeof process !== 'undefined' && {}.toString.call(process) === '[object process]');
 
 export var isBrowser: boolean =
-    !isNode && !isWebWorker && !!(window && window['HTMLElement']);
+    !isNode && !isWebWorker && !!(typeof window !== 'undefined' && window['HTMLElement']);
 
 
 export function patchProperty(obj, prop) {


### PR DESCRIPTION
This fixes an issue when using zone.js in non-browser environments like node, or for instance, `nativescript-angular`. Ran into this while updating `nativescript-angular` to latest angular beta.13 and zone 0.6.6.