### PR TITLE
fix longstacktracezone will not render long stack trace when reject a…

### DIFF
--- a/lib/zone-spec/long-stack-trace.ts
+++ b/lib/zone-spec/long-stack-trace.ts
@@ -85,7 +85,7 @@
     onHandleError: function(parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone,
                  error: any): any
     {
-      const parentTask = Zone.currentTask;
+      const parentTask = Zone.currentTask || error.task;
       if (error instanceof Error && parentTask) {
         let descriptor = Object.getOwnPropertyDescriptor(error, 'stack');
         if (descriptor) {

--- a/test/zone-spec/long-stack-trace-zone.spec.ts
+++ b/test/zone-spec/long-stack-trace-zone.spec.ts
@@ -32,6 +32,29 @@ describe('longStackTraceZone', function () {
       }, 0);
     });
   });
+
+  it('should produce long stack traces when reject in promise', function(done) {
+    lstz.runGuarded(function () {
+      setTimeout(function () {
+        setTimeout(async function () {
+          setTimeout(function () {
+            try {
+              expect(log[0].split('Elapsed: ').length).toBe(3);
+              done();
+            } catch (e) {
+              expect(e).toBe(null);
+            }
+          }, 0);
+          let promise = new Promise((resolve, reject) => {
+             process.nextTick(() => {
+               reject(new Error('Hello Promise'));
+             });
+          });
+          await promise;
+        }, 0);
+      }, 0);
+    });
+  });
 });
 
 export var __something__;


### PR DESCRIPTION
I found a problem when using long-stack-trace zone, if I reject a promise inside the zone, the long stack trace will not rendered instead the original stack will be returned.

Because when promise was reject, zone will keep it in an array called _uncaughtPromiseErrors, and 
when drainMicroTaskQueue was called, the _uncaughtPromiseErrors will be rethrow with the original zone, but the Zone.currentTask has been cleared, so onHandleError of long-stack-trace will not rendered the correct long stack trace.

because the _uncaughtPromiseError has a reference of current task, we can check the task in long-stack-trace.