### PR TITLE
fix test spec setInterval in android 4.4

### DIFF
--- a/test/common/setInterval.spec.ts
+++ b/test/common/setInterval.spec.ts
@@ -17,9 +17,14 @@ describe('setInterval', function() {
     testZone.run(() => {
       let id;
       let intervalCount = 0;
+      let timeoutRunning = false;
       const intervalFn = function() {
         intervalCount++;
         expect(Zone.current.name).toEqual(('TestZone'));
+        if (timeoutRunning) {
+          return;
+        }
+        timeoutRunning = true;
         global[zoneSymbol('setTimeout')](function() {
           const intervalUnitLog = [
             '> Zone:invokeTask:setInterval("<root>::ProxyZone::WTF::TestZone")',


### PR DESCRIPTION
setInterval will still fail sometimes in Android 4.4.
current spec is .

```javascript
let cancelId = setInterval(() => {
   setTimeout(() => {
    expect();
    cancelInterval(cancelId);
   });
}, 10);
```

Sometimes the interval will run twice before setTimeout, so two setTimeout will begin, and the expect in the second setTimeout will fail.

So in this PR, add a flag to make sure only one setTimeout run