### PR TITLE
add explicit 'any' type

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -486,7 +486,7 @@ type AmbientZone = Zone;
 /** @internal */
 type AmbientZoneDelegate = ZoneDelegate;
 
-const Zone: ZoneType = (function(global) {
+const Zone: ZoneType = (function(global: any) {
   class Zone implements AmbientZone {
     static __symbol__: (name: string) => string = __symbol__;
 


### PR DESCRIPTION
TypeScript 1.9 does better type inference on immediately evaluated
function expressions, which results in a type error.

Adding explicit any makes the current code behave the same in 1.8 and
1.9. A further change should add a more constrained type.