### PR TITLE
fix(core): fix #405, refine the error message when zone.js already loaded

### DIFF
--- a/test/common/zone.spec.ts
+++ b/test/common/zone.spec.ts
@@ -328,12 +328,24 @@ describe('Zone', function() {
 
       it('should throw when Promise has been patched', () => {
         class WrongPromise {}
+        const errorMessage =
+            'Zone.js has detected that ZoneAwarePromise `(window|global).Promise` ' +
+            'has been overwritten.';
+        const errorScriptMessage = 'the loaded Zone.js script file seems to be';
 
         const ZoneAwarePromise = global.Promise;
         global.Promise = WrongPromise;
         try {
           expect(ZoneAwarePromise).toBeTruthy();
-          expect(() => Zone.assertZonePatched()).toThrow();
+          try {
+            Zone.assertZonePatched();
+          } catch (error) {
+            expect(error.message).toContain(errorMessage);
+            expect(error.message).toContain(errorScriptMessage);
+            const idx = error.message.lastIndexOf(errorScriptMessage);
+            const fileName: string = error.message.slice(idx + errorScriptMessage.length);
+            expect(fileName).toContain('zone.js');
+          }
         } finally {
           // restore it.
           global.Promise = ZoneAwarePromise;


### PR DESCRIPTION
fix #405.

We often see that 'Zone.js already loaded' error, when we wrongly load zone.js twice, or load zone.js in some polyfill by incidentally. 

In this PR, we will try to throw the error message as 

```javascript
Zone already loaded. The loaded Zone.js script file seems to be path/to/zone.js(or some vender.bundle.js...)
```

So it will be easy to find out what is wrong, but it require the both zone.js to be upgrade to newer version (maybe 0.8.6) 