### PR TITLE
fix #546, should keep error prototype chain correctly

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1283,13 +1283,14 @@ const Zone: ZoneType = (function(global: any) {
   function ZoneAwareError() {
     // Create an Error.
     let error: Error = NativeError.apply(this, arguments);
+    this.message = error.message;
 
     // Save original stack trace
-    error.originalStack = error.stack;
+    this.originalStack = error.stack;
 
     // Process the stack trace and rewrite the frames.
-    if (ZoneAwareError[stackRewrite] && error.originalStack) {
-      let frames: string[] = error.originalStack.split('\n');
+    if (ZoneAwareError[stackRewrite] && this.originalStack) {
+      let frames: string[] = this.originalStack.split('\n');
       let zoneFrame = _currentZoneFrame;
       let i = 0;
       // Find the first frame
@@ -1317,13 +1318,12 @@ const Zone: ZoneType = (function(global: any) {
           }
         }
       }
-      error.stack = error.zoneAwareStack = frames.join('\n');
+      this.stack = this.zoneAwareStack = frames.join('\n');
     }
-    return error;
-  }
+  };
 
   // Copy the prototype so that instanceof operator works as expected
-  ZoneAwareError.prototype = NativeError.prototype;
+  ZoneAwareError.prototype = Object.create(NativeError.prototype);
   ZoneAwareError[Zone.__symbol__('blacklistedStackFrames')] = blackListedStackFrames;
   ZoneAwareError[stackRewrite] = false;
 

--- a/test/common/Error.spec.ts
+++ b/test/common/Error.spec.ts
@@ -16,6 +16,7 @@ describe('ZoneAwareError', () => {
     const myError = new MyError();
     expect(myError instanceof Error).toBe(true);
     expect(myError instanceof MyError).toBe(true);
+    expect(myError.stack).not.toBe(undefined);
   });
 
   it('should show zone names in stack frames and remove extra frames', () => {

--- a/test/common/Error.spec.ts
+++ b/test/common/Error.spec.ts
@@ -11,6 +11,13 @@ describe('ZoneAwareError', () => {
   // and there is no point in running them.
   if (!Error['stackRewrite']) return;
 
+  it('should keep error prototype chain correctly', () => {
+    class MyError extends Error {}
+    const myError = new MyError();
+    expect(myError instanceof Error).toBe(true);
+    expect(myError instanceof MyError).toBe(true);
+  });
+
   it('should show zone names in stack frames and remove extra frames', () => {
     const rootZone = getRootZone();
     const innerZone = rootZone.fork({name: 'InnerZone'});


### PR DESCRIPTION
Fix #546, should keep error prototype chain correctly, in the original code, the ZoneAwareError will return a nativeError and lost the prototype chain