### PR TITLE
fix(event): fix #667, eventHandler should return result

### DIFF
--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -88,7 +88,10 @@ export function patchProperty(obj: any, prop: string) {
         let result;
         result = fn.apply(this, arguments);
 
-        if (result != undefined && !result) event.preventDefault();
+        if (result != undefined && !result) {
+          event.preventDefault();
+        }
+        return result;
       };
 
       this[_prop] = wrapFn;


### PR DESCRIPTION
fix #667,
now we wrap the onProperty such as onclick, onsubmit with wrapFn, but wrapFn did not return the returnValue from eventHandler, currently we call event.preventDefault if the original eventHandler return false, but sometimes, user may need the return value to process other logic.