### PR TITLE
Pass actual error to failCallback

### DIFF
--- a/lib/zone-spec/async-test.ts
+++ b/lib/zone-spec/async-test.ts
@@ -47,7 +47,7 @@
       // Let the parent try to handle the error.
       const result = parentZoneDelegate.handleError(targetZone, error);
       if (result) {
-        this._failCallback(error.message ? error.message : 'unknown error');
+        this._failCallback(error);
         this._alreadyErrored = true;
       }
       return false;

--- a/test/zone-spec/async-test.spec.ts
+++ b/test/zone-spec/async-test.spec.ts
@@ -208,7 +208,7 @@ describe('AsyncTestZoneSpec', function() {
       var testZoneSpec = new AsyncTestZoneSpec(() => {
         done.fail('expected failCallback to be called');
       }, (err) => {
-        expect(err).toEqual('bad url failure');
+        expect(err.message).toEqual('bad url failure');
         done();
       }, 'name');
 
@@ -251,7 +251,7 @@ describe('AsyncTestZoneSpec', function() {
     var testZoneSpec = new AsyncTestZoneSpec(() => {
       done.fail('expected failCallback to be called');
     }, (err) => {
-      expect(err).toEqual('my error');
+      expect(err.message).toEqual('my error');
       done();
     }, 'name');
 
@@ -270,7 +270,7 @@ describe('AsyncTestZoneSpec', function() {
     var testZoneSpec = new AsyncTestZoneSpec(() => {
       done.fail('expected failCallback to be called');
     }, (err) => {
-      expect(err).toEqual('Uncaught (in promise): my reason');
+      expect(err.message).toEqual('Uncaught (in promise): my reason');
       done();
     }, 'name');
 


### PR DESCRIPTION
When handling an error in the `AsyncTestZoneSpec`, instead of just passing the error message to the `_failCallback`, pass the actual error instance already available. This ensures that the complete stack trace is printed when logging a failed test.

Closes #379 