### PR TITLE
fix(package): fix #649, use fixed version typescript and clang-format

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@types/jasmine": "^2.2.33",
+    "@types/jasmine": "2.2.33",
     "@types/node": "^6.0.38",
     "@types/systemjs": "^0.19.30",
-    "clang-format": "^1.0.46",
+    "clang-format": "1.0.46",
     "concurrently": "^2.2.0",
     "conventional-changelog": "^1.1.0",
     "es6-promise": "^3.0.2",
@@ -79,7 +79,7 @@
     "ts-loader": "^0.6.0",
     "tslint": "^4.1.1",
     "tslint-eslint-rules": "^3.1.0",
-    "typescript": "^2.0.2",
+    "typescript": "2.0.10",
     "vrsource-tslint-rules": "^4.0.0",
     "whatwg-fetch": "^2.0.1"
   }


### PR DESCRIPTION
fix #649, use fixed version of typescript and clang-format @types/jasmine for now.