### PR TITLE
fix: fluent interface for EventEmitter

### DIFF
--- a/lib/node/events.ts
+++ b/lib/node/events.ts
@@ -8,6 +8,12 @@
 
 import {makeZoneAwareAddListener, makeZoneAwareListeners, makeZoneAwareRemoveListener, patchMethod} from '../common/utils';
 
+const callAndReturnFirstParam = (fn: (self: any, args: any[]) => any) => {
+  return (self: any, args: any[]) => {
+    fn(self, args);
+    return self;
+  };
+};
 
 // For EventEmitter
 const EE_ADD_LISTENER = 'addListener';
@@ -16,12 +22,9 @@ const EE_REMOVE_LISTENER = 'removeListener';
 const EE_LISTENERS = 'listeners';
 const EE_ON = 'on';
 
-
-const zoneAwareAddListener =
-    makeZoneAwareAddListener(EE_ADD_LISTENER, EE_REMOVE_LISTENER, false, true);
-const zoneAwarePrependListener =
-    makeZoneAwareAddListener(EE_PREPEND_LISTENER, EE_REMOVE_LISTENER, false, true);
-const zoneAwareRemoveListener = makeZoneAwareRemoveListener(EE_REMOVE_LISTENER, false);
+const zoneAwareAddListener = callAndReturnFirstParam(makeZoneAwareAddListener(EE_ADD_LISTENER, EE_REMOVE_LISTENER, false, true));
+const zoneAwarePrependListener = callAndReturnFirstParam(makeZoneAwareAddListener(EE_PREPEND_LISTENER, EE_REMOVE_LISTENER, false, true));
+const zoneAwareRemoveListener = callAndReturnFirstParam(makeZoneAwareRemoveListener(EE_REMOVE_LISTENER, false));
 const zoneAwareListeners = makeZoneAwareListeners(EE_LISTENERS);
 
 export function patchEventEmitterMethods(obj: any): boolean {

--- a/test/node/events.spec.ts
+++ b/test/node/events.spec.ts
@@ -37,6 +37,12 @@ describe('nodejs EventEmitter', () => {
     zoneB.run(() => emitter.emit('test', 'test value'));
     expect(expectZoneACount).toBe(2);
   });
+  it('allows chaining methods', () => {
+    zoneA.run(() => {
+      expect(emitter.on('test', expectZoneA)).toBe(emitter);
+      expect(emitter.addListener('test', expectZoneA)).toBe(emitter);
+    });
+  });
   it('should remove listeners properly', () => {
     zoneA.run(() => {
       emitter.on('test', shouldNotRun);


### PR DESCRIPTION
Fixes #470 by returning self from `addListener`, `on`, `prependListener`, `removeListener` in Node.js. 
