### PR TITLE
fix(tasks): do not drain the microtask queue early.

### DIFF
--- a/test/browser/element.spec.ts
+++ b/test/browser/element.spec.ts
@@ -51,16 +51,15 @@ describe('element', function () {
   });
 
   it('should not call microtasks early when an event is invoked', function(done) {
-    // we have to run this test in setTimeout to guarantee that we are running in an existing task
-    setTimeout(() => {
-      var log = '';
+    var log = '';
+    button.addEventListener('click', () => {
       Zone.current.scheduleMicroTask('test', () => log += 'microtask;');
-      button.addEventListener('click', () => log += 'click;');
-      button.click();
-
-      expect(log).toEqual('click;');
-      done();
+      log += 'click;'
     });
+    button.click();
+
+    expect(log).toEqual('click;');
+    done();
   });
 
   it('should call microtasks early when an event is invoked', function(done) {
@@ -80,11 +79,15 @@ describe('element', function () {
      *    eager drainage.
      * 3. Pay the cost of throwing an exception in event tasks and verifying that we are the
      *    top most frame.
+     *
+     * For now we are choosing to ignore it and assume that this arrises in tests only.
      */
     global[Zone['__symbol__']('setTimeout')](() => {
       var log = '';
-      Zone.current.scheduleMicroTask('test', () => log += 'microtask;');
-      button.addEventListener('click', () => log += 'click;');
+      button.addEventListener('click', () => {
+        Zone.current.scheduleMicroTask('test', () => log += 'microtask;');
+        log += 'click;'
+      });
       button.click();
 
       expect(log).toEqual('click;microtask;');

--- a/test/common/zone.spec.ts
+++ b/test/common/zone.spec.ts
@@ -150,6 +150,33 @@ describe('Zone', function () {
       ]);
     });
   });
+
+  describe('invoking tasks', () => {
+    var log;
+    function noop() {}
+
+
+    beforeEach(() => {
+      log = [];
+    });
+
+    it('should not drain the microtask queue too early', () => {
+      var z = Zone.current;
+      var event = z.scheduleEventTask('test', () => log.push('eventTask'), null, noop, noop);
+
+      z.scheduleMicroTask('test', () => log.push('microTask'));
+
+      var macro = z.scheduleMacroTask('test', () => {
+        event.invoke();
+        // At this point, we should not have invoked the microtask.
+        expect(log).toEqual([
+          'eventTask'
+        ]);
+      }, null, noop, noop);
+
+      macro.invoke();
+    });
+  });
 });
 
 function throwError () {

--- a/test/jasmine-patch.spec.ts
+++ b/test/jasmine-patch.spec.ts
@@ -1,3 +1,8 @@
+beforeEach(() => {
+  // assert that each jasmine run has a task, so that darinMicrotask works properly.
+  expect(Zone.currentTask).toBeTruthy();
+});
+
 describe('jasmine', () => {
   let throwOnAsync = false;
   let beforeEachZone: Zone = null;


### PR DESCRIPTION
Fixes a bug where a event task invoked inside another task
would drain the microtask queue too early. This would mean that microtasks
would be called unexpectedly in the middle of what should have been
a block of synchronous code.