### PR TITLE
Patching node.js domain.bind to preserve Zone

### DIFF
--- a/lib/node/node.ts
+++ b/lib/node/node.ts
@@ -35,6 +35,8 @@ if (shouldPatchGlobalTimers) {
 patchProcess();
 handleUnhandledPromiseRejection();
 
+patchDomains();
+
 // Crypto
 let crypto: any;
 try {
@@ -92,4 +94,14 @@ function handleUnhandledPromiseRejection() {
 
   (Zone as any)[zoneSymbol('rejectionHandledHandler')] =
       findProcessPromiseRejectionHandler('rejectionHandled');
+}
+
+// Preserve Zones along with domains
+function patchDomains() {
+  if (process.domain && process.domain.bind) {
+    const originalBind = process.domain.bind;
+    process.domain.constructor.prototype.bind = function(cb: Function) {
+      return originalBind.call(this, Zone.current.wrap(cb, 'domain.bind'));
+    };
+  }
 }


### PR DESCRIPTION
A number of libraries (such as redis and mysql) include support for domains by invoking `domain.bind(callback)` at some point. With these changes, those libraries will now also preserve the current zone in their callbacks as well.