### PR TITLE
feat(longStackTraceSpec): handled promise rejection can also render longstacktrace

### DIFF
--- a/lib/zone-spec/long-stack-trace.ts
+++ b/lib/zone-spec/long-stack-trace.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {zoneSymbol} from '../common/utils';
+
 const NEWLINE = '\n';
 const SEP = '  -------------  ';
 const IGNORE_FRAMES = [];
@@ -73,6 +75,18 @@ function renderLongStackTrace(frames: LongStackTrace[], stack: string): string {
 Zone['longStackTraceZoneSpec'] = <ZoneSpec>{
   name: 'long-stack-trace',
   longStackTraceLimit: 10,  // Max number of task to keep the stack trace for.
+
+  getLongStackTrace: function(error: Error): string {
+    if (!error) {
+      return undefined;
+    }
+    const task = error[zoneSymbol('currentTask')];
+    const trace = task && task.data && task.data[creationTrace];
+    if (!trace) {
+      return error.stack;
+    }
+    return renderLongStackTrace(trace, error.stack);
+  },
 
   onScheduleTask: function(
       parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, task: Task): any {

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1169,6 +1169,12 @@ const Zone: ZoneType = (function(global: any) {
         const queue = promise[symbolValue];
         promise[symbolValue] = value;
 
+        // record task information in value when error occurs, so we can
+        // do some additional work such as render longStackTrace
+        if (state === REJECTED && value) {
+          value[__symbol__('currentTask')] = Zone.currentTask;
+        }
+
         for (let i = 0; i < queue.length;) {
           scheduleResolveOrReject(promise, queue[i++], queue[i++], queue[i++], queue[i++]);
         }


### PR DESCRIPTION
zone.js have longStackTraceSpec, it is very powerful, but it can't render handled promise rejection.

```javascript
const longStackTraceZoneSpec = Zone['longStackTraceZoneSpec'];

Zone.current.fork(longStackTraceZoneSpec).run(() => {
  Promise p = new Promise((resolve, reject) => {
    setTimeout(() => {
      reject(new Error('Promise error'));
    }, 10);
  });

  p.catch(error => console.log(error.stack);}
});
```

In this case, the error p.catch got is not a longStackTrace, because it is a handled promise rejection so it will not call longStackTraceSpec's onHandleError callback.

in this PR, I add a helper method in LongStackTraceZoneSpec, so if user want to render longStackTrace in promise.then/catch, user can call the method.

```javascript
```javascript
const longStackTraceZoneSpec = Zone['longStackTraceZoneSpec'];

Zone.current.fork(longStackTraceZoneSpec).run(() => {
  Promise p = new Promise((resolve, reject) => {
    setTimeout(() => {
      reject(new Error('Promise error'));
    }, 10);
  });

  p.catch(error => console.log(longStackTraceZoneSpec.getLongStackTrace(error));}
});
```
```