### PR TITLE
update README.md to add conflict explaination with other libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ Implements _Zones_ for JavaScript, inspired by [Dart](https://www.dartlang.org/a
 
 > If you're using zone.js via unpkg please provide a query param `?main=browser`  
 `https://unpkg.com/zone.js?main=browser`  
-> If you're using `newrelic` make sure you import `newrelic` first as it patches global.Promise before zone,js does
+> If you're using the following library, make sure you import them first 
+> 1. 'newrelic' as it patches global.Promise before zone,js does
+> 2. 'async-listener' as it patches global.setTimeout, global.setInterval before zone,js does
+> 3. 'continuation-local-storage' as it uses async-listener 
 
 # NEW Zone.js POST-v0.6.0
 


### PR DESCRIPTION
Because zone.js patch global.promise, global.setTimeout and other API, so zone.js may conflict with other libs that also patch those API, in current README.md, we have warning about newrelic, we should also add async-listener, continuation-local-storage.