### PR TITLE
Make the check for ZoneAwarePromise more stringent

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1030,7 +1030,10 @@ const Zone: ZoneType = (function(global: any) {
   function resolvePromise(
       promise: ZoneAwarePromise<any>, state: boolean, value: any): ZoneAwarePromise<any> {
     if (promise[symbolState] === UNRESOLVED) {
-      if (value instanceof ZoneAwarePromise && value[symbolState] !== UNRESOLVED) {
+      if (value instanceof ZoneAwarePromise &&
+          value.hasOwnProperty(symbolState) &&
+          value.hasOwnProperty(symbolValue) &&
+          value[symbolState] !== UNRESOLVED) {
         clearRejectedNoCatch(<Promise<any>>value);
         resolvePromise(promise, value[symbolState], value[symbolValue]);
       } else if (isThenable(value)) {


### PR DESCRIPTION
Hi,

Here is my proposed fix for #494. I've opted to check for the properties "__zone_symbol__state" and "__zone_symbol__value". It just occurred to me that checking the `constructor` might also work, but I am not sure. Commit message below.

Thanks,
Mark

---

`resolvePromise` assumes that if a value is an `instanceof` ZoneAwarePromise then it has the properties "__zone_symbol__state" and "__zone_symbol__value" and it _is_ a true ZoneAwarePromise; however, a user can construct a value that breaks this assumption by inheriting from ZoneAwarePromise without actually having those properties or being a true ZoneAwarePromise (for example, by attempting to subclass Promise).

We can fix this by adding checks for "__zone_symbol__state" and "__zone_symbol__value" to `resolvePromise`.
