### PR TITLE
fix(error): fix #674, handle error.stack readonly case

### DIFF
--- a/test/common/Error.spec.ts
+++ b/test/common/Error.spec.ts
@@ -405,4 +405,24 @@ describe('Error stack', () => {
                         }, null, () => null, null);
        task.invoke();
      }));
+
+  it('should be able to generate zone free stack even NativeError stack is readonly', function() {
+    const _global: any =
+        typeof window === 'object' && window || typeof self === 'object' && self || global;
+    const NativeError = _global['__zone_symbol__Error'];
+    const desc = Object.getOwnPropertyDescriptor(NativeError.prototype, 'stack');
+    if (desc) {
+      const originalSet: (value: any) => void = desc.set;
+      // make stack readonly
+      desc.set = null;
+
+      try {
+        const error = new Error('test error');
+        expect(error.stack).toBeTruthy();
+        assertStackDoesNotContainZoneFrames(error);
+      } finally {
+        desc.set = originalSet;
+      }
+    }
+  });
 });


### PR DESCRIPTION
in phantomJS, the error.stack is readonly, so we need to catch such case and set the stack property directly to ZoneAwareError.

before 0.8.1, the case is OK because code here, https://github.com/angular/zone.js/blob/master/lib/zone.ts#L1955

and 

https://github.com/angular/zone.js/blob/master/lib/zone.ts#L1992

before 0.8.1 , the stackTraceLimit is 15, so in PhantomJS, ZoneAwareError can't finish finding all run/runGuarded/runTask, so stackRewrite is false, and ZoneAwareError will not try to override NativeError.stack.

and in 0.8.1, the stackTraceLimit increased to 100 in detect phase, so ZoneAwareError can find all run/runGuarded/runTask, so stackRewrite is true. 

In this PR, we just try/catch and write the zoneAware stack frames to ZoneAwareError directly