### PR TITLE
fix #593, only call removeAttribute when have the method

### DIFF
--- a/lib/browser/property-descriptor.ts
+++ b/lib/browser/property-descriptor.ts
@@ -56,6 +56,8 @@ function canPatchViaPropertyDescriptor() {
     if (desc && !desc.configurable) return false;
   }
 
+  const xhrDesc = Object.getOwnPropertyDescriptor(XMLHttpRequest.prototype, 'onreadystatechange');
+
   // add enumerable and configurable here because in opera
   // by default XMLHttpRequest.prototype.onreadystatechange is undefined
   // without adding enumerable and configurable will cause onreadystatechange
@@ -69,7 +71,8 @@ function canPatchViaPropertyDescriptor() {
   });
   const req = new XMLHttpRequest();
   const result = !!req.onreadystatechange;
-  Object.defineProperty(XMLHttpRequest.prototype, 'onreadystatechange', {});
+  // restore original desc
+  Object.defineProperty(XMLHttpRequest.prototype, 'onreadystatechange', xhrDesc || {});
   return result;
 };
 

--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -101,14 +101,15 @@ export function patchProperty(obj, prop) {
     // because the onclick function is internal raw uncompiled handler
     // the onclick will be evaluated when first time event was triggered or
     // the property is accessed, https://github.com/angular/zone.js/issues/525
-    // so we should use original native get to retrive the handler
+    // so we should use original native get to retrieve the handler
     if (r === null) {
-      let oriDesc = Object.getOwnPropertyDescriptor(obj, 'original' + prop);
-      if (oriDesc && oriDesc.get) {
-        r = oriDesc.get.apply(this, arguments);
+      if (originalDesc && originalDesc.get) {
+        r = originalDesc.get.apply(this, arguments);
         if (r) {
           desc.set.apply(this, [r]);
-          this.removeAttribute(prop);
+          if (typeof this['removeAttribute'] === 'function') {
+            this.removeAttribute(prop);
+          }
         }
       }
     }

--- a/test/browser/XMLHttpRequest.spec.ts
+++ b/test/browser/XMLHttpRequest.spec.ts
@@ -209,4 +209,15 @@ describe('XMLHttpRequest', function() {
          });
        });
      });
+
+  it('should not throw error when get XMLHttpRequest.prototype.onreadystatechange the first time',
+     function() {
+       const func = function() {
+         testZone.run(function() {
+           const req = new XMLHttpRequest();
+           req.onreadystatechange;
+         });
+       };
+       expect(func).not.toThrow();
+     });
 });


### PR DESCRIPTION
Fix #593, the issue can be described as following case.

```javascript
  var xhr = new XMLHttpRequest();
  console.log('property', xhr.onreadystatechange);
```

When first time try to get xhr.onreadystatechange, it will access patched getter, and because 
canPatchPropertyDescriptor change the getter which always return true, so the logic will go to 
this.removeAttribute part which is not correct (this.removeAttribute is only for DOMElement).