### PR TITLE
patch fs methods as macrotask, add test cases of fs watcher

### DIFF
--- a/lib/node/fs.ts
+++ b/lib/node/fs.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {bindArguments} from '../common/utils';
+import {patchMethod} from '../common/utils';
 
 let fs;
 try {
@@ -14,8 +14,9 @@ try {
 } catch (err) {
 }
 
-// TODO(alxhub): Patch `watch` and `unwatchFile`.
-const TO_PATCH = [
+// watch, watchFile, unwatchFile has been patched
+// because EventEmitter has been patched
+const TO_PATCH_MACROTASK_METHODS = [
   'access',  'appendFile', 'chmod',    'chown',    'close',     'exists',    'fchmod',
   'fchown',  'fdatasync',  'fstat',    'fsync',    'ftruncate', 'futimes',   'lchmod',
   'lchown',  'link',       'lstat',    'mkdir',    'mkdtemp',   'open',      'read',
@@ -24,11 +25,37 @@ const TO_PATCH = [
 ];
 
 if (fs) {
-  TO_PATCH.filter(name => !!fs[name] && typeof fs[name] === 'function').forEach(name => {
-    fs[name] = ((delegate: Function) => {
-      return function() {
-        return delegate.apply(this, bindArguments(<any>arguments, 'fs.' + name));
-      };
-    })(fs[name]);
+  TO_PATCH_MACROTASK_METHODS.filter(name => !!fs[name] && typeof fs[name] === 'function')
+      .forEach(name => {
+        patchFsMacroTaskMethod(fs, name);
+      });
+}
+
+interface FileSystemOptions extends TaskData {
+  args: any[];
+}
+
+function patchFsMacroTaskMethod(fs: any, methodName: string) {
+  let setNative = null;
+
+  function scheduleTask(task: Task) {
+    const data = <FileSystemOptions>task.data;
+    data.args[data.args.length - 1] = function() {
+      task.invoke.apply(this, arguments);
+    };
+    setNative.apply(fs, data.args);
+    return task;
+  }
+
+  setNative = patchMethod(fs, methodName, (delegate: Function) => function(self: any, args: any[]) {
+    if (args.length > 0 && typeof args[args.length - 1] === 'function') {
+      const options: FileSystemOptions = {args: args};
+      const task = Zone.current.scheduleMacroTask(
+          'fs.' + methodName, args[args.length - 1], options, scheduleTask, null);
+      return task;
+    } else {
+      // cause an error by calling it directly.
+      return delegate.apply(fs, args);
+    }
   });
 }

--- a/test/node/fs.spec.ts
+++ b/test/node/fs.spec.ts
@@ -6,15 +6,83 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {exists} from 'fs';
+import {exists, unlink, unwatchFile, watch, watchFile, writeFile} from 'fs';
 
 describe('nodejs file system', () => {
-  it('has patched exists()', (done) => {
-    const zoneA = Zone.current.fork({name: 'A'});
-    zoneA.run(() => {
-      exists('testfile', (_) => {
-        expect(Zone.current.name).toBe(zoneA.name);
-        done();
+  describe('async method patch test', () => {
+    it('has patched exists()', (done) => {
+      const zoneA = Zone.current.fork({name: 'A'});
+      zoneA.run(() => {
+        exists('testfile', (_) => {
+          expect(Zone.current.name).toBe(zoneA.name);
+          done();
+        });
+      });
+    });
+
+    it('has patched exists as macroTask', (done) => {
+      const zoneASpec = {
+        name: 'A',
+        onScheduleTask: (delegate, currentZone, targetZone, task): Task => {
+          return delegate.scheduleTask(targetZone, task);
+        }
+      };
+      const zoneA = Zone.current.fork(zoneASpec);
+      spyOn(zoneASpec, 'onScheduleTask').and.callThrough();
+      zoneA.run(() => {
+        exists('testfile', (_) => {
+          expect(zoneASpec.onScheduleTask).toHaveBeenCalled();
+          done();
+        });
+      });
+    });
+  });
+
+  describe('watcher related methods test', () => {
+    const zoneASpec = {
+      name: 'A',
+      onScheduleTask: (delegate, currentZone, targetZone, task): Task => {
+        return delegate.scheduleTask(targetZone, task);
+      }
+    };
+
+    it('fs.watch has been patched as eventTask', (done) => {
+      spyOn(zoneASpec, 'onScheduleTask').and.callThrough();
+      const zoneA = Zone.current.fork(zoneASpec);
+      zoneA.run(() => {
+        writeFile('testfile', 'test content', () => {
+          const watcher = watch('testfile', (eventType, filename) => {
+            expect(filename).toEqual('testfile');
+            expect(eventType).toEqual('change');
+            expect(zoneASpec.onScheduleTask).toHaveBeenCalled();
+            expect(Zone.current.name).toBe('A');
+            watcher.close();
+            unlink('testfile', () => {
+              done();
+            });
+          });
+          writeFile('testfile', 'test new content');
+        });
+      });
+    });
+
+    it('fs.watchFile has been patched as eventTask', (done) => {
+      spyOn(zoneASpec, 'onScheduleTask').and.callThrough();
+      const zoneA = Zone.current.fork(zoneASpec);
+      zoneA.run(() => {
+        writeFile('testfile', 'test content', () => {
+          watchFile('testfile', {persistent: false, interval: 1000}, (curr, prev) => {
+            expect(curr.size).toBe(16);
+            expect(prev.size).toBe(12);
+            expect(zoneASpec.onScheduleTask).toHaveBeenCalled();
+            expect(Zone.current.name).toBe('A');
+            unwatchFile('testfile');
+            unlink('testfile', () => {
+              done();
+            });
+          });
+          writeFile('testfile', 'test new content');
+        });
       });
     });
   });


### PR DESCRIPTION
1. patch fs async methods (open, exists, write...) as macrotask, in previous patch, we use wrap, 
in my understanding, patch with wrap vs as macro task, we can both intercept schedule and invoke, 
but patch with macroTask can also have the ability to intercept cancelTask and hasTask.

2. add test cases of fs watcher related methods. Because we already patched EventEmitter, so fs.watch, fs.watchFile, fs.unwatchFile don't need additional patch. 
3. add a generic patch macro task method in util.ts

And in original patch, we patched the fs function with wrap, now we treat them as macrotask, so fs method will make additional callback (invokeTask/scheduleTask etc..) call, it may have some performance impact, I will make some other performance demo to check it.