### PR TITLE
fix #579, add isOrphan property to zoneSpec

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -271,6 +271,12 @@ interface ZoneSpec {
   name: string;
 
   /**
+   * Is the spec is Orphan Spec, by default orphan is false
+   * If Orphan is true, than the spec will not call parent zone delegate's callback
+   */
+  isOrphan?: boolean;
+
+  /**
    * A set of properties to be associated with Zone. Use [Zone.get] to retrive them.
    */
   properties?: {[key: string]: any};
@@ -717,6 +723,8 @@ const Zone: ZoneType = (function(global: any) {
   class ZoneDelegate implements AmbientZoneDelegate {
     public zone: Zone;
 
+    private _isOrphan: boolean = false;
+
     private _taskCounts: {microTask: number,
                           macroTask: number,
                           eventTask: number} = {microTask: 0, macroTask: 0, eventTask: 0};
@@ -759,63 +767,69 @@ const Zone: ZoneType = (function(global: any) {
       this.zone = zone;
       this._parentDelegate = parentDelegate;
 
-      this._forkZS = zoneSpec && (zoneSpec && zoneSpec.onFork ? zoneSpec : parentDelegate._forkZS);
+      this._isOrphan = zoneSpec ? zoneSpec.isOrphan : false;
+
+      this._forkZS =
+          zoneSpec && ((zoneSpec.onFork || this._isOrphan) ? zoneSpec : parentDelegate._forkZS);
       this._forkDlgt = zoneSpec && (zoneSpec.onFork ? parentDelegate : parentDelegate._forkDlgt);
       this._forkCurrZone = zoneSpec && (zoneSpec.onFork ? this.zone : parentDelegate.zone);
 
-      this._interceptZS =
-          zoneSpec && (zoneSpec.onIntercept ? zoneSpec : parentDelegate._interceptZS);
+      this._interceptZS = zoneSpec &&
+          ((zoneSpec.onIntercept || this._isOrphan) ? zoneSpec : parentDelegate._interceptZS);
       this._interceptDlgt =
           zoneSpec && (zoneSpec.onIntercept ? parentDelegate : parentDelegate._interceptDlgt);
       this._interceptCurrZone =
           zoneSpec && (zoneSpec.onIntercept ? this.zone : parentDelegate.zone);
 
-      this._invokeZS = zoneSpec && (zoneSpec.onInvoke ? zoneSpec : parentDelegate._invokeZS);
+      this._invokeZS =
+          zoneSpec && ((zoneSpec.onInvoke || this._isOrphan) ? zoneSpec : parentDelegate._invokeZS);
       this._invokeDlgt =
           zoneSpec && (zoneSpec.onInvoke ? parentDelegate : parentDelegate._invokeDlgt);
       this._invokeCurrZone = zoneSpec && (zoneSpec.onInvoke ? this.zone : parentDelegate.zone);
 
-      this._handleErrorZS =
-          zoneSpec && (zoneSpec.onHandleError ? zoneSpec : parentDelegate._handleErrorZS);
+      this._handleErrorZS = zoneSpec &&
+          ((zoneSpec.onHandleError || this._isOrphan) ? zoneSpec : parentDelegate._handleErrorZS);
       this._handleErrorDlgt =
           zoneSpec && (zoneSpec.onHandleError ? parentDelegate : parentDelegate._handleErrorDlgt);
       this._handleErrorCurrZone =
           zoneSpec && (zoneSpec.onHandleError ? this.zone : parentDelegate.zone);
 
-      this._scheduleTaskZS =
-          zoneSpec && (zoneSpec.onScheduleTask ? zoneSpec : parentDelegate._scheduleTaskZS);
+      this._scheduleTaskZS = zoneSpec &&
+          ((zoneSpec.onScheduleTask || this._isOrphan) ? zoneSpec : parentDelegate._scheduleTaskZS);
       this._scheduleTaskDlgt =
           zoneSpec && (zoneSpec.onScheduleTask ? parentDelegate : parentDelegate._scheduleTaskDlgt);
       this._scheduleTaskCurrZone =
           zoneSpec && (zoneSpec.onScheduleTask ? this.zone : parentDelegate.zone);
 
-      this._invokeTaskZS =
-          zoneSpec && (zoneSpec.onInvokeTask ? zoneSpec : parentDelegate._invokeTaskZS);
+      this._invokeTaskZS = zoneSpec &&
+          ((zoneSpec.onInvokeTask || this._isOrphan) ? zoneSpec : parentDelegate._invokeTaskZS);
       this._invokeTaskDlgt =
           zoneSpec && (zoneSpec.onInvokeTask ? parentDelegate : parentDelegate._invokeTaskDlgt);
       this._invokeTaskCurrZone =
           zoneSpec && (zoneSpec.onInvokeTask ? this.zone : parentDelegate.zone);
 
-      this._cancelTaskZS =
-          zoneSpec && (zoneSpec.onCancelTask ? zoneSpec : parentDelegate._cancelTaskZS);
+      this._cancelTaskZS = zoneSpec &&
+          ((zoneSpec.onCancelTask || this._isOrphan) ? zoneSpec : parentDelegate._cancelTaskZS);
       this._cancelTaskDlgt =
           zoneSpec && (zoneSpec.onCancelTask ? parentDelegate : parentDelegate._cancelTaskDlgt);
       this._cancelTaskCurrZone =
           zoneSpec && (zoneSpec.onCancelTask ? this.zone : parentDelegate.zone);
 
-      this._hasTaskZS = zoneSpec && (zoneSpec.onHasTask ? zoneSpec : parentDelegate._hasTaskZS);
+      this._hasTaskZS = zoneSpec &&
+          ((zoneSpec.onHasTask || this._isOrphan) ? zoneSpec : parentDelegate._hasTaskZS);
       this._hasTaskDlgt =
           zoneSpec && (zoneSpec.onHasTask ? parentDelegate : parentDelegate._hasTaskDlgt);
       this._hasTaskCurrZone = zoneSpec && (zoneSpec.onHasTask ? this.zone : parentDelegate.zone);
     }
 
     fork(targetZone: Zone, zoneSpec: ZoneSpec): AmbientZone {
-      return this._forkZS ? this._forkZS.onFork(this._forkDlgt, this.zone, targetZone, zoneSpec) :
-                            new Zone(targetZone, zoneSpec);
+      return (this._forkZS && this._forkZS.onFork) ?
+          this._forkZS.onFork(this._forkDlgt, this.zone, targetZone, zoneSpec) :
+          new Zone(targetZone, zoneSpec);
     }
 
     intercept(targetZone: Zone, callback: Function, source: string): Function {
-      return this._interceptZS ?
+      return (this._interceptZS && this._interceptZS.onIntercept) ?
           this._interceptZS.onIntercept(
               this._interceptDlgt, this._interceptCurrZone, targetZone, callback, source) :
           callback;
@@ -823,7 +837,7 @@ const Zone: ZoneType = (function(global: any) {
 
     invoke(targetZone: Zone, callback: Function, applyThis: any, applyArgs: any[], source: string):
         any {
-      return this._invokeZS ?
+      return (this._invokeZS && this._invokeZS.onInvoke) ?
           this._invokeZS.onInvoke(
               this._invokeDlgt, this._invokeCurrZone, targetZone, callback, applyThis, applyArgs,
               source) :
@@ -831,7 +845,7 @@ const Zone: ZoneType = (function(global: any) {
     }
 
     handleError(targetZone: Zone, error: any): boolean {
-      return this._handleErrorZS ?
+      return (this._handleErrorZS && this._handleErrorZS.onHandleError) ?
           this._handleErrorZS.onHandleError(
               this._handleErrorDlgt, this._handleErrorCurrZone, targetZone, error) :
           true;
@@ -839,7 +853,7 @@ const Zone: ZoneType = (function(global: any) {
 
     scheduleTask(targetZone: Zone, task: Task): Task {
       try {
-        if (this._scheduleTaskZS) {
+        if (this._scheduleTaskZS && this._scheduleTaskZS.onScheduleTask) {
           return this._scheduleTaskZS.onScheduleTask(
               this._scheduleTaskDlgt, this._scheduleTaskCurrZone, targetZone, task);
         } else if (task.scheduleFn) {
@@ -859,7 +873,7 @@ const Zone: ZoneType = (function(global: any) {
 
     invokeTask(targetZone: Zone, task: Task, applyThis: any, applyArgs: any): any {
       try {
-        return this._invokeTaskZS ?
+        return (this._invokeTaskZS && this._invokeTaskZS.onInvokeTask) ?
             this._invokeTaskZS.onInvokeTask(
                 this._invokeTaskDlgt, this._invokeTaskCurrZone, targetZone, task, applyThis,
                 applyArgs) :
@@ -874,7 +888,7 @@ const Zone: ZoneType = (function(global: any) {
 
     cancelTask(targetZone: Zone, task: Task): any {
       let value;
-      if (this._cancelTaskZS) {
+      if (this._cancelTaskZS && this._cancelTaskZS.onCancelTask) {
         value = this._cancelTaskZS.onCancelTask(
             this._cancelTaskDlgt, this._cancelTaskCurrZone, targetZone, task);
       } else if (!task.cancelFn) {
@@ -890,7 +904,7 @@ const Zone: ZoneType = (function(global: any) {
     }
 
     hasTask(targetZone: Zone, isEmpty: HasTaskState) {
-      return this._hasTaskZS &&
+      return this._hasTaskZS && this._hasTaskZS.onHasTask &&
           this._hasTaskZS.onHasTask(this._hasTaskDlgt, this._hasTaskCurrZone, targetZone, isEmpty);
     }
 
@@ -911,7 +925,7 @@ const Zone: ZoneType = (function(global: any) {
         try {
           this.hasTask(this.zone, isEmpty);
         } finally {
-          if (this._parentDelegate) {
+          if (this._parentDelegate && !this._isOrphan) {
             this._parentDelegate._updateTaskCount(type, count);
           }
         }

--- a/test/common_tests.ts
+++ b/test/common_tests.ts
@@ -19,5 +19,6 @@ import './zone-spec/sync-test.spec';
 import './zone-spec/fake-async-test.spec';
 import './zone-spec/proxy.spec';
 import './zone-spec/task-tracking.spec';
+import './zone-spec/orphan.spec';
 
 Error.stackTraceLimit = Number.POSITIVE_INFINITY;

--- a/test/zone-spec/orphan.spec.ts
+++ b/test/zone-spec/orphan.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+describe('orphan zonespec test', () => {
+  it('orphan zonespec should not call parent delegate callback test', (done) => {
+    let beginToSpy = false;
+
+    const onForkSpy = jasmine.createSpy('fork');
+    const onInterceptSpy = jasmine.createSpy('intercept');
+    const onInvokeSpy = jasmine.createSpy('invoke');
+    const onScheduleTaskSpy = jasmine.createSpy('scheduleTask');
+    const onInvokeTaskSpy = jasmine.createSpy('invokeTask');
+    const onCancelTaskSpy = jasmine.createSpy('cancelTask');
+    const onHasTaskSpy = jasmine.createSpy('hasTask');
+    const onErrorSpy = jasmine.createSpy('error');
+
+    const zoneParentSpec = {
+      name: 'parent',
+      onFork: (delegate, currentZone, targetZone, zoneSpec) => {
+        if (beginToSpy) {
+          onForkSpy(targetZone, zoneSpec);
+        }
+        return delegate.fork(targetZone, zoneSpec);
+      },
+      onIntercept: (delegate, currentZone, targetZone, callback, source) => {
+        if (beginToSpy) {
+          onInterceptSpy(targetZone, callback, source);
+        }
+        return delegate.intercept(targetZone, callback, source);
+      },
+      onHandleError: (delegate, currentZone, targetZone, error) => {
+        if (beginToSpy) {
+          onErrorSpy(targetZone, error);
+        }
+        return delegate.handleError(targetZone, error);
+      },
+      onInvoke: (delegate, currentZone, targetZone, callback, applyThis, applyArgs, source) => {
+        if (beginToSpy) {
+          onInvokeSpy(targetZone, error);
+        }
+        return delegate.invoke(targetZone, callback, applyThis, applyArgs, source);
+      },
+      onScheduleTask: (delegate, currentZone, targetZone, task) => {
+        if (beginToSpy) {
+          onScheduleTaskSpy(targetZone, error);
+        }
+        return delegate.scheduleTask(targetZone, task);
+      },
+      onInvokeTask: (delegate, currentZone, targetZone, task, applyThis, applyArgs) => {
+        if (beginToSpy) {
+          onInvokeTaskSpy(targetZone, error);
+        }
+        return delegate.invokeTask(targetZone, task, applyThis, applyArgs);
+      },
+      onCancelTask: (delegate, currentZone, targetZone, task) => {
+        if (beginToSpy) {
+          onCancelTaskSpy(targetZone, error);
+        }
+        return delegate.cancelTask(targetZone, task);
+      },
+      onHasTask: (delegate, currentZone, targetZone, hasTaskState) => {
+        if (beginToSpy) {
+          onHasTaskSpy(targetZone, error);
+        }
+        return delegate.hasTask(targetZone, hasTaskState);
+      }
+    };
+
+    const zoneParent = Zone.current.fork(zoneParentSpec);
+
+    const zoneOrphan = zoneParent.fork({name: 'orphan', isOrphan: true});
+
+    zoneOrphan.run(() => {
+      expect(Zone.current.name).toEqual('orphan');
+      // fork a new zone to trigger onFork
+      Zone.current.fork({name: 'test'}).run(() => {
+        beginToSpy = true;
+        expect(Zone.current.name).toEqual('test');
+
+        // trigger intercept and invoke
+        const func = function() {};
+        const wrappedFunc = Zone.current.wrap(func, 'func');
+        wrappedFunc.apply(null, null);
+
+        // trigger task related callback
+        Zone.current.scheduleMicroTask('test', () => {});
+        const macro = Zone.current.scheduleMacroTask('test', () => {}, null, () => {}, () => {});
+        Zone.current.cancelTask(macro);
+      });
+    });
+
+    setTimeout(() => {
+      expect(onForkSpy).not.toHaveBeenCalled();
+      expect(onInterceptSpy).not.toHaveBeenCalled();
+      expect(onErrorSpy).not.toHaveBeenCalled();
+      expect(onInvokeSpy).not.toHaveBeenCalled();
+      expect(onScheduleTaskSpy).not.toHaveBeenCalled();
+      expect(onInvokeTaskSpy).not.toHaveBeenCalled();
+      expect(onCancelTaskSpy).not.toHaveBeenCalled();
+      expect(onHasTaskSpy).not.toHaveBeenCalled();
+      done();
+    }, 10);
+  });
+
+  it('should not fall into dead loop', (done) => {
+    function asyncLog() {
+      setTimeout(() => {}, 10);
+    }
+    const zoneA = Zone.current.fork({
+      name: 'A',
+      onScheduleTask: (delegate, currentZone, targetZone, task) => {
+        Zone.current.fork({name: 'orphan', isOrphan: true}).run(() => {
+          asyncLog();
+        });
+        return delegate.scheduleTask(targetZone, task);
+      }
+    });
+
+    zoneA.run(() => {
+      Promise.resolve().then(() => {
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
fix #579, add isOrphan property to zoneSpec, by default is false, so will not impact current behavior, 
if isOrphan is true, then the parent zone's callback will not be called.

- usage

```javascript
  const zoneASpec = {
        name: 'A',
        onScheduleTask: (delegate, currentZone, targetZone, task): Task => {
           Zone.current.fork({name:'orphan', isOrphan: true}).run(() => {
              console.log('log here');
           });
           return delegate.scheduleTask(targetZone, task);
        }
      };
```

So the code run in orphan zone will not trigger it's parent zone zoneA's callback.

I think maybe all code run in zoneSpec's callback which may trigger other async operation 
should run in an orphan zone, otherwise may trigger dead loop error.
for example.

```javascript
const zoneASpec = {
        name: 'A',
        onScheduleTask: (delegate, currentZone, targetZone, task): Task => {
           asyncLog('log here');
           return delegate.scheduleTask(targetZone, task);
        }
      };
```

such code may cause dead loop, because asyncLog will also trigger onScheduleTask 
in zoneA.

with orphanZone, the code may like this.
```javascript
  const zoneASpec = {
        name: 'A',
        onScheduleTask: (delegate, currentZone, targetZone, task): Task => {
           Zone.current.fork({name:'orphan', isOrphan: true}).run(() => {
              asyncLog('log here');
           });
           return delegate.scheduleTask(targetZone, task);
        }
      };
```
