### PR TITLE
Add a nativescript zone implementation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,6 +60,10 @@ gulp.task('build/zone-node.js', ['compile-esm'], function(cb) {
   return generateScript('./lib/node/node.ts', 'zone-node.js', false, cb);
 });
 
+gulp.task('build/zone-nativescript.js', ['compile-esm'], function(cb) {
+  return generateScript('./lib/nativescript/nativescript.ts', 'zone-nativescript.js', false, cb);
+});
+
 // Zone for the browser.
 gulp.task('build/zone.js', ['compile-esm'], function(cb) {
 
@@ -127,6 +131,7 @@ gulp.task('build', [
   'build/zone.js.d.ts',
   'build/zone.min.js',
   'build/zone-node.js',
+  'build/zone-nativescript.js',
   'build/jasmine-patch.js',
   'build/jasmine-patch.min.js',
   'build/long-stack-trace-zone.js',
@@ -147,6 +152,34 @@ gulp.task('test/node', ['compile'], function(cb) {
   var jrunner = new JasmineRunner();
 
   var specFiles = ['build/test/node_entry_point.js'];
+
+  jrunner.configureDefaultReporter({showColors: true});
+
+  jrunner.onComplete(function(passed) {
+    if (!passed) {
+      var err = new Error('Jasmine node tests failed.');
+      // The stack is not useful in this context.
+      err.showStack = false;
+      cb(err);
+    } else {
+      cb();
+    }
+  });
+  jrunner.print = function(value) {
+    process.stdout.write(value);
+  }
+  jrunner.addReporter(new JasmineRunner.ConsoleReporter(jrunner));
+  jrunner.projectBaseDir = __dirname;
+  jrunner.specDir = '';
+  jrunner.addSpecFiles(specFiles);
+  jrunner.execute();
+});
+
+gulp.task('test/nativescript', ['compile'], function(cb) {
+  var JasmineRunner = require('jasmine');
+  var jrunner = new JasmineRunner();
+
+  var specFiles = ['build/test/nativescript_entry_point.js'];
 
   jrunner.configureDefaultReporter({showColors: true});
 

--- a/lib/nativescript/nativescript.ts
+++ b/lib/nativescript/nativescript.ts
@@ -1,0 +1,11 @@
+import '../zone';
+import {patchTimer} from '../common/timers';
+
+
+const set = 'set';
+const clear = 'clear';
+
+// Timers
+patchTimer(global, set, clear, 'Timeout');
+patchTimer(global, set, clear, 'Interval');
+patchTimer(global, set, clear, 'Immediate');

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1148,7 +1148,7 @@ const Zone: ZoneType = (function(global: any) {
       const fetchPromise = global['fetch']();
       // ignore output to prevent error;
       fetchPromise.then(() => null, () => null);
-      if (fetchPromise.constructor != NativePromise) {
+      if (fetchPromise.constructor != NativePromise && fetchPromise.constructor != ZoneAwarePromise) {
         patchThen(fetchPromise.constructor);
       }
     }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "tsc:w": "./node_modules/.bin/tsc -w",
     "test": "npm run tsc && concurrently \"npm run tsc:w\" \"npm run ws-server\" \"karma start karma.conf.js\"",
     "test-node": "./node_modules/.bin/gulp test/node",
+    "test-nativescript": "./node_modules/.bin/gulp test/nativescript",
     "serve": "python -m SimpleHTTPServer 8000"
   },
   "repository": {

--- a/test/nativescript_entry_point.ts
+++ b/test/nativescript_entry_point.ts
@@ -1,0 +1,20 @@
+// Must be loaded before zone loads, so that zone can detect WTF.
+import './wtf_mock';
+
+// Setup tests for Zone without microtask support
+import '../lib/zone';
+import '../lib/nativescript/nativescript';
+import '../lib/zone-spec/async-test';
+import '../lib/zone-spec/fake-async-test';
+import '../lib/zone-spec/long-stack-trace';
+import '../lib/zone-spec/proxy';
+import '../lib/zone-spec/sync-test';
+import '../lib/zone-spec/task-tracking';
+import '../lib/zone-spec/wtf';
+
+// Setup test environment
+import './test-env-setup';
+
+// List all tests here:
+import './common_tests';
+import './nativescript_tests';


### PR DESCRIPTION
The [nativescript-angular](https://github.com/NativeScript/nativescript-angular/) mobile renderer was using the zone-node.js bundle until 0.6.18+ added patching for the `timers` module and `fetch` promise-likes. Those are incompatible with NativeScript and cause runtime errors. The best solution to support zone.js in NativeScript in a way that minimizes future breakage seems to involve creating a separate bundle.

I based this bundle on the node one, just removing the unsupported patches. I also added a rudimentary test task that runs under node (to avoid spinning up device emulators and complicate build infrastructure).

`nativescript-angular` vendors the `zone-nativescript.js` bundle that this PR adds, but it would be great if we get rid of that in the future.

This PR takes care of #437 and the `fetch()` change is somewhat related to #439.