### PR TITLE
fix(xhr): XHR macrotasks allow abort after XHR has completed

### DIFF
--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -95,6 +95,10 @@ function patchXHR(window: any) {
   var clearNative = patchMethod(window.XMLHttpRequest.prototype, 'abort', (delegate: Function) => function(self: any, args: any[]) {
     var task: Task = findPendingTask(self);
     if (task && typeof task.type == 'string') {
+      // If the XHR has already completed, do nothing.
+      if (task.cancelFn == null) {
+        return;
+      }
       task.zone.cancelTask(task);
     }
     // Otherwise, we are trying to abort an XHR which has not yet been sent, so there is no task to cancel. Do nothing.

--- a/test/browser/XMLHttpRequest.spec.ts
+++ b/test/browser/XMLHttpRequest.spec.ts
@@ -107,6 +107,27 @@ describe('XMLHttpRequest', function () {
         done();
       }, 0);
     });
+
+    it('should allow aborting an XMLHttpRequest after its completed', function(done) {
+      var req;
+
+      testZone.run(function() {
+        req = new XMLHttpRequest();
+        req.onreadystatechange = function() {
+          if (req.readyState === XMLHttpRequest.DONE) {
+            if (req.status !== 0) {
+              setTimeout(function() {
+                req.abort();
+                done();
+              }, 0);
+            }
+          }
+        };
+        req.open('get', '/', true);
+
+        req.send();
+      });
+    });
   }));
 
   it('should preserve other setters', function () {


### PR DESCRIPTION
Avoid throwing an error if an XHR is aborted after it has already
been sent and completed (this throws no error in the browser,
and zones should not introduce a new error).