### PR TITLE
[WIP]fix(patchProperty): fix when property is function with property

### DIFF
--- a/test/browser/XMLHttpRequest.spec.ts
+++ b/test/browser/XMLHttpRequest.spec.ts
@@ -182,4 +182,22 @@ describe('XMLHttpRequest', function() {
     expect(XMLHttpRequest.LOADING).toEqual(3);
     expect(XMLHttpRequest.DONE).toEqual(4);
   });
+
+  it('should reflect property in originFn after patched', function(done) {
+    var req = new XMLHttpRequest();
+    req.open('get', '/', true);
+    function readyStateChanged (event: ProgressEvent): any {
+      const { subscriber } = (<any>readyStateChanged);
+      expect(() => { subscriber(event) })
+        .not.toThrow();
+      done();
+    }
+    req.onreadystatechange = readyStateChanged;
+    (<any>req.onreadystatechange).subscriber = function(event: ProgressEvent) {
+      event.cancelBubble = true;
+    };
+    req.send();
+    // ensure onreadystatechange callback only called once
+    req.abort();
+  });
 });


### PR DESCRIPTION
property patch may cause some other libary that use `function with property` as property.

see https://github.com/ReactiveX/rxjs/blob/master/src/observable/dom/AjaxObservable.ts#L357

and simple example:
http://plnkr.co/edit/oX1v8tTjTog1T57Z0JnI?p=preview 