### PR TITLE
fix(listener): fix #616, webdriver removeEventListener throw permission denied error

### DIFF
--- a/test/webdriver/test.html
+++ b/test/webdriver/test.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src='../../dist/zone.js'></script>
+</head>
+<body>
+<div id="thetext">Hello Zones!</div>
+</body>
+</html>

--- a/test/webdriver/test.js
+++ b/test/webdriver/test.js
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// TODO: @JiaLiPassion, try to add it into travis/saucelabs test after saucelabs support Firefox 52+
+// requirement, Firefox 52+, webdriver-manager 12.0.4+, selenium-webdriver 3.3.0+
+// test step,
+// webdriver-manager update
+// webdriver-manager start
+// http-server test/webdriver
+// node test/webdriver/test.js
+
+// testcase1: removeEventHandler in firefox cross site context
+const webdriver = require('selenium-webdriver');
+const capabilities = webdriver.Capabilities.firefox();
+const driver = new webdriver.Builder().usingServer('http://localhost:4444/wd/hub').withCapabilities(capabilities).build();
+driver.get("http://localhost:8080/test.html");
+driver.executeAsyncScript((cb) => { window.setTimeout(cb,1000) });
+
+// test case2 addEventHandler in firefox cross site context
+driver.findElement(webdriver.By.css('#thetext')).getText().then(function(text) {
+    console.log(text);
+});


### PR DESCRIPTION
fix #616, and https://github.com/mozilla/geckodriver/issues/515.

the issue just like https://github.com/angular/protractor/issues/2784.

In cross site contexts (such as WebDriver frameworks like Selenium), 
access eventHandler will throw permission denied error.

and in  https://github.com/angular/protractor/issues/2784, @juliemr fixed addEventListener, 
in #616, firefox will also call removeEventListener , the code can be found here, 
https://reviewboard.mozilla.org/r/98064/diff/12#index_header

so we need to do the same with addEventListener in removeEventListener to avoid 
such issue.

- And I modify a little about addEventListener/removeEventListener

https://github.com/JiaLiPassion/zone.js/blob/3fae05d347fde7e46cc8834158da74e544506877/lib/common/utils.ts#L320

in earlier fix, if data.handler.toString is permission denied, we do nothing, but in FF52+, toString() is not accessible, but we can still call native addEventListener/removeEventListener with the data.handler, so we can try to do that and try/catch to avoid error.

- I also add test cases which include the test cases from https://github.com/juliemr/zone-firefox-driver/blob/master/test.js provided by @juliemr and from https://github.com/mgiambalvo/firefox-zonejs-issue-demo which provided by @mgiambalvo. Now it can be run locally after install the 
Firefox 52+, webdriver-manager 12.0.4+, selenium-webdriver 3.3.0+, and I will try to add it into travis/saucelabs after saucelabs support those newest browser/webdriver versions.