### PR TITLE
Don't patch itself recursively

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1155,7 +1155,7 @@ const Zone: ZoneType = (function(global: any) {
       }
       // ignore output to prevent error;
       fetchPromise.then(() => null, () => null);
-      if (fetchPromise.constructor != NativePromise) {
+      if (fetchPromise.constructor != NativePromise && fetchPromise.constructor != ZoneAwarePromise) {
         patchThen(fetchPromise.constructor);
       }
     }


### PR DESCRIPTION
I'm using fetch polyfill (https://github.com/camsong/fetch-ie8).
I'm loading this polyfill before zone.js loading, to get fetch patched by zone.

In this block fetch has been called to patch its returning Promise realization.
It happens, that at the moment of the call, global Promise already has been patched by Zone, fetch returns ZoneAwarePromise as a result, and then zone patch its own promise which leads to recursive calls on the first attempt of using fetch.