### PR TITLE
fix inline event handler issue #525 #540

### DIFF
--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -55,7 +55,7 @@ export function patchProperty(obj, prop) {
   const desc = Object.getOwnPropertyDescriptor(obj, prop) || {enumerable: true, configurable: true};
 
   const originalDesc = Object.getOwnPropertyDescriptor(obj, 'original' + prop);
-  if (!originalDesc) {
+  if (!originalDesc && desc.get) {
     Object.defineProperty(obj, 'original' + prop, {
       enumerable: false,
       configurable: true,
@@ -106,7 +106,7 @@ export function patchProperty(obj, prop) {
     // the property is accessed, https://github.com/angular/zone.js/issues/525
     // so we should use original native get to retrive the handler
     if (r === null) {
-      var oriDesc = Object.getOwnPropertyDescriptor(obj, 'original' + prop);
+      let oriDesc = Object.getOwnPropertyDescriptor(obj, 'original' + prop);
       if (oriDesc && oriDesc.get) {
         r = oriDesc.get.apply(this, arguments);
         if (r) {

--- a/test/browser/browser.spec.ts
+++ b/test/browser/browser.spec.ts
@@ -139,7 +139,7 @@ describe('Zone', function() {
 
         zone.run(function() {
           button.setAttribute('onclick', 'return');
-          expect(button.onclick).not.toBeUndefined();
+          expect(button.onclick).not.toBe(undefined);
         });
       })
     });

--- a/test/browser/browser.spec.ts
+++ b/test/browser/browser.spec.ts
@@ -141,10 +141,6 @@ describe('Zone', function() {
           button.setAttribute('onclick', 'return');
           expect(button.onclick).not.toBeUndefined();
         });
-
-        button.dispatchEvent(clickEvent);
-
-        expect(hookSpy).toHaveBeenCalled();
       })
     });
   });

--- a/test/browser/browser.spec.ts
+++ b/test/browser/browser.spec.ts
@@ -125,6 +125,27 @@ describe('Zone', function() {
         expect(hookSpy).toHaveBeenCalled();
         expect(eventListenerSpy).not.toHaveBeenCalled();
       });
+
+      it('should support inline event handler attributes', function() {
+        var hookSpy = jasmine.createSpy('hook');
+        var zone = rootZone.fork({
+          name: 'spy',
+          onScheduleTask: (parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone,
+                           task: Task): any => {
+            hookSpy();
+            return parentZoneDelegate.scheduleTask(targetZone, task);
+          }
+        });
+
+        zone.run(function() {
+          button.setAttribute('onclick', 'return');
+          expect(button.onclick).not.toBeUndefined();
+        });
+
+        button.dispatchEvent(clickEvent);
+
+        expect(hookSpy).toHaveBeenCalled();
+      })
     });
   });
 });

--- a/test/browser/browser.spec.ts
+++ b/test/browser/browser.spec.ts
@@ -139,7 +139,7 @@ describe('Zone', function() {
 
         zone.run(function() {
           button.setAttribute('onclick', 'return');
-          expect(button.onclick).not.toBe(undefined);
+          expect(button.onclick).not.toBe(null);
         });
       })
     });


### PR DESCRIPTION
fix #525 and #540, inline event handler will not be patched with zone. And when you want to get the inline event handler will return null.

```javascript
<button id="btn1" onclick="func()">ok</button>
```

The func will not be patched, and if you access document.getElementById('btn1').onclick will return null.

The PR will not totally fixed the issue, if you don't access the elem.onclick for example, still no patch(but not null, you will get the original native version handler). you should add the following code to patch if you want to handle inline event handler

```javascript
          var all = document.getElementsByTagName("*");

          for (var i=0, max=all.length; i < max; i++) {
           var elem = all[i];
           for (var j = 0; j < eventNames.length; j ++) {
             var attr = eventNames[j];
             var attrValue = elem['on' + attr];
           }
          }
```