### PR TITLE
fix #595,#427, refactor Error construct process

### DIFF
--- a/test/common/Error.spec.ts
+++ b/test/common/Error.spec.ts
@@ -67,6 +67,46 @@ describe('ZoneAwareError', () => {
     }
   });
 
+  it('should not use child Error class get/set in ZoneAwareError constructor', () => {
+    // simulate @angular/facade/src/error.ts
+    class BaseError extends Error {
+      /** @internal **/
+      _nativeError: Error;
+
+      constructor(message: string) {
+        super(message);
+        const nativeError = new Error(message) as any as Error;
+        this._nativeError = nativeError;
+      }
+
+      get message() {
+        return this._nativeError.message;
+      }
+      set message(message) {
+        this._nativeError.message = message;
+      }
+      get name() {
+        return this._nativeError.name;
+      }
+      get stack() {
+        return (this._nativeError as any).stack;
+      }
+      set stack(value) {
+        (this._nativeError as any).stack = value;
+      }
+      toString() {
+        return this._nativeError.toString();
+      }
+    }
+
+    const func = () => {
+      const error = new BaseError('test');
+      expect(error.message).toEqual('test');
+    };
+
+    expect(func).not.toThrow();
+  });
+
   it('should show zone names in stack frames and remove extra frames', () => {
     const rootZone = getRootZone();
     const innerZone = rootZone.fork({name: 'InnerZone'});


### PR DESCRIPTION
fix #595,#427.
In previous PR to fix #546, we copy every property from NativeError to this (ZoneAwareError), 
and such logic will break angular2 BaseError.

```javascript
  class BaseError extends Error {
      /** @internal **/
      _nativeError: Error;

      constructor(message: string) {
        super(message);
        const nativeError = new Error(message) as any as Error;
        this._nativeError = nativeError;
      }

      get message() {
        return this._nativeError.message;
      }
      set message(message) {
        this._nativeError.message = message;
      }
      get name() {
        return this._nativeError.name;
      }
      get stack() {
        return (this._nativeError as any).stack;
      }
      set stack(value) {
        (this._nativeError as any).stack = value;
      }
      toString() {
        return this._nativeError.toString();
      }
}
```

because BaseError's constructor will call super , and super will call copy, copy will then call 
BaseError's setter, but this._nativeError is still undefined, so it will cause Exception.

In this PR, instead of copy, I create propertyDescriptor to delegate to native error, just like angular2 did. 

And because ZoneAwareError already handle Error `this` constructor issue, maybe in the future, angular2 BaseError don't need to handle such issue again.
https://github.com/angular/angular/issues/13908
