### PR TITLE
fix #584, remove android 4.1~4.3, add no-ssl options to make android 4.4 pass test

### DIFF
--- a/sauce.conf.js
+++ b/sauce.conf.js
@@ -76,7 +76,9 @@ module.exports = function (config) {
       platform: 'Windows 10',
       version: '13.10586'
     },
-    /*'SL_ANDROID4.1': {
+    /*
+     fix issue #584, Android 4.1~4.3 are not supported
+    'SL_ANDROID4.1': {
       base: 'SauceLabs',
       browserName: 'android',
       platform: 'Linux',
@@ -93,13 +95,13 @@ module.exports = function (config) {
       browserName: 'android',
       platform: 'Linux',
       version: '4.3'
-    },
+    },*/
     'SL_ANDROID4.4': {
       base: 'SauceLabs',
       browserName: 'android',
       platform: 'Linux',
       version: '4.4'
-    },*/
+    },
     'SL_ANDROID5.1': {
       base: 'SauceLabs',
       browserName: 'android',

--- a/sauce.conf.js
+++ b/sauce.conf.js
@@ -76,7 +76,7 @@ module.exports = function (config) {
       platform: 'Windows 10',
       version: '13.10586'
     },
-    'SL_ANDROID4.1': {
+    /*'SL_ANDROID4.1': {
       base: 'SauceLabs',
       browserName: 'android',
       platform: 'Linux',
@@ -99,7 +99,7 @@ module.exports = function (config) {
       browserName: 'android',
       platform: 'Linux',
       version: '4.4'
-    },
+    },*/
     'SL_ANDROID5.1': {
       base: 'SauceLabs',
       browserName: 'android',

--- a/scripts/sauce/sauce_connect_setup.sh
+++ b/scripts/sauce/sauce_connect_setup.sh
@@ -46,4 +46,4 @@ echo "  $CONNECT_LOG"
 echo "  $CONNECT_STDOUT"
 echo "  $CONNECT_STDERR"
 sauce-connect/bin/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY $ARGS \
-  --reconnect 100 --logfile $CONNECT_LOG 2> $CONNECT_STDERR 1> $CONNECT_STDOUT &
+  --reconnect 100 --no-ssl-bump-domains all --logfile $CONNECT_LOG 2> $CONNECT_STDERR 1> $CONNECT_STDOUT &


### PR DESCRIPTION
fix #584, 

- because saucelabs announced that Android 4.0~4.3 will be [EOL](https://wiki.saucelabs.com/pages/viewpage.action?pageId=67012495
) so I remove those version from sauce lab test target.
- When test android 4.4 in sauce lab, there will be security waring pop up and let the test timeout, so we need to add --no-ssl-bump-domains options.