### PR TITLE
fix(toString): fix #666, Zone patched method toString should like non patched

### DIFF
--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -7,6 +7,7 @@
  */
 
 import {patchTimer} from '../common/timers';
+import {patchFuncToString} from '../common/to-string';
 import {findEventTask, patchClass, patchEventTargetMethods, patchMethod, patchPrototype, zoneSymbol} from '../common/utils';
 
 import {propertyPatch} from './define-property';
@@ -150,6 +151,9 @@ function patchXHR(window: any) {
 if (_global['navigator'] && _global['navigator'].geolocation) {
   patchPrototype(_global['navigator'].geolocation, ['getCurrentPosition', 'watchPosition']);
 }
+
+// patch Func.prototype.toString to let them look like native
+patchFuncToString();
 
 // handle unhandled promise rejection
 function findPromiseRejectionHandler(evtName: string) {

--- a/lib/browser/register-element.ts
+++ b/lib/browser/register-element.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {isBrowser, isMix} from '../common/utils';
+import {attachOriginToPatched, isBrowser, isMix} from '../common/utils';
 
 import {_redefineProperty} from './define-property';
 
@@ -39,4 +39,6 @@ export function registerElementPatch(_global: any) {
 
     return _registerElement.apply(document, [name, opts]);
   };
+
+  attachOriginToPatched((<any>document).registerElement, _registerElement);
 }

--- a/lib/common/to-string.ts
+++ b/lib/common/to-string.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {zoneSymbol} from './utils';
+
+// override Function.prototype.toString to make zone.js patched function
+// look like native function
+export function patchFuncToString() {
+  const originalFunctionToString = Function.prototype.toString;
+  const g: any =
+      typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || global;
+  Function.prototype.toString = function() {
+    if (typeof this === 'function') {
+      if (this[zoneSymbol('OriginalDelegate')]) {
+        return originalFunctionToString.apply(this[zoneSymbol('OriginalDelegate')], arguments);
+      }
+      if (this === Promise) {
+        const nativePromise = g[zoneSymbol('Promise')];
+        if (nativePromise) {
+          return originalFunctionToString.apply(nativePromise, arguments);
+        }
+      }
+      if (this === Error) {
+        const nativeError = g[zoneSymbol('Error')];
+        if (nativeError) {
+          return originalFunctionToString.apply(nativeError, arguments);
+        }
+      }
+    }
+    return originalFunctionToString.apply(this, arguments);
+  };
+}

--- a/lib/node/node.ts
+++ b/lib/node/node.ts
@@ -11,6 +11,7 @@ import './events';
 import './fs';
 
 import {patchTimer} from '../common/timers';
+import {patchFuncToString} from '../common/to-string';
 import {findEventTask, patchMacroTask, patchMicroTask, zoneSymbol} from '../common/utils';
 
 const set = 'set';
@@ -34,6 +35,9 @@ if (shouldPatchGlobalTimers) {
 // patch process related methods
 patchProcess();
 handleUnhandledPromiseRejection();
+
+// patch Function.prototyp.toString
+patchFuncToString();
 
 // Crypto
 let crypto: any;

--- a/test/common/toString.spec.ts
+++ b/test/common/toString.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {zoneSymbol} from '../../lib/common/utils';
+import {ifEnvSupports} from '../test-util';
+
+const g: any =
+    typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || global;
+describe('global function patch', () => {
+  describe('isOriginal', () => {
+    it('setTimeout toString should be the same with non patched setTimeout', () => {
+      expect(Function.prototype.toString.call(setTimeout))
+          .toEqual(Function.prototype.toString.call(g[zoneSymbol('setTimeout')]));
+    });
+  });
+
+  describe('isNative', () => {
+    it('ZoneAwareError toString should look like native', () => {
+      expect(Function.prototype.toString.call(Error)).toContain('[native code]');
+    });
+
+    it('EventTarget addEventListener should look like native', ifEnvSupports('HTMLElement', () => {
+         expect(Function.prototype.toString.call(HTMLElement.prototype.addEventListener))
+             .toContain('[native code]');
+       }));
+  });
+});

--- a/test/common_tests.ts
+++ b/test/common_tests.ts
@@ -14,6 +14,7 @@ import './common/Promise.spec';
 import './common/Error.spec';
 import './common/setInterval.spec';
 import './common/setTimeout.spec';
+import './common/toString.spec';
 import './zone-spec/long-stack-trace-zone.spec';
 import './zone-spec/async-test.spec';
 import './zone-spec/sync-test.spec';


### PR DESCRIPTION
fix #666 
after zone.js patch, function toString will look like 

```
function addEventListener(){return f(this, arguments)}
```

or other patched function. 

in this PR, we use the before patched delegate to output toString.
so function toString will look like 

```
function() {[native code]}
```

and will pass lodash isNative test.