### PR TITLE
fix #604, sometimes setInterval test spec will fail on Android 4.4

### DIFF
--- a/test/common/setInterval.spec.ts
+++ b/test/common/setInterval.spec.ts
@@ -16,17 +16,25 @@ describe('setInterval', function() {
     const testZone = Zone.current.fork(Zone['wtfZoneSpec']).fork({name: 'TestZone'});
     testZone.run(() => {
       let id;
+      let intervalCount = 0;
       const intervalFn = function() {
+        intervalCount++;
         expect(Zone.current.name).toEqual(('TestZone'));
         global[zoneSymbol('setTimeout')](function() {
+          const intervalUnitLog = [
+            '> Zone:invokeTask:setInterval("<root>::ProxyZone::WTF::TestZone")',
+            '< Zone:invokeTask:setInterval'
+          ];
+          let intervalLog = [];
+          for (let i = 0; i < intervalCount; i++) {
+            intervalLog = intervalLog.concat(intervalUnitLog);
+          }
           expect(wtfMock.log).toEqual([
             '# Zone:fork("<root>::ProxyZone::WTF", "TestZone")',
             '> Zone:invoke:unit-test("<root>::ProxyZone::WTF::TestZone")',
             '# Zone:schedule:macroTask:setInterval("<root>::ProxyZone::WTF::TestZone", ' + id + ')',
-            '< Zone:invoke:unit-test',
-            '> Zone:invokeTask:setInterval("<root>::ProxyZone::WTF::TestZone")',
-            '< Zone:invokeTask:setInterval'
-          ]);
+            '< Zone:invoke:unit-test'
+          ].concat(intervalLog));
           clearInterval(cancelId);
           done();
         });


### PR DESCRIPTION
Fix #604, add a counter incase setInterval run more than once before setTimeout.