### PR TITLE
fix(xhr): fix #657, sometimes xhr will fire onreadystatechange with done twice

### DIFF
--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -73,7 +73,9 @@ function patchXHR(window: any) {
     }
     const newListener = data.target[XHR_LISTENER] = () => {
       if (data.target.readyState === data.target.DONE) {
-        if (!data.aborted && self[XHR_SCHEDULED]) {
+        // sometimes on some browsers XMLHttpRequest will fire onreadystatechange with
+        // readyState=4 multiple times, so we need to check task state here
+        if (!data.aborted && self[XHR_SCHEDULED] && task.state === 'scheduled') {
           task.invoke();
         }
       }


### PR DESCRIPTION
Fix #657.

The similar issue can be found here,https://bugs.chromium.org/p/chromium/issues/detail?id=159827

And some times the XMLHttpRequest will fire  onreadystatechange with readyState=4 multiple times.


```javascript
xhr.onreadystatechange = function() {
                    if (xhr.readyState === 4) {
                        if (xhr['ok']) {
                            console.log('error duplicate done');
                        }
                        xhr['ok'] = true;
                    }
                }
```

 this will cause ZoneTask to try to transit from notScheduled to running and cause error.
So I add a check to make sure ZoneTask is in scheduled state before running.