### PR TITLE
fix(typo): fix typo, remove extra semicolons, unify api doc

### DIFF
--- a/STANDARD-APIS.md
+++ b/STANDARD-APIS.md
@@ -73,15 +73,23 @@ on properties, such as onclick, onreadystatechange, the following on properties 
 be patched as EventTask, the following is the on properties zone.js patched  
 
  |||||||||
- |---|---|---|---|---|---|---|---|
- |copy|cut|paste|abort|blur|focus|canplay|canplaythrough|
- |change|click|contextmenu|dblclick|drag|dragend|dragenter|dragleave|
- |dragover|dragstart|drop|durationchange|emptied|ended|input|invalid|
- |keydown|keypress|keyup|load|loadeddata|loadedmetadata|loadstart|message|
- |mousedown|mouseenter|mouseleave|mousemove|mouseout|mouseover|mouseup|pause|
- |play|playing|progress|ratechange|reset|scroll|seeked|seeking|
- |select|show|stalled|submit|suspend|timeupdate|volumechange|waiting|
- |mozfullscreenchange|mozfullscreenerror|mozpointerlockchange|mozpointerlockerror|error|webglcontextrestored|webglcontextlost|webglcontextcreationerror|
+ |---|---|---|---|
+ |copy|cut|paste|abort|
+ |blur|focus|canplay|canplaythrough|
+ |change|click|contextmenu|dblclick|
+ |drag|dragend|dragenter|dragleave|
+ |dragover|dragstart|drop|durationchange|
+ |emptied|ended|input|invalid|
+ |keydown|keypress|keyup|load|
+ |loadeddata|loadedmetadata|loadstart|message|
+ |mousedown|mouseenter|mouseleave|mousemove|
+ |mouseout|mouseover|mouseup|pause|
+ |play|playing|progress|ratechange|
+ |reset|scroll|seeked|seeking|
+ |select|show|stalled|submit|
+ |suspend|timeupdate|volumechange|waiting|
+ |mozfullscreenchange|mozfullscreenerror|mozpointerlockchange|mozpointerlockerror|
+ |error|webglcontextrestored|webglcontextlost|webglcontextcreationerror|
 
 ## NodeJS
 

--- a/STANDARD-APIS.md
+++ b/STANDARD-APIS.md
@@ -70,9 +70,7 @@ inherit from EventTarget will also be patched.
  |IDBCursor|DBIndex|WebSocket|
 
 on properties, such as onclick, onreadystatechange, the following on properties will 
-be patched as EventTask 
-
-- all on properties
+be patched as EventTask, the following is the on properties zone.js patched  
 
  |||||||||
  |---|---|---|---|---|---|---|---|

--- a/lib/browser/define-property.ts
+++ b/lib/browser/define-property.ts
@@ -53,13 +53,13 @@ export function propertyPatch() {
     }
     return desc;
   };
-};
+}
 
 export function _redefineProperty(obj: any, prop: string, desc: any) {
   const originalConfigurableFlag = desc.configurable;
   desc = rewriteDescriptor(obj, prop, desc);
   return _tryDefineProperty(obj, prop, desc, originalConfigurableFlag);
-};
+}
 
 function isUnconfigurable(obj: any, prop: any) {
   return obj && obj[unconfigurablesKey] && obj[unconfigurablesKey][prop];

--- a/lib/browser/property-descriptor.ts
+++ b/lib/browser/property-descriptor.ts
@@ -79,7 +79,7 @@ function canPatchViaPropertyDescriptor() {
   // restore original desc
   Object.defineProperty(XMLHttpRequest.prototype, 'onreadystatechange', xhrDesc || {});
   return result;
-};
+}
 
 const unboundKey = zoneSymbol('unbound');
 
@@ -106,5 +106,5 @@ function patchViaCapturingAllTheEvents() {
         elt = elt.parentElement;
       }
     }, true);
-  };
-};
+  }
+}

--- a/lib/common/timers.ts
+++ b/lib/common/timers.ts
@@ -29,7 +29,7 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
       } finally {
         delete tasksByHandleId[data.handleId];
       }
-    };
+    }
     data.args[0] = timer;
     data.handleId = setNative.apply(window, data.args);
     tasksByHandleId[data.handleId] = task;

--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -128,7 +128,7 @@ export function patchProperty(obj: any, prop: string) {
   };
 
   Object.defineProperty(obj, prop, desc);
-};
+}
 
 export function patchOnProperties(obj: any, properties: string[]) {
   const onProperties = [];
@@ -145,7 +145,7 @@ export function patchOnProperties(obj: any, properties: string[]) {
       patchProperty(obj, 'on' + properties[i]);
     }
   }
-};
+}
 
 const EVENT_TASKS = zoneSymbol('eventTasks');
 
@@ -363,8 +363,6 @@ export function makeZoneAwareRemoveAllListeners(fnName: string, useCapturingPara
 }
 
 export function makeZoneAwareListeners(fnName: string) {
-  const symbol = zoneSymbol(fnName);
-
   return function zoneAwareEventListeners(self: any, args: any[]) {
     const eventName: string = args[0];
     const target = self || _global;
@@ -376,10 +374,6 @@ export function makeZoneAwareListeners(fnName: string) {
         .map((task: Task) => (task.data as any)['handler']);
   };
 }
-
-const zoneAwareAddEventListener =
-    makeZoneAwareAddListener(ADD_EVENT_LISTENER, REMOVE_EVENT_LISTENER);
-const zoneAwareRemoveEventListener = makeZoneAwareRemoveListener(REMOVE_EVENT_LISTENER);
 
 export function patchEventTargetMethods(
     obj: any, addFnName: string = ADD_EVENT_LISTENER, removeFnName: string = REMOVE_EVENT_LISTENER,
@@ -469,7 +463,7 @@ export function patchClass(className: string) {
       _global[className][prop] = OriginalClass[prop];
     }
   }
-};
+}
 
 export function createNamedFn(name: string, delegate: (self: any, args: any[]) => any): Function {
   try {

--- a/lib/extra/bluebird.ts
+++ b/lib/extra/bluebird.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-((_global: any) => {
+(() => {
   const __symbol__ = (Zone as any).__symbol__;
   // TODO: @JiaLiPassion, we can automatically patch bluebird
   // if global.Promise = Bluebird, but sometimes in nodejs,
@@ -17,4 +17,4 @@
       Zone.current.scheduleMicroTask('bluebird', fn);
     });
   };
-})(typeof window === 'object' && window || typeof self === 'object' && self || global);
+})();

--- a/lib/jasmine/jasmine.ts
+++ b/lib/jasmine/jasmine.ts
@@ -41,7 +41,7 @@
   // Example:
   //   - In beforeEach() do childZone = Zone.current.fork(...);
   //   - In it() try to do fakeAsync(). The issue is that because the beforeEach forked the
-  //     zone outside of fakeAsync it will be able to escope the fakeAsync rules.
+  //     zone outside of fakeAsync it will be able to escape the fakeAsync rules.
   //   - Because ProxyZone is parent fo `childZone` fakeAsync can retroactively add
   //     fakeAsync behavior to the childZone.
   let testProxyZone: Zone = null;

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -214,7 +214,7 @@ interface Zone {
   /**
    * Execute the Task by restoring the [Zone.currentTask] in the Task's zone.
    *
-   * @param callback
+   * @param task to run
    * @param applyThis
    * @param applyArgs
    * @returns {*}
@@ -310,12 +310,12 @@ interface ZoneType {
  */
 interface ZoneSpec {
   /**
-   * The name of the zone. Usefull when debugging Zones.
+   * The name of the zone. Useful when debugging Zones.
    */
   name: string;
 
   /**
-   * A set of properties to be associated with Zone. Use [Zone.get] to retrive them.
+   * A set of properties to be associated with Zone. Use [Zone.get] to retrieve them.
    */
   properties?: {[key: string]: any};
 
@@ -325,7 +325,7 @@ interface ZoneSpec {
    * When the zone is being forked, the request is forwarded to this method for interception.
    *
    * @param parentZoneDelegate Delegate which performs the parent [ZoneSpec] operation.
-   * @param currentZone The current [Zone] where the current interceptor has beed declared.
+   * @param currentZone The current [Zone] where the current interceptor has been declared.
    * @param targetZone The [Zone] which originally received the request.
    * @param zoneSpec The argument passed into the `fork` method.
    */
@@ -337,7 +337,7 @@ interface ZoneSpec {
    * Allows interception of the wrapping of the callback.
    *
    * @param parentZoneDelegate Delegate which performs the parent [ZoneSpec] operation.
-   * @param currentZone The current [Zone] where the current interceptor has beed declared.
+   * @param currentZone The current [Zone] where the current interceptor has been declared.
    * @param targetZone The [Zone] which originally received the request.
    * @param delegate The argument passed into the `warp` method.
    * @param source The argument passed into the `warp` method.
@@ -350,7 +350,7 @@ interface ZoneSpec {
    * Allows interception of the callback invocation.
    *
    * @param parentZoneDelegate Delegate which performs the parent [ZoneSpec] operation.
-   * @param currentZone The current [Zone] where the current interceptor has beed declared.
+   * @param currentZone The current [Zone] where the current interceptor has been declared.
    * @param targetZone The [Zone] which originally received the request.
    * @param delegate The argument passed into the `run` method.
    * @param applyThis The argument passed into the `run` method.
@@ -365,7 +365,7 @@ interface ZoneSpec {
    * Allows interception of the error handling.
    *
    * @param parentZoneDelegate Delegate which performs the parent [ZoneSpec] operation.
-   * @param currentZone The current [Zone] where the current interceptor has beed declared.
+   * @param currentZone The current [Zone] where the current interceptor has been declared.
    * @param targetZone The [Zone] which originally received the request.
    * @param error The argument passed into the `handleError` method.
    */
@@ -377,7 +377,7 @@ interface ZoneSpec {
    * Allows interception of task scheduling.
    *
    * @param parentZoneDelegate Delegate which performs the parent [ZoneSpec] operation.
-   * @param currentZone The current [Zone] where the current interceptor has beed declared.
+   * @param currentZone The current [Zone] where the current interceptor has been declared.
    * @param targetZone The [Zone] which originally received the request.
    * @param task The argument passed into the `scheduleTask` method.
    */
@@ -389,10 +389,10 @@ interface ZoneSpec {
        applyThis: any, applyArgs: any) => any;
 
   /**
-   * Allows interception of task cancelation.
+   * Allows interception of task cancellation.
    *
    * @param parentZoneDelegate Delegate which performs the parent [ZoneSpec] operation.
-   * @param currentZone The current [Zone] where the current interceptor has beed declared.
+   * @param currentZone The current [Zone] where the current interceptor has been declared.
    * @param targetZone The [Zone] which originally received the request.
    * @param task The argument passed into the `cancelTask` method.
    */
@@ -403,12 +403,13 @@ interface ZoneSpec {
    * Notifies of changes to the task queue empty status.
    *
    * @param parentZoneDelegate Delegate which performs the parent [ZoneSpec] operation.
-   * @param currentZone The current [Zone] where the current interceptor has beed declared.
+   * @param currentZone The current [Zone] where the current interceptor has been declared.
    * @param targetZone The [Zone] which originally received the request.
-   * @param isEmpty
+   * @param hasTaskState
    */
   onHasTask?:
-      (delegate: ZoneDelegate, current: Zone, target: Zone, hasTaskState: HasTaskState) => void;
+      (parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone,
+       hasTaskState: HasTaskState) => void;
 }
 
 
@@ -568,7 +569,7 @@ interface Task {
 
   /**
    * Cancel the scheduling request. This method can be called from `ZoneSpec.onScheduleTask` to
-   * cancel the current scheduling interception. Once canceled the task can be discarted or
+   * cancel the current scheduling interception. Once canceled the task can be discarded or
    * rescheduled using `Zone.scheduleTask` on a different zone.
    */
   cancelScheduleRequest(): void;
@@ -596,7 +597,7 @@ interface Error {
   zoneAwareStack?: string;
 
   /**
-   * Original stack trace with no modiffications
+   * Original stack trace with no modifications
    */
   originalStack?: string;
 }
@@ -1090,7 +1091,6 @@ const Zone: ZoneType = (function(global: any) {
           eventTask: counts.eventTask > 0,
           change: type
         };
-        // TODO(misko): what should happen if it throws?
         this.hasTask(this.zone, isEmpty);
       }
     }
@@ -1206,7 +1206,7 @@ const Zone: ZoneType = (function(global: any) {
 
   function __symbol__(name: string) {
     return '__zone_symbol__' + name;
-  };
+  }
   const symbolSetTimeout = __symbol__('setTimeout');
   const symbolPromise = __symbol__('Promise');
   const symbolThen = __symbol__('then');
@@ -1579,9 +1579,9 @@ const Zone: ZoneType = (function(global: any) {
       if (resultPromise instanceof ZoneAwarePromise) {
         return resultPromise;
       }
-      let Ctor = resultPromise.constructor;
-      if (!Ctor[symbolThenPatched]) {
-        patchThen(Ctor);
+      let ctor = resultPromise.constructor;
+      if (!ctor[symbolThenPatched]) {
+        patchThen(ctor);
       }
       return resultPromise;
     };
@@ -1596,7 +1596,7 @@ const Zone: ZoneType = (function(global: any) {
     }
   }
 
-  // This is not part of public API, but it is usefull for tests, so we expose it.
+  // This is not part of public API, but it is useful for tests, so we expose it.
   (Promise as any)[Zone.__symbol__('uncaughtPromiseErrors')] = _uncaughtPromiseErrors;
 
   /*
@@ -1775,7 +1775,7 @@ const Zone: ZoneType = (function(global: any) {
   });
 
   // Now we need to populate the `blacklistedStackFrames` as well as find the
-  // run/runGuraded/runTask frames. This is done by creating a detect zone and then threading
+  // run/runGuarded/runTask frames. This is done by creating a detect zone and then threading
   // the execution through all of the above methods so that we can look at the stack trace and
   // find the frames of interest.
   let detectZone: Zone = Zone.current.fork({

--- a/test/browser/WebSocket.spec.ts
+++ b/test/browser/WebSocket.spec.ts
@@ -11,8 +11,8 @@ declare const window: any;
 
 const TIMEOUT = 5000;
 
-if (!window['soucelabs']) {
-  // SouceLabs does not support WebSockets; skip these tests
+if (!window['saucelabs']) {
+  // sauceLabs does not support WebSockets; skip these tests
 
   describe('WebSocket', ifEnvSupports('WebSocket', function() {
              let socket: WebSocket;
@@ -76,7 +76,7 @@ if (!window['soucelabs']) {
                    expect(log).toEqual('a');
                    done();
                  }, 10);
-               };
+               }
 
                socket.addEventListener('message', logOnMessage);
                socket.send('hi');

--- a/test/browser/element.spec.ts
+++ b/test/browser/element.spec.ts
@@ -36,7 +36,7 @@ describe('element', function() {
        // `this` would be null inside the method when `addEventListener` is called from strict mode
        // it would be `window`:
        // - when called from non strict-mode,
-       // - when `window.addEventListener` is called explicitely.
+       // - when `window.addEventListener` is called explicitly.
        addEventListener('click', listener);
 
        button.dispatchEvent(clickEvent);
@@ -88,7 +88,7 @@ describe('element', function() {
      * 3. Pay the cost of throwing an exception in event tasks and verifying that we are the
      *    top most frame.
      *
-     * For now we are choosing to ignore it and assume that this arrises in tests only.
+     * For now we are choosing to ignore it and assume that this arises in tests only.
      * As an added measure we make sure that all jasmine tests always run in a task. See: jasmine.ts
      */
     (window as any)[(Zone as any).__symbol__('setTimeout')](() => {

--- a/test/saucelabs.js
+++ b/test/saucelabs.js
@@ -6,4 +6,4 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-window.soucelabs = true;
+window.saucelabs = true;

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -33,4 +33,4 @@ export function ifEnvSupports(test: any, block: Function) {
       });
     }
   };
-};
+}

--- a/test/zone-spec/long-stack-trace-zone.spec.ts
+++ b/test/zone-spec/long-stack-trace-zone.spec.ts
@@ -55,7 +55,7 @@ describe('longStackTraceZone', function() {
   });
 
   it('should produce a long stack trace even if stack setter throws', (done) => {
-    let wasStackAssigne = false;
+    let wasStackAssigned = false;
     let error = new Error('Expected error');
     defineProperty(error, 'stack', {
       configurable: false,

--- a/test/zone-spec/proxy.spec.ts
+++ b/test/zone-spec/proxy.spec.ts
@@ -76,9 +76,9 @@ describe('ProxySpec', () => {
     });
 
     it('should fork', () => {
-      const forkeZone = proxyZone.fork({name: 'fork'});
-      expect(forkeZone).not.toBe(proxyZone);
-      expect(forkeZone.name).toBe('fork');
+      const forkedZone = proxyZone.fork({name: 'fork'});
+      expect(forkedZone).not.toBe(proxyZone);
+      expect(forkedZone.name).toBe('fork');
       let called = false;
       proxyZoneSpec.setDelegate({
         name: '.',


### PR DESCRIPTION
1. Fix all typos in source files
2. Remove extra semicolons after function definitions.
3. Fix some api doc of Zone.