### PR TITLE
feat(promise), fix #621, add unhandledRejection handler and ignore consoleError

### DIFF
--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -527,6 +527,7 @@ export interface MicroTaskMeta extends TaskData {
   callbackIndex: number;
   args: any[];
 }
+
 export function patchMicroTask(
     obj: any, funcName: string, metaCreator: (self: any, args: any[]) => MicroTaskMeta) {
   let setNative = null;
@@ -551,4 +552,19 @@ export function patchMicroTask(
       return delegate.apply(self, args);
     }
   });
+}
+
+export function findEventTask(target: any, evtName: string) {
+  const eventTasks: Task[] = target[zoneSymbol('eventTasks')];
+  if (eventTasks) {
+    for (let i = 0; i < eventTasks.length; i++) {
+      const eventTask = eventTasks[i];
+      const data = eventTask.data;
+      const eventName = data && (<any>data).eventName;
+      if (eventName === evtName) {
+        return eventTask;
+      }
+    }
+  }
+  return undefined;
 }

--- a/lib/node/node.ts
+++ b/lib/node/node.ts
@@ -11,7 +11,7 @@ import './events';
 import './fs';
 
 import {patchTimer} from '../common/timers';
-import {patchMacroTask, patchMethod, patchMicroTask} from '../common/utils';
+import {findEventTask, patchMacroTask, patchMicroTask, zoneSymbol} from '../common/utils';
 
 const set = 'set';
 const clear = 'clear';
@@ -33,6 +33,7 @@ if (shouldPatchGlobalTimers) {
 
 // patch process related methods
 patchProcess();
+handleUnhandledPromiseRejection();
 
 // Crypto
 let crypto;
@@ -67,4 +68,28 @@ function patchProcess() {
       target: process
     };
   });
+}
+
+// handle unhandled promise rejection
+function findProcessPromiseRejectionHandler(evtName: string) {
+  return function(e: any) {
+    const eventTask = findEventTask(process, evtName);
+    if (eventTask) {
+      // process has added unhandledrejection event listener
+      // trigger the event listener
+      if (evtName === 'unhandledRejection') {
+        eventTask.invoke(e.rejection, e.promise);
+      } else if (evtName === 'rejectionHandled') {
+        eventTask.invoke(e.promise);
+      }
+    }
+  };
+}
+
+function handleUnhandledPromiseRejection() {
+  Zone[zoneSymbol('unhandledPromiseRejectionHandler')] =
+      findProcessPromiseRejectionHandler('unhandledRejection');
+
+  Zone[zoneSymbol('rejectionHandledHandler')] =
+      findProcessPromiseRejectionHandler('rejectionHandled');
 }

--- a/promise-adapter.js
+++ b/promise-adapter.js
@@ -1,5 +1,5 @@
 require('./dist/zone-node.js');
-
+Zone[('__zone_symbol__ignoreConsoleErrorUncaughtError')] = true;
 module.exports.deferred = function() {
   const p = {};
   p.promise = new Promise((resolve, reject) => {


### PR DESCRIPTION
1. add a flag to ignore consleError when uncaught promise error occurs, just like #614.
2. trigger unhandledrejection and rejectionhandled event handler in browser and nodejs env.
fix #621.

the spec can be found here.

- browser, https://developer.mozilla.org/en-US/docs/Web/Events/unhandledrejection

```javascript
 window.addEventListener("unhandledrejection", function (event) {
  console.warn("WARNING: Unhandled promise rejection. Shame on you! Reason: "
               + event.reason);
});

window.addEventListener("rejectionhandled", function (event) {
  console.log("Promise rejected! Reason: " + reason);
});
```

- nodejs, https://nodejs.org/api/process.html#process_event_rejectionhandled

```javascript
process.on('unhandledRejection', (reason, p) => {
  console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
  // application specific logging, throwing an error, or other logic here
});

process.on('rejectionHandled', (p) => {
});
```