### PR TITLE
add Zone.root to get root zone directly 

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -257,6 +257,11 @@ interface ZoneType {
    * Verify that Zone has been correctly patched. Specifically that Promise is zone aware.
    */
   assertZonePatched();
+
+  /**
+   *  Return the root zone.
+   */
+  root: Zone;
 }
 
 /**
@@ -564,6 +569,13 @@ const Zone: ZoneType = (function(global: any) {
       }
     }
 
+    static get root(): AmbientZone {
+      let zone = Zone.current;
+      while (zone.parent) {
+        zone = zone.parent;
+      }
+      return zone;
+    }
 
     static get current(): AmbientZone {
       return _currentZoneFrame.zone;

--- a/test/common/zone.spec.ts
+++ b/test/common/zone.spec.ts
@@ -83,6 +83,30 @@ describe('Zone', function() {
     });
   });
 
+  describe('run out side of current zone', function() {
+    it('should be able to get root zone', function() {
+      Zone.current.fork({name: 'testZone'}).run(function() {
+        expect(Zone.root.name).toEqual('<root>');
+      });
+    });
+
+    it('should be able to get run under rootZone', function() {
+      Zone.current.fork({name: 'testZone'}).run(function() {
+        Zone.root.run(() => {
+          expect(Zone.current.name).toEqual('<root>');
+        });
+      });
+    });
+
+    it('should be able to get run outside of current zone', function() {
+      Zone.current.fork({name: 'testZone'}).run(function() {
+        Zone.root.fork({name: 'newTestZone'}).run(() => {
+          expect(Zone.current.name).toEqual('newTestZone');
+          expect(Zone.current.parent.name).toEqual('<root>');
+        });
+      });
+    });
+  });
 
   describe('get', function() {
     it('should store properties', function() {


### PR DESCRIPTION
add runOutsideOfCurrentZone method just like runOutsideAngular so we can run under rootZone or fork a new zone under rootZone.

```javascript
Zone.current.fork({name: 'testZone'}).run(function() {
        Zone.runOutsideOfCurrentZone(() => {
          expect(Zone.current.name).toEqual('<root>');
        });
      });
```

The motivation is to run some async code inside the zoneSpec's callback. Without the runOutsideOfCurrentZone method, such async call will cause infinite loop. 
for example:

```javascript
Zone.current.fork({
  name: 'testZone', 
  onScheduleTask: function(delegate, currentZone, targetZone, task) {
     asyncLog(task);
     return delegate.scheduleTask(targetZone, task);
  }
});
```

asyncLog will cause infinite loop, now we can 

```javascript
Zone.current.fork({
  name: 'testZone', 
  onScheduleTask: function(delegate, currentZone, targetZone, task) {
     Zone.runOutsideCurrentZone(() => {
        asyncLog(task);
    });
     return delegate.scheduleTask(targetZone, task);
  }
});
```