### PR TITLE
fix #577, canPatchViaPropertyDescriptor test break XHR prototype

### DIFF
--- a/lib/browser/property-descriptor.ts
+++ b/lib/browser/property-descriptor.ts
@@ -56,7 +56,13 @@ function canPatchViaPropertyDescriptor() {
     if (desc && !desc.configurable) return false;
   }
 
+  // add enumerable and configurable here because in opera
+  // by default XMLHttpRequest.prototype.onreadystatechange is undefined
+  // without adding enumerable and configurable will cause onreadystatechange
+  // non-configurable
   Object.defineProperty(XMLHttpRequest.prototype, 'onreadystatechange', {
+    enumerable: true,
+    configurable: true,
     get: function() {
       return true;
     }


### PR DESCRIPTION
fix #577, canPatchViaPropertyDescriptor test should add configurable to XMLHttpRequest.prototype.onreadystatechange, otherwise in opera 12, by default 
XMLHttpRequest.prototype.onreadystatechange,

so after test below.

```javascript
Object.defineProperty(XMLHttpRequest.prototype, 'onreadystatechange', {
    get: function() {
      return true;
    }
});
```

XMLHttpRequest.prototype.onreadystatechange become non-configurable.