### PR TITLE
fix: resolve errors with closure

### DIFF
--- a/lib/browser/property-descriptor.ts
+++ b/lib/browser/property-descriptor.ts
@@ -25,8 +25,8 @@ export function propertyDescriptorPatch(_global: any) {
     if (isBrowser) {
       patchOnProperties(window, eventNames);
       patchOnProperties(Document.prototype, eventNames);
-      if (typeof SVGElement !== 'undefined') {
-        patchOnProperties(SVGElement.prototype, eventNames);
+      if (typeof (<any>window)['SVGElement'] !== 'undefined') {
+        patchOnProperties((<any>window)['SVGElement'].prototype, eventNames);
       }
       patchOnProperties(HTMLElement.prototype, eventNames);
     }

--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -128,24 +128,25 @@ export function patchProperty(obj: any, prop: string) {
   };
 
   Object.defineProperty(obj, prop, desc);
-};
+}
 
 export function patchOnProperties(obj: any, properties: string[]) {
-  const onProperties = [];
-  for (const prop in obj) {
-    if (prop.substr(0, 2) == 'on') {
-      onProperties.push(prop);
-    }
-  }
-  for (let j = 0; j < onProperties.length; j++) {
-    patchProperty(obj, onProperties[j]);
-  }
   if (properties) {
     for (let i = 0; i < properties.length; i++) {
       patchProperty(obj, 'on' + properties[i]);
     }
+  } else {
+    const onProperties = [];
+    for (const prop in obj) {
+      if (prop.substr(0, 2) == 'on') {
+        onProperties.push(prop);
+      }
+    }
+    for (let j = 0; j < onProperties.length; j++) {
+      patchProperty(obj, onProperties[j]);
+    }
   }
-};
+}
 
 const EVENT_TASKS = zoneSymbol('eventTasks');
 


### PR DESCRIPTION
Also don't patch all "on" properties if a list of properties is being
passed in. Otherwise various global variables in window get clobbered.