### PR TITLE
fix #584, remove test target of Android 4.1,4.2,4.3

### DIFF
--- a/sauce.conf.js
+++ b/sauce.conf.js
@@ -76,24 +76,6 @@ module.exports = function (config) {
       platform: 'Windows 10',
       version: '13.10586'
     },
-    'SL_ANDROID4.1': {
-      base: 'SauceLabs',
-      browserName: 'android',
-      platform: 'Linux',
-      version: '4.1'
-    },
-    'SL_ANDROID4.2': {
-      base: 'SauceLabs',
-      browserName: 'android',
-      platform: 'Linux',
-      version: '4.2'
-    },
-    'SL_ANDROID4.3': {
-      base: 'SauceLabs',
-      browserName: 'android',
-      platform: 'Linux',
-      version: '4.3'
-    },
     'SL_ANDROID4.4': {
       base: 'SauceLabs',
       browserName: 'android',


### PR DESCRIPTION
based on issue #584, we should remove the Android 4.1~4.3 from sauceslab config. because saucelabs will not support those old platforms any longer.