### PR TITLE
fix(tasks): do not drain the microtask queue early.

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -504,6 +504,9 @@ const Zone: ZoneType = (function(global: any) {
   if (global.Zone) {
     throw new Error('Zone already loaded.');
   }
+
+  let _invokingTasks = 0;
+
   class Zone implements AmbientZone {
     static __symbol__: (name: string) => string = __symbol__;
 
@@ -835,10 +838,16 @@ const Zone: ZoneType = (function(global: any) {
       this.callback = callback;
       const self = this;
       this.invoke = function () {
+        let drainAfter: boolean;
         try {
+          drainAfter = !_invokingTasks;
+          _invokingTasks++;
           return zone.runTask(self, this, <any>arguments);
         } finally {
-          drainMicroTaskQueue();
+          if (drainAfter) {
+            drainMicroTaskQueue();
+          }
+          _invokingTasks--;
         }
       };
     }

--- a/test/browser/element.spec.ts
+++ b/test/browser/element.spec.ts
@@ -50,6 +50,22 @@ describe('element', function () {
     button.dispatchEvent(clickEvent);
   });
 
+  fit('should not call microtasks early when an event is invoked', function() {
+    var log = '';
+    var logFunction = function logFunction () {
+      log += 'a';
+    };
+
+    Zone.current.scheduleMicroTask('test', () => {
+      log += 'microtask';
+    });
+    button.addEventListener('click', logFunction);
+
+    button.click();
+
+    expect(log).toEqual('a');
+  });
+
   it('should work with addEventListener when called with an EventListener-implementing listener', function () {
     var eventListener = {
       x: 5,

--- a/test/common/zone.spec.ts
+++ b/test/common/zone.spec.ts
@@ -150,6 +150,33 @@ describe('Zone', function () {
       ]);
     });
   });
+
+  describe('invoking tasks', () => {
+    var log;
+    function noop() {}
+
+
+    beforeEach(() => {
+      log = [];
+    });
+
+    it('should not drain the microtask queue too early', () => {
+      var z = Zone.current;
+      var event = z.scheduleEventTask('test', () => log.push('eventTask'), null, noop, noop);
+
+      z.scheduleMicroTask('test', () => log.push('microTask'));
+
+      var macro = z.scheduleMacroTask('test', () => {
+        event.invoke();
+        // At this point, we should not have invoked the microtask.
+        expect(log).toEqual([
+          'eventTask'
+        ]);
+      }, null, noop, noop);
+
+      macro.invoke();
+    });
+  });
 });
 
 function throwError () {


### PR DESCRIPTION
Fixes a bug where a event task invoked inside another task
would drain the microtask queue too early. This would mean that microtasks
would be called unexpectedly in the middle of what should have been
a block of synchronous code.