### PR TITLE
fix #574, captureStackTrace will have additional stackframe from Zone…

### DIFF
--- a/test/node/Error.spec.ts
+++ b/test/node/Error.spec.ts
@@ -25,4 +25,16 @@ describe('ZoneAwareError', () => {
     Error.captureStackTrace(obj);
     expect(obj.stack[0].getFileName()).not.toBeUndefined();
   });
+
+  it('should not add additional stacktrace from Zone when use prepareStackTrace', () => {
+    (<any>Error).prepareStackTrace = function(error, stack) {
+      return stack;
+    };
+    let obj: any = new Object();
+    Error.captureStackTrace(obj);
+    expect(obj.stack.length).not.toBe(0);
+    obj.stack.forEach(function(st) {
+      expect(st.getFunctionName()).not.toEqual('zoneCaptureStackTrace');
+    });
+  });
 });


### PR DESCRIPTION
Fix #574, from zone.js 0.7.x, we have a patched ZoneAwareError, and we patch everything from native Error includes captureStackTrace and prepareStackTrace like this.

```javascript
      if (NativeError.hasOwnProperty('captureStackTrace')) {
    Object.defineProperty(ZoneAwareError, 'captureStackTrace', {
      // add named function here because we need to remove this
      // stack frame when prepareStackTrace below
      value: function(targetObject: Object, constructorOpt?: Function) {
        NativeError.captureStackTrace(targetObject, constructorOpt);
      }
    });
  }
```

It works but will add an additional stack frame, which is the patched function named 
value above. So it will break [binding.js](https://github.com/TooTallNate/node-bindings/blob/master/bindings.js#L112) which try to find the current loaded js filename.

So in this fix, I change the patch function to a named function(zoneCaptureStackTrace), 
and remove this stack information when call prepareStackTrace.