### PR TITLE
feat(error): remove zone internal stack frames in error.stack

### DIFF
--- a/test/node/fs.spec.ts
+++ b/test/node/fs.spec.ts
@@ -63,7 +63,7 @@ describe('nodejs file system', () => {
               done();
             });
           });
-          writeFile('testfile', 'test new content');
+          writeFile('testfile', 'test new content', () => {});
         });
       });
     });
@@ -83,7 +83,7 @@ describe('nodejs file system', () => {
               done();
             });
           });
-          writeFile('testfile', 'test new content');
+          writeFile('testfile', 'test new content', () => {});
         });
       });
     });


### PR DESCRIPTION
1.zone.js patches most basic APIs, so when we want to debug, we will see a lot of zone related stack traces, for example, in example/basic.html, the simple event listener stack trace will look like this.

```
Error: aw shucks
    at HTMLButtonElement.throwError (file:///Users/lijia/workspace/zone.js/example/basic.html:43:11) [long-stack-trace]
    at Zone.runTask (file:///Users/lijia/workspace/zone.js/dist/zone.js:162:47) [<root> => long-stack-trace]
    at HTMLButtonElement.ZoneTask.invoke (file:///Users/lijia/workspace/zone.js/dist/zone.js:356:33) [<root>]
  -------------   Elapsed: 2483 ms; At: Sun Feb 12 2017 16:18:19 GMT+0900 (JST)   -------------  
    at getStacktraceWithUncaughtError (file:///Users/lijia/workspace/zone.js/dist/long-stack-trace-zone.js:33:12) [long-stack-trace]
    at new LongStackTrace (file:///Users/lijia/workspace/zone.js/dist/long-stack-trace-zone.js:27:22) [long-stack-trace]
    at Object.onScheduleTask (file:///Users/lijia/workspace/zone.js/dist/long-stack-trace-zone.js:83:18) [long-stack-trace]
    at ZoneDelegate.scheduleTask (file:///Users/lijia/workspace/zone.js/dist/zone.js:263:49) [long-stack-trace]
    at Zone.scheduleEventTask (file:///Users/lijia/workspace/zone.js/dist/zone.js:182:39) [long-stack-trace]
    at zoneAwareAddListener (file:///Users/lijia/workspace/zone.js/dist/zone.js:1318:14) [long-stack-trace]
    at HTMLButtonElement.addEventListener (eval at createNamedFn (file:///Users/lijia/workspace/zone.js/dist/zone.js:1424:17), <anonymous>:3:43) [long-stack-trace]
    at HTMLButtonElement.bindSecondButton (file:///Users/lijia/workspace/zone.js/example/basic.html:38:8) [long-stack-trace]
    at Zone.runTask (file:///Users/lijia/workspace/zone.js/dist/zone.js:162:47) [<root> => long-stack-trace]
    at HTMLButtonElement.ZoneTask.invoke (file:///Users/lijia/workspace/zone.js/dist/zone.js:356:33) [<root>]
  -------------   Elapsed: 3122 ms; At: Sun Feb 12 2017 16:18:16 GMT+0900 (JST)   -------------  
    at getStacktraceWithUncaughtError (file:///Users/lijia/workspace/zone.js/dist/long-stack-trace-zone.js:33:12) [long-stack-trace]
    at new LongStackTrace (file:///Users/lijia/workspace/zone.js/dist/long-stack-trace-zone.js:27:22) [long-stack-trace]
    at Object.onScheduleTask (file:///Users/lijia/workspace/zone.js/dist/long-stack-trace-zone.js:83:18) [long-stack-trace]
    at ZoneDelegate.scheduleTask (file:///Users/lijia/workspace/zone.js/dist/zone.js:263:49) [long-stack-trace]
    at Zone.scheduleEventTask (file:///Users/lijia/workspace/zone.js/dist/zone.js:182:39) [long-stack-trace]
    at zoneAwareAddListener (file:///Users/lijia/workspace/zone.js/dist/zone.js:1318:14) [long-stack-trace]
    at HTMLButtonElement.addEventListener (eval at createNamedFn (file:///Users/lijia/workspace/zone.js/dist/zone.js:1424:17), <anonymous>:3:43) [long-stack-trace]
    at main (file:///Users/lijia/workspace/zone.js/example/basic.html:25:8) [long-stack-trace]
    at Zone.run (file:///Users/lijia/workspace/zone.js/dist/zone.js:124:43) [<root> => long-stack-trace]
    at file:///Users/lijia/workspace/zone.js/example/basic.html:57:39 [<root>]
```

It is a little difficult to find out which is the application's stack, so in this PR, we reduce the stack frames belong to zone internal.

```
Error: aw shucks
    at HTMLButtonElement.throwError (file:///Users/lijia/workspace/zone.js/example/basic.html:43:11)
  -------------   Elapsed: 2484 ms; At: Sun Feb 12 2017 16:18:19 GMT+0900 (JST)   -------------  
    at HTMLButtonElement.addEventListener (eval at createNamedFn (file:///Users/lijia/workspace/zone.js/dist/zone.js:1424:17), <anonymous>:3:43)
    at HTMLButtonElement.bindSecondButton (file:///Users/lijia/workspace/zone.js/example/basic.html:38:8)
  -------------   Elapsed: 3122 ms; At: Sun Feb 12 2017 16:18:16 GMT+0900 (JST)   -------------  
    at HTMLButtonElement.addEventListener (eval at createNamedFn (file:///Users/lijia/workspace/zone.js/dist/zone.js:1424:17), <anonymous>:3:43)
    at main (file:///Users/lijia/workspace/zone.js/example/basic.html:25:8)
    at file:///Users/lijia/workspace/zone.js/example/basic.html:57:39
```

Basically, only user's code will be left here. not all, but most.

to access the original stack, just call

```javascript
err.orignalStack
```

Another changes is in IE, error.stack will be undefined when constructed, and only have the stack 
when throw.
https://docs.microsoft.com/en-us/scripting/javascript/reference/stack-property-error-javascript

in this PR, the stack will be there when constructed.

2. fix typo in zone.js

3. fix test cases for fs.spec.ts to remove warning.
