### PR TITLE
fix(promise): support more aggressive optimization.

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -916,7 +916,7 @@ const Zone: ZoneType = (function(global: any) {
           'Unhandled Promise rejection:', rejection instanceof Error ? rejection.message : rejection,
           '; Zone:', (<Zone>e.zone).name,
           '; Task:', e.task && (<Task>e.task).source,
-          '; Value:', rejection, 
+          '; Value:', rejection,
           rejection instanceof Error ? rejection.stack : undefined
       );
     }
@@ -1121,6 +1121,12 @@ const Zone: ZoneType = (function(global: any) {
       return this.then(null, onRejected);
     }
   }
+  // Protect against aggressive optimizers dropping seemingly unused properties.
+  // E.g. Closure Compiler in advanced mode.
+  ZoneAwarePromise['resolve'] = ZoneAwarePromise.resolve;
+  ZoneAwarePromise['reject'] = ZoneAwarePromise.reject;
+  ZoneAwarePromise['race'] = ZoneAwarePromise.race;
+  ZoneAwarePromise['all'] = ZoneAwarePromise.all;
 
   const NativePromise = global[__symbol__('Promise')] = global.Promise;
   global.Promise = ZoneAwarePromise;


### PR DESCRIPTION
ZoneAwarePromise does not technically implement or inherit the static
side of Promise, so aggressive optimizers may drop static methods such
as `all`, `race`, `reject`, and `resolve`.

This change explicitly exports them into quoted properties, which is
harmless for normal use and protects users of more aggressive
optimizers, such as Closure Compiler in typed mode.