### PR TITLE
fix(task): fix #705, don't json task.data to prevent cyclic error

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1177,7 +1177,6 @@ const Zone: ZoneType = (function(global: any) {
         type: this.type,
         state: this.state,
         source: this.source,
-        data: this.data,
         zone: this.zone.name,
         invoke: this.invoke,
         scheduleFn: this.scheduleFn,

--- a/test/browser/browser.spec.ts
+++ b/test/browser/browser.spec.ts
@@ -312,6 +312,32 @@ describe('Zone', function() {
           });
         });
       });
+
+      it('should be able to covert element with event listener to json without cyclic error',
+         function() {
+           const eventListenerSpy = jasmine.createSpy('eventListener');
+           let elemThrowErrorWhenToJson = false;
+           try {
+             JSON.stringify(button);
+           } catch (err) {
+             elemThrowErrorWhenToJson = true;
+           }
+
+           // in chrome mobile, dom element will throw
+           // cyclic error when call JSON.stringify,
+           // so we just ignore it.
+           if (elemThrowErrorWhenToJson) {
+             return;
+           }
+
+           Zone.current.run(function() {
+             button.addEventListener('click', eventListenerSpy);
+           });
+
+           expect(function() {
+             JSON.stringify(button);
+           }).not.toThrow();
+         });
     });
   });
 });


### PR DESCRIPTION
fix #705,

don't json task.data(it has the target property) to prevent cyclic json error.