### PR TITLE
add runOutsideOfCurrentZone method in ZoneType

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -257,6 +257,11 @@ interface ZoneType {
    * Verify that Zone has been correctly patched. Specifically that Promise is zone aware.
    */
   assertZonePatched();
+
+  /**
+   * @returns {Zone} Returns the root [Zone].
+   */
+  rootZone: Zone;
 }
 
 /**
@@ -564,6 +569,13 @@ const Zone: ZoneType = (function(global: any) {
       }
     }
 
+    static get rootZone(): AmbientZone {
+      let zone = Zone.current;
+      while (zone.parent) {
+        zone = zone.parent;
+      }
+      return zone;
+    }
 
     static get current(): AmbientZone {
       return _currentZoneFrame.zone;

--- a/test/common/zone.spec.ts
+++ b/test/common/zone.spec.ts
@@ -83,6 +83,14 @@ describe('Zone', function() {
     });
   });
 
+  describe('rootZone', function() {
+    it('should be able to get rootZone', function() {
+      Zone.current.fork({name: 'testZone'}).run(function() {
+        const rootZone = Zone.rootZone;
+        expect(rootZone.name).toEqual('<root>');
+      });
+    });
+  });
 
   describe('get', function() {
     it('should store properties', function() {


### PR DESCRIPTION
add runOutsideOfCurrentZone method just like runOutsideAngular so we can run under rootZone or fork a new zone under rootZone.

```javascript
Zone.current.fork({name: 'testZone'}).run(function() {
        Zone.runOutsideOfCurrentZone(() => {
          expect(Zone.current.name).toEqual('<root>');
        });
      });
```