### PR TITLE
fix #551, add toJSON to ZoneTask to prevent cyclic error

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -962,6 +962,22 @@ const Zone: ZoneType = (function(global: any) {
         return Object.prototype.toString.call(this);
       }
     }
+
+    // add toJSON method to prevent cyclic error when
+    // call JSON.stringify(zoneTask)
+    public toJSON() {
+      return {
+        type: this.type,
+        source: this.source,
+        data: this.data,
+        zone: this.zone.name,
+        invoke: this.invoke,
+        scheduleFn: this.scheduleFn,
+        cancelFn: this.cancelFn,
+        runCount: this.runCount,
+        callback: this.callback
+      };
+    }
   }
 
   interface UncaughtPromiseError extends Error {

--- a/test/common/zone.spec.ts
+++ b/test/common/zone.spec.ts
@@ -231,6 +231,22 @@ describe('Zone', function() {
 
       macro.invoke();
     });
+
+    it('should convert task to json without cyclic error', () => {
+      const z = Zone.current;
+      const event = z.scheduleEventTask('test', () => {}, null, noop, noop);
+      const micro = z.scheduleMicroTask('test', () => {});
+      const macro = z.scheduleMacroTask('test', () => {}, null, noop, noop);
+      expect(function() {
+        JSON.stringify(event);
+      }).not.toThrow();
+      expect(function() {
+        JSON.stringify(micro);
+      }).not.toThrow();
+      expect(function() {
+        JSON.stringify(macro);
+      }).not.toThrow();
+    });
   });
 });
 


### PR DESCRIPTION
in issue #551, vaddin use zone.js and use JSON.stringify the dom element, because zone.js patched 
eventlistener, the JSON.stringify will serialize ZoneTask as well, and ZoneTask has reference to Zone, JSON.stringify(zoneTask) will cause cyclic error.

in this PR, I just leave the simplified information with toJSON() callback.