### PR TITLE
ignore consoleError when run promise a+ test to avoid annoying error …

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1029,6 +1029,11 @@ const Zone: ZoneType = (function(global: any) {
   }
 
   function consoleError(e: any) {
+    const zoneConsoleError = Zone[__symbol__('consoleError')];
+    if (zoneConsoleError && typeof zoneConsoleError === 'function') {
+      zoneConsoleError(e);
+      return;
+    }
     const rejection = e && e.rejection;
     if (rejection) {
       console.error(

--- a/promise-adapter.js
+++ b/promise-adapter.js
@@ -1,4 +1,7 @@
 require('./dist/zone-node.js');
+Zone['__zone_symbol__consoleError'] = function(error) {
+  // ignore unchaught error output.
+}
 
 module.exports.deferred = function() {
   const p = {};


### PR DESCRIPTION
when run promise a+ test, don't output console.error for uncaught promise errors.