### PR TITLE
fix(error): fix #706, handleError when onHasTask throw error

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1073,6 +1073,7 @@ const Zone: ZoneType = (function(global: any) {
             this._hasTaskZS.onHasTask(
                 this._hasTaskDlgt, this._hasTaskCurrZone, targetZone, isEmpty);
       } catch (err) {
+        this.handleError(targetZone, err);
       }
     }
 

--- a/test/common/zone.spec.ts
+++ b/test/common/zone.spec.ts
@@ -382,6 +382,25 @@ describe('Zone', function() {
         JSON.stringify(macro);
       }).not.toThrow();
     });
+
+    it('should call onHandleError callback when zoneSpec onHasTask throw error', () => {
+      const spy = jasmine.createSpy('error');
+      const hasTaskZone = Zone.current.fork({
+        name: 'hasTask',
+        onHasTask: (delegate: ZoneDelegate, currentZone: Zone, targetZone: Zone,
+                    hasTasState: HasTaskState) => {
+          throw new Error('onHasTask Error');
+        },
+        onHandleError:
+            (delegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, error: Error) => {
+              spy(error.message);
+              return delegate.handleError(targetZone, error);
+            }
+      });
+
+      const microTask = hasTaskZone.scheduleMicroTask('test', () => {}, null, () => {});
+      expect(spy).toHaveBeenCalledWith('onHasTask Error');
+    });
   });
 });
 


### PR DESCRIPTION
fix #706,
when zoneSpec's onHasTask throw error, should call handleError to let zoneSpec has chance to process the error.