### PR TITLE
fix(webapi): refactor webapi to not import util.ts directly

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -92,11 +92,19 @@ gulp.task('build/zone.min.js', ['compile-esm'], function(cb) {
 });
 
 gulp.task('build/webapis-media-query.js', ['compile-esm'], function(cb) {
-    return generateScript('./lib/browser/webapis-media-query.ts', 'webapis-media-query.js', true, cb);
+    return generateScript('./lib/browser/webapis-media-query.ts', 'webapis-media-query.js', false, cb);
+});
+
+gulp.task('build/webapis-media-query.min.js', ['compile-esm'], function(cb) {
+    return generateScript('./lib/browser/webapis-media-query.ts', 'webapis-media-query.min.js', true, cb);
 });
 
 gulp.task('build/webapis-notification.js', ['compile-esm'], function(cb) {
-    return generateScript('./lib/browser/webapis-notification.ts', 'webapis-notification.js', true, cb);
+    return generateScript('./lib/browser/webapis-notification.ts', 'webapis-notification.js', false, cb);
+});
+
+gulp.task('build/webapis-notification.min.js', ['compile-esm'], function(cb) {
+    return generateScript('./lib/browser/webapis-notification.ts', 'webapis-notification.min.js', true, cb);
 });
 
 gulp.task('build/bluebird.js', ['compile-esm'], function(cb) {
@@ -173,7 +181,9 @@ gulp.task('build', [
   'build/zone.min.js',
   'build/zone-node.js',
   'build/webapis-media-query.js',
+  'build/webapis-media-query.min.js',
   'build/webapis-notification.js',
+  'build/webapis-notification.min.js',
   'build/zone-mix.js',
   'build/bluebird.js',
   'build/bluebird.min.js',

--- a/lib/browser/webapis-media-query.ts
+++ b/lib/browser/webapis-media-query.ts
@@ -5,8 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {NestedEventListenerOrEventListenerObject, patchEventTargetMethods} from '../common/utils';
-
 ((_global: any) => {
   // patch MediaQuery
   patchMediaQuery(_global);
@@ -15,6 +13,7 @@ import {NestedEventListenerOrEventListenerObject, patchEventTargetMethods} from 
     if (!_global['MediaQueryList']) {
       return;
     }
+    const patchEventTargetMethods = Zone[Zone['__symbol__']('patchEventTargetMethods')];
     patchEventTargetMethods(
         _global['MediaQueryList'].prototype, 'addListener', 'removeListener', (self, args) => {
           return {
@@ -23,16 +22,14 @@ import {NestedEventListenerOrEventListenerObject, patchEventTargetMethods} from 
             handler: args[0],
             target: self || _global,
             name: 'mediaQuery',
-            invokeAddFunc: function(
-                addFnSymbol: any, delegate: Task|NestedEventListenerOrEventListenerObject) {
+            invokeAddFunc: function(addFnSymbol: any, delegate) {
               if (delegate && (<Task>delegate).invoke) {
                 return this.target[addFnSymbol]((<Task>delegate).invoke);
               } else {
                 return this.target[addFnSymbol](delegate);
               }
             },
-            invokeRemoveFunc: function(
-                removeFnSymbol: any, delegate: Task|NestedEventListenerOrEventListenerObject) {
+            invokeRemoveFunc: function(removeFnSymbol: any, delegate) {
               if (delegate && (<Task>delegate).invoke) {
                 return this.target[removeFnSymbol]((<Task>delegate).invoke);
               } else {

--- a/lib/browser/webapis-notification.ts
+++ b/lib/browser/webapis-notification.ts
@@ -5,8 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {patchOnProperties} from '../common/utils';
-
 ((_global: any) => {
   // patch Notification
   patchNotification(_global);
@@ -16,7 +14,11 @@ import {patchOnProperties} from '../common/utils';
     if (!Notification || !Notification.prototype) {
       return;
     }
-
+    const desc = Object.getOwnPropertyDescriptor(Notification.prototype, 'onerror');
+    if (!desc || !desc.configurable) {
+      return;
+    }
+    const patchOnProperties = Zone[Zone['__symbol__']('patchOnProperties')];
     patchOnProperties(Notification.prototype, null);
   }
 })(typeof window === 'object' && window || typeof self === 'object' && self || global);

--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -569,3 +569,15 @@ export function findEventTask(target: any, evtName: string): Task[] {
   }
   return result;
 }
+
+Zone[zoneSymbol('patchEventTargetMethods')] = patchEventTargetMethods;
+Zone[zoneSymbol('patchMicroTask')] = patchMicroTask;
+Zone[zoneSymbol('patchMacroTask')] = patchMacroTask;
+Zone[zoneSymbol('patchClass')] = patchClass;
+Zone[zoneSymbol('patchProperty')] = patchProperty;
+Zone[zoneSymbol('patchOnProperties')] = patchOnProperties;
+Zone[zoneSymbol('isNode')] = isNode;
+Zone[zoneSymbol('isBrowser')] = isBrowser;
+Zone[zoneSymbol('isMix')] = isMix;
+Zone[zoneSymbol('isWebWorker')] = isWebWorker;
+Zone[zoneSymbol('findEventTask')] = findEventTask;

--- a/test/browser/MediaQuery.spec.ts
+++ b/test/browser/MediaQuery.spec.ts
@@ -21,7 +21,7 @@ describe('test mediaQuery patch', ifEnvSupports(supportMediaQuery, () => {
            it('test whether addListener is patched', () => {
              const mqList = window.matchMedia('min-width:500px');
              if (mqList && mqList['addListener']) {
-               expect(mqList[zoneSymbol('addListener')]).not.toBe(undefined);
+               expect(mqList[zoneSymbol('addListener')]).toBeTruthy();
              }
            });
          }));

--- a/test/browser/Notification.spec.ts
+++ b/test/browser/Notification.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import '../../lib/browser/webapis-notification';
+
+import {zoneSymbol} from '../../lib/common/utils';
+import {ifEnvSupports} from '../test-util';
+
+function notificationSupport() {
+  const desc = window['Notification'] &&
+      Object.getOwnPropertyDescriptor(window['Notification'].prototype, 'onerror');
+  return window['Notification'] && window['Notification'].prototype && desc.configurable;
+}
+
+(<any>notificationSupport).message = 'Notification Support';
+
+describe('Notification API', ifEnvSupports(notificationSupport, function() {
+           it('Notification API should be patched by Zone', () => {
+             const Notification = window['Notification'];
+             expect(Notification.prototype[zoneSymbol('addEventListener')]).toBeTruthy();
+           });
+         }));

--- a/test/browser_entry_point.ts
+++ b/test/browser_entry_point.ts
@@ -20,5 +20,6 @@ import './browser/requestAnimationFrame.spec';
 import './browser/WebSocket.spec';
 import './browser/XMLHttpRequest.spec';
 import './browser/MediaQuery.spec';
+import './browser/Notification.spec';
 import './mocha-patch.spec';
 import './jasmine-patch.spec';


### PR DESCRIPTION
1. webapi mediaquery, notification should not import methods from util.ts because it will pull all util.ts content into webapi-media-query.js and webapis-notification.js under dist
2. export some zone util's method through Zone[symbol(methodName)]
3. add webapis dist/min.js