### PR TITLE
Fixed the long stack trace example

### DIFF
--- a/example/basic.html
+++ b/example/basic.html
@@ -1,53 +1,58 @@
 <!doctype html>
 <html>
 <head>
-  <meta charset="utf-8">
-  <title>Zone.js Basic Demo</title>
-  <link rel="stylesheet" href="css/style.css">
-  <script src="../dist/zone.js"></script>
-  <script src="../dist/long-stack-trace-zone.js"></script>
+    <meta charset="utf-8">
+    <title>Zone.js Basic Demo</title>
+    <link rel="stylesheet" href="css/style.css">
+    <script src="../dist/zone.js"></script>
+    <script src="../dist/long-stack-trace-zone.js"></script>
 </head>
 <body>
 
-  <h1>Basic Example</h1>
+<h1>Basic Example</h1>
 
-  <button id="b1">Bind Error</button>
-  <button id="b2">Cause Error</button>
+<button id="b1">Bind Error</button>
+<button id="b2">Cause Error</button>
 
-  <script>
+<script>
 
-  /*
-   * This is a simple example of async stack traces with zones
-   */
+    /*
+     * This is a simple example of async stack traces with zones
+     */
 
-  function main () {
-    b1.addEventListener('click', bindSecondButton);
-  }
+    function main() {
+        b1.addEventListener('click', bindSecondButton);
+    }
 
-  /*
-   * What if your stack trace could tell you what
-   * order the user pushed the buttons from the stack trace?
-   *
-   * What if you could log this back to the server?
-   *
-   * Think of how much more productive your debugging could be!
-   */
+    /*
+     * What if your stack trace could tell you what
+     * order the user pushed the buttons from the stack trace?
+     *
+     * What if you could log this back to the server?
+     *
+     * Think of how much more productive your debugging could be!
+     */
 
-  function bindSecondButton () {
-    b2.addEventListener('click', throwError);
-  }
+    function bindSecondButton() {
+        b2.addEventListener('click', throwError);
+    }
 
+    function throwError() {
+        throw new Error('aw shucks');
+    }
 
-  function throwError () {
-    throw new Error('aw shucks');
-  }
+    /*
+     * Bootstrap the app
+     */
+    //main();
 
-  /*
-   * Bootstrap the app
-   */
-  //main();
-  Zone.current.fork(Zone.longStackTraceZoneSpec).run(main);
-
-  </script>
+    Zone.current.fork(
+            {
+                onHandleError: function (parentZoneDelegate, currentZone, targetZone, error) {
+                    console.log(error.stack);
+                }
+            }
+    ).fork(Zone.longStackTraceZoneSpec).run(main);
+</script>
 </body>
 </html>

--- a/example/basic.html
+++ b/example/basic.html
@@ -1,58 +1,59 @@
 <!doctype html>
 <html>
 <head>
-    <meta charset="utf-8">
-    <title>Zone.js Basic Demo</title>
-    <link rel="stylesheet" href="css/style.css">
-    <script src="../dist/zone.js"></script>
-    <script src="../dist/long-stack-trace-zone.js"></script>
+  <meta charset="utf-8">
+  <title>Zone.js Basic Demo</title>
+  <link rel="stylesheet" href="css/style.css">
+  <script src="../dist/zone.js"></script>
+  <script src="../dist/long-stack-trace-zone.js"></script>
 </head>
 <body>
 
-<h1>Basic Example</h1>
+  <h1>Basic Example</h1>
 
-<button id="b1">Bind Error</button>
-<button id="b2">Cause Error</button>
+  <button id="b1">Bind Error</button>
+  <button id="b2">Cause Error</button>
 
-<script>
+  <script>
 
-    /*
-     * This is a simple example of async stack traces with zones
-     */
+  /*
+   * This is a simple example of async stack traces with zones
+   */
 
-    function main() {
-        b1.addEventListener('click', bindSecondButton);
-    }
+  function main () {
+    b1.addEventListener('click', bindSecondButton);
+  }
 
-    /*
-     * What if your stack trace could tell you what
-     * order the user pushed the buttons from the stack trace?
-     *
-     * What if you could log this back to the server?
-     *
-     * Think of how much more productive your debugging could be!
-     */
+  /*
+   * What if your stack trace could tell you what
+   * order the user pushed the buttons from the stack trace?
+   *
+   * What if you could log this back to the server?
+   *
+   * Think of how much more productive your debugging could be!
+   */
 
-    function bindSecondButton() {
-        b2.addEventListener('click', throwError);
-    }
+  function bindSecondButton () {
+    b2.addEventListener('click', throwError);
+  }
 
-    function throwError() {
-        throw new Error('aw shucks');
-    }
 
-    /*
-     * Bootstrap the app
-     */
-    //main();
+  function throwError () {
+    throw new Error('aw shucks');
+  }
 
-    Zone.current.fork(
-            {
-                onHandleError: function (parentZoneDelegate, currentZone, targetZone, error) {
-                    console.log(error.stack);
-                }
-            }
-    ).fork(Zone.longStackTraceZoneSpec).run(main);
-</script>
+  /*
+   * Bootstrap the app
+   */
+  //main();
+  Zone.current.fork(
+          {
+              onHandleError: function (parentZoneDelegate, currentZone, targetZone, error) {
+                  console.log(error.stack);
+              }
+          }
+  ).fork(Zone.longStackTraceZoneSpec).run(main);
+
+  </script>
 </body>
 </html>


### PR DESCRIPTION
The longStackTraceZoneSpec delegates the handling of the error to the zone. Without the changes I've made, the handling was passed to the 'root' zone which doesn't handle the error object. By adding a parentZone which handles the printing of the error in the 'onHandleError' hook, the full stack trace is visible.