### PR TITLE
make it be array anyway

### DIFF
--- a/lib/zone-spec/fake-async-test.ts
+++ b/lib/zone-spec/fake-async-test.ts
@@ -86,7 +86,7 @@
     private _microtasks: Function[] = [];
     private _lastError: Error = null;
     private _uncaughtPromiseErrors: {rejection: any}[] =
-        Promise[Zone['__symbol__']('uncaughtPromiseErrors')];
+        Promise[Zone['__symbol__']('uncaughtPromiseErrors')] || [];
 
     pendingPeriodicTimers: number[] = [];
     pendingTimers: number[] = [];


### PR DESCRIPTION
In the rest of the class we act as we are sure this has to be array (`this._uncaughtPromiseErrors[0]`, `this._uncaughtPromiseErrors.length` usw). So it has to be an array even if something with zone is not like expected.
