### PR TITLE
feat(longStackTraceSpec): handled promise rejection can also render longstacktrace

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1332,6 +1332,12 @@ const Zone: ZoneType = (function(global: any) {
         const queue = promise[symbolValue];
         promise[symbolValue] = value;
 
+        // record task information in value when error occurs, so we can
+        // do some additional work such as render longStackTrace
+        if (state === REJECTED && value instanceof Error) {
+          value[__symbol__('currentTask')] = Zone.currentTask;
+        }
+
         for (let i = 0; i < queue.length;) {
           scheduleResolveOrReject(promise, queue[i++], queue[i++], queue[i++], queue[i++]);
         }

--- a/test/zone-spec/long-stack-trace-zone.spec.ts
+++ b/test/zone-spec/long-stack-trace-zone.spec.ts
@@ -12,9 +12,10 @@ const defineProperty = Object[zoneSymbol('defineProperty')] || Object.defineProp
 describe('longStackTraceZone', function() {
   let log: Error[];
   let lstz: Zone;
+  let longStackTraceZoneSpec = Zone['longStackTraceZoneSpec'];
 
   beforeEach(function() {
-    lstz = Zone.current.fork(Zone['longStackTraceZoneSpec']).fork({
+    lstz = Zone.current.fork(longStackTraceZoneSpec).fork({
       name: 'long-stack-trace-zone-test',
       onHandleError: (parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone,
                       error: any): boolean => {
@@ -67,7 +68,7 @@ describe('longStackTraceZone', function() {
     });
   });
 
-  it('should produce long stack traces when reject in promise', function(done) {
+  it('should produce long stack traces when has uncaught error in promise', function(done) {
     lstz.runGuarded(function() {
       setTimeout(function() {
         setTimeout(function() {
@@ -87,6 +88,26 @@ describe('longStackTraceZone', function() {
               expect(e).toBe(null);
             }
           }, 0);
+        }, 0);
+      }, 0);
+    });
+  });
+
+  it('should produce long stack traces when handling error in promise', function(done) {
+    lstz.runGuarded(function() {
+      setTimeout(function() {
+        setTimeout(function() {
+          let promise = new Promise(function(resolve, reject) {
+            setTimeout(function() {
+              reject(new Error('Hello Promise'));
+            }, 0);
+          });
+          promise.catch(function(error) {
+            // should be able to get long stack trace
+            const longStackFrames: string = longStackTraceZoneSpec.getLongStackTrace(error);
+            expect(longStackFrames.split('Elapsed: ').length).toBe(4);
+            done();
+          });
         }, 0);
       }, 0);
     });


### PR DESCRIPTION
1. fix typo in longstacktrace
2. zone.js have longStackTraceSpec, it is very powerful, but it can't render handled promise rejection.

```javascript
const longStackTraceZoneSpec = Zone['longStackTraceZoneSpec'];

Zone.current.fork(longStackTraceZoneSpec).run(() => {
  Promise p = new Promise((resolve, reject) => {
    setTimeout(() => {
      reject(new Error('Promise error'));
    }, 10);
  });

  p.catch(error => console.log(error.stack);}
});
```

In this case, the error p.catch got is not a longStackTrace, because it is a handled promise rejection so it will not call longStackTraceSpec's onHandleError callback.

in this PR, I add a helper method in LongStackTraceZoneSpec, so if user want to render longStackTrace in promise.then/catch, user can call the method.

```javascript
const longStackTraceZoneSpec = Zone['longStackTraceZoneSpec'];

Zone.current.fork(longStackTraceZoneSpec).run(() => {
  Promise p = new Promise((resolve, reject) => {
    setTimeout(() => {
      reject(new Error('Promise error'));
    }, 10);
  });

  p.catch(error => console.log(longStackTraceZoneSpec.getLongStackTrace(error));}
});
```

Here, user should call longStackTraceZoneSpec.getLongStackTrace(error) themselves, error.stack
is still the original stack. the reason that not set stack automatically here is because I don't want to break the logic of "handled promise rejection".