### PR TITLE
fix bug add event listener to xhrhttprequest multiple times and invalid request call

### DIFF
--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -48,6 +48,7 @@ patchXHR(_global);
 
 const XHR_TASK = zoneSymbol('xhrTask');
 const XHR_SYNC = zoneSymbol('xhrSync');
+const XHR_LISTENER = zoneSymbol('xhrListener');
 
 interface XHROptions extends TaskData {
   target: any;
@@ -63,13 +64,20 @@ function patchXHR(window: any) {
 
   function scheduleTask(task: Task) {
     var data = <XHROptions>task.data;
-    data.target.addEventListener('readystatechange', () => {
+    // remove existing event listener
+    var listener = data.target[XHR_LISTENER];
+    if (listener) {
+        data.target.removeEventListener('readystatechange', listener);
+    }
+    var newListener = data.target[XHR_LISTENER] = () => {
       if (data.target.readyState === data.target.DONE) {
         if (!data.aborted) {
           task.invoke();
         }
       }
-    });
+    };
+    data.target.addEventListener('readystatechange', newListener);
+
     var storedTask: Task = data.target[XHR_TASK];
     if (!storedTask) {
       data.target[XHR_TASK] = task;

--- a/test/browser/XMLHttpRequest.spec.ts
+++ b/test/browser/XMLHttpRequest.spec.ts
@@ -24,14 +24,12 @@ describe('XMLHttpRequest', function() {
         // The last entry in the log should be the invocation for the current onload,
         // which will vary depending on browser environment. The prior entries
         // should be the invocation of the send macrotask.
-        expect(wtfMock.log[wtfMock.log.length - 6])
-            .toMatch(/\> Zone\:invokeTask.*addEventListener\:readystatechange/);
         expect(wtfMock.log[wtfMock.log.length - 5])
-            .toEqual('> Zone:invokeTask:XMLHttpRequest.send("<root>::ProxyZone::WTF::TestZone")');
+            .toMatch(/\> Zone\:invokeTask.*addEventListener\:readystatechange/);
         expect(wtfMock.log[wtfMock.log.length - 4])
-            .toEqual('< Zone:invokeTask:XMLHttpRequest.send');
+            .toEqual('> Zone:invokeTask:XMLHttpRequest.send("<root>::ProxyZone::WTF::TestZone")');
         expect(wtfMock.log[wtfMock.log.length - 3])
-            .toMatch(/# Zone\:cancel.*addEventListener\:readystatechange/);
+            .toEqual('< Zone:invokeTask:XMLHttpRequest.send');
         expect(wtfMock.log[wtfMock.log.length - 2])
             .toMatch(/\< Zone\:invokeTask.*addEventListener\:readystatechange/);
         done();

--- a/test/browser/XMLHttpRequest.spec.ts
+++ b/test/browser/XMLHttpRequest.spec.ts
@@ -24,12 +24,14 @@ describe('XMLHttpRequest', function() {
         // The last entry in the log should be the invocation for the current onload,
         // which will vary depending on browser environment. The prior entries
         // should be the invocation of the send macrotask.
-        expect(wtfMock.log[wtfMock.log.length - 5])
+        expect(wtfMock.log[wtfMock.log.length - 6])
             .toMatch(/\> Zone\:invokeTask.*addEventListener\:readystatechange/);
-        expect(wtfMock.log[wtfMock.log.length - 4])
+        expect(wtfMock.log[wtfMock.log.length - 5])
             .toEqual('> Zone:invokeTask:XMLHttpRequest.send("<root>::ProxyZone::WTF::TestZone")');
-        expect(wtfMock.log[wtfMock.log.length - 3])
+        expect(wtfMock.log[wtfMock.log.length - 4])
             .toEqual('< Zone:invokeTask:XMLHttpRequest.send');
+        expect(wtfMock.log[wtfMock.log.length - 3])
+            .toMatch(/# Zone\:cancel.*addEventListener\:readystatechange/);
         expect(wtfMock.log[wtfMock.log.length - 2])
             .toMatch(/\< Zone\:invokeTask.*addEventListener\:readystatechange/);
         done();

--- a/test/browser/XMLHttpRequest.spec.ts
+++ b/test/browser/XMLHttpRequest.spec.ts
@@ -194,12 +194,4 @@ describe('XMLHttpRequest', function() {
       }
     });
   })
-
-  it('should work properly when send request to an invalid instance', function() {
-    testZone.run(function() {
-      var req = new XMLHttpRequest();
-      req.open('get', 'file:///test', true);
-      req.send();
-    });
-  });
 });

--- a/test/browser/XMLHttpRequest.spec.ts
+++ b/test/browser/XMLHttpRequest.spec.ts
@@ -182,4 +182,16 @@ describe('XMLHttpRequest', function() {
     expect(XMLHttpRequest.LOADING).toEqual(3);
     expect(XMLHttpRequest.DONE).toEqual(4);
   });
+
+  it('should work properly when send request multiple times on single xmlRequest instance', function() {
+    testZone.run(function() {
+      var req = new XMLHttpRequest();
+      req.open('get', '/', true);
+      req.send();
+      req.onloadend = function() {
+        req.open('get', '/', true);
+        req.send();
+      }
+    });
+  })
 });

--- a/test/browser/XMLHttpRequest.spec.ts
+++ b/test/browser/XMLHttpRequest.spec.ts
@@ -194,4 +194,12 @@ describe('XMLHttpRequest', function() {
       }
     });
   })
+
+  it('should work properly when send request to an invalid instance', function() {
+    testZone.run(function() {
+      var req = new XMLHttpRequest();
+      req.open('get', 'file:///test', true);
+      req.send();
+    });
+  });
 });


### PR DESCRIPTION
1. in issue #287, the xhrhttprequest add documentreadychange eventlistener multipletimes (https://github.com/angular/zone.js/blob/master/lib/browser/browser.ts#L66), so when task finished, updateTaskCount will cause "More tasks executed then were scheduled" error. The issue
can be simplified as the following test case.

```javascript
Zone.current.fork({name:'test'}).run(function() {
      var req = new XMLHttpRequest();
      req.open('get', '/', true);
      req.send();
      req.onloadend = function() {
        req.open('get', '/', true);
        req.send();
      }
```
So we should removeEventlistener before add new one.

2. another issue when xhrhttprequest call invalid url described in #530.

```javascript
var req = new XMLHttpRequest();
      req.open('get', 'file:///test', true);
      req.send();
```

