### PR TITLE
fix(patch): fix #618, use zoneSymbol as property name to avoid name conflict

### DIFF
--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -74,7 +74,7 @@ export function patchProperty(obj, prop) {
 
   // substr(2) cuz 'onclick' -> 'click', etc
   const eventName = prop.substr(2);
-  const _prop = '_' + prop;
+  const _prop = zoneSymbol('_' + prop);
 
   desc.set = function(fn) {
     if (this[_prop]) {


### PR DESCRIPTION
in issue #618, sharepoint's code will create property on HTMLSpanElement like this

```javascript
                oParent['_onmouseover'] = oParent.onmouseover;
```

and in zone.js 
https://github.com/angular/zone.js/blob/master/lib/common/utils.ts#L77
the inner property name is also startsWith '_'

```javascript
  const _prop = '_' + prop; 
```

So this will cause a lot of problems. 
So we just use zoneSymbol to wrap the prop name.