### PR TITLE
fix #607 to change catch variable name to error/err

### DIFF
--- a/lib/browser/define-property.ts
+++ b/lib/browser/define-property.ts
@@ -79,7 +79,7 @@ function rewriteDescriptor(obj, prop, desc) {
 function _tryDefineProperty(obj, prop, desc, originalConfigurableFlag) {
   try {
     return _defineProperty(obj, prop, desc);
-  } catch (e) {
+  } catch (error) {
     if (desc.configurable) {
       // In case of errors, when the configurable flag was likely set by rewriteDescriptor(), let's
       // retry with the original flag value
@@ -90,18 +90,18 @@ function _tryDefineProperty(obj, prop, desc, originalConfigurableFlag) {
       }
       try {
         return _defineProperty(obj, prop, desc);
-      } catch (e) {
+      } catch (error) {
         let descJson: string = null;
         try {
           descJson = JSON.stringify(desc);
-        } catch (e) {
+        } catch (error) {
           descJson = descJson.toString();
         }
         console.log(`Attempting to configure '${prop}' with descriptor '${descJson
-                    }' on object '${obj}' and got error, giving up: ${e}`);
+                    }' on object '${obj}' and got error, giving up: ${error}`);
       }
     } else {
-      throw e;
+      throw error;
     }
   }
 }

--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -277,7 +277,7 @@ export function makeZoneAwareAddListener(
       // accessing the handler object here will cause an exception to be thrown which
       // will fail tests prematurely.
       validZoneHandler = data.handler && data.handler.toString() === '[object FunctionWrapper]';
-    } catch (e) {
+    } catch (error) {
       // Returning nothing here is fine, because objects in a cross-site context are unusable
       return;
     }
@@ -454,7 +454,7 @@ export function patchClass(className) {
 export function createNamedFn(name: string, delegate: (self: any, args: any[]) => any): Function {
   try {
     return (Function('f', `return function ${name}(){return f(this, arguments)}`))(delegate);
-  } catch (e) {
+  } catch (error) {
     // if we fail, we must be CSP, just return delegate.
     return function() {
       return delegate(this, <any>arguments);

--- a/lib/zone-spec/long-stack-trace.ts
+++ b/lib/zone-spec/long-stack-trace.ts
@@ -23,8 +23,8 @@ function getStacktraceWithUncaughtError(): Error {
 function getStacktraceWithCaughtError(): Error {
   try {
     throw getStacktraceWithUncaughtError();
-  } catch (e) {
-    return e;
+  } catch (error) {
+    return error;
   }
 }
 
@@ -107,7 +107,7 @@ Zone['longStackTraceZoneSpec'] = <ZoneSpec>{
           Object.defineProperty(error, 'stack', descriptor);
           stackSetSucceeded = true;
         }
-      } catch (e) {
+      } catch (err) {
       }
       const longStack: string = stackSetSucceeded ?
           null :
@@ -115,13 +115,13 @@ Zone['longStackTraceZoneSpec'] = <ZoneSpec>{
       if (!stackSetSucceeded) {
         try {
           stackSetSucceeded = error.stack = longStack;
-        } catch (e) {
+        } catch (err) {
         }
       }
       if (!stackSetSucceeded) {
         try {
           stackSetSucceeded = (error as any).longStack = longStack;
-        } catch (e) {
+        } catch (err) {
         }
       }
     }

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1050,8 +1050,8 @@ const Zone: ZoneType = (function(global: any) {
           const task = queue[i];
           try {
             task.zone.runTask(task, null, null);
-          } catch (e) {
-            consoleError(e);
+          } catch (error) {
+            consoleError(error);
           }
         }
       }
@@ -1062,8 +1062,8 @@ const Zone: ZoneType = (function(global: any) {
             uncaughtPromiseError.zone.runGuarded(() => {
               throw uncaughtPromiseError;
             });
-          } catch (e) {
-            consoleError(e);
+          } catch (error) {
+            consoleError(error);
           }
         }
       }
@@ -1122,8 +1122,8 @@ const Zone: ZoneType = (function(global: any) {
             throw new Error(
                 'Uncaught (in promise): ' + value +
                 (value && value.stack ? '\n' + value.stack : ''));
-          } catch (e) {
-            const error: UncaughtPromiseError = e;
+          } catch (err) {
+            const error: UncaughtPromiseError = err;
             error.rejection = value;
             error.promise = promise;
             error.zone = Zone.current;
@@ -1240,8 +1240,8 @@ const Zone: ZoneType = (function(global: any) {
       promise[symbolValue] = [];  // queue;
       try {
         executor && executor(makeResolver(promise, RESOLVED), makeResolver(promise, REJECTED));
-      } catch (e) {
-        resolvePromise(promise, false, e);
+      } catch (error) {
+        resolvePromise(promise, false, error);
       }
     }
 
@@ -1291,7 +1291,7 @@ const Zone: ZoneType = (function(global: any) {
       try {
         // In MS Edge this throws
         fetchPromise = global['fetch']();
-      } catch (e) {
+      } catch (error) {
         // In Chrome this throws instead.
         fetchPromise = global['fetch']('about:blank');
       }


### PR DESCRIPTION
fix #607, sometimes uglifyjs will generate wrong code when our code like this.

```javascript
try {
  doSomething();
} catch(e) {
  errorHandling();
}
```

after uglifyjs, sometimes the code may become

```javascript
try {
  doSomething();
} catch(e) {
  e();
}
```

although use screwie8 option can resolve such issue, but to use another variable name other than 'e' is much safe.  