### PR TITLE
fix(task): eventTask/Periodical task should not be reset after being cancelled when running

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -754,7 +754,11 @@ const Zone: ZoneType = (function(global: any) {
         }
       } finally {
         if (task.type == eventTask || (task.data && task.data.isPeriodic)) {
-          reEntryGuard && (task as ZoneTask)._transitionTo(scheduled, running, notScheduled);
+          // if the task's state is notScheduled, then it has already been cancelled
+          // we should not reset the state to scheduled
+          if (task.state !== notScheduled) {
+            reEntryGuard && (task as ZoneTask)._transitionTo(scheduled, running);
+          }
         } else {
           task.runCount = 0;
           this._updateTaskCount(task as ZoneTask, -1);

--- a/test/common/zone.spec.ts
+++ b/test/common/zone.spec.ts
@@ -299,6 +299,30 @@ describe('Zone', function() {
       ]);
     });
 
+    it('period task should not transit to scheduled state after being cancelled in running state',
+       () => {
+         const zone = Zone.current.fork({name: 'testZone'});
+
+         const task = zone.scheduleMacroTask('testPeriodTask', () => {
+           zone.cancelTask(task);
+         }, {isPeriodic: true}, () => {}, () => {});
+
+         task.invoke();
+         expect(task.state).toBe('notScheduled');
+       });
+
+    it('event task should not transit to scheduled state after being cancelled in running state',
+       () => {
+         const zone = Zone.current.fork({name: 'testZone'});
+
+         const task = zone.scheduleEventTask('testEventTask', () => {
+           zone.cancelTask(task);
+         }, null, () => {}, () => {});
+
+         task.invoke();
+         expect(task.state).toBe('notScheduled');
+       });
+
     describe('assert ZoneAwarePromise', () => {
       it('should not throw when all is OK', () => {
         Zone.assertZonePatched();


### PR DESCRIPTION
the issue can be described as the following cases.

```javascript
     const zone = Zone.current.fork({name: 'testZone'});

     const task = zone.scheduleMacroTask('testPeriodTask', () => {
       zone.cancelTask(task);
     }, {isPeriodic: true}, () => {}, () => {});

    task.invoke();
    expect(task.state).toBe('notScheduled');

    
     const task = zone.scheduleEventTask('testEventTask', () => {
       zone.cancelTask(task);
     }, null, () => {}, () => {});

    task.invoke();
    expect(task.state).toBe('notScheduled');
```

When task is cancelled in task's callback(running state), the runTask logic here https://github.com/angular/zone.js/blob/master/lib/zone.ts#L757 will reset the task's state to scheduled, so it will cause issues such as #638, updateTaskCount cause null error, because the task is cancelled but still in scheduled state.