### PR TITLE
fix: make getter safe when patching a property

### DIFF
--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -106,6 +106,9 @@ export function patchProperty(obj: any, prop: string) {
   // The getter would return undefined for unassigned properties but the default value of an
   // unassigned property is null
   desc.get = function() {
+    if (this == null) {
+      return this;
+    }
     let r = this[_prop] || null;
     // result will be null when use inline event attribute,
     // such as <button onclick="func();">OK</button>


### PR DESCRIPTION
I'm not sure about how to test this case, but it is happening in Safari 10.0 and iOS 10.2 when running the Angular main test campaign:
- iOS 10: https://travis-ci.org/angular/angular/jobs/218405097
- Safari 10: https://travis-ci.org/angular/angular/jobs/218405098