### PR TITLE
fix(doc): fix #725 in document, fix a typescript warning in test

### DIFF
--- a/STANDARD-APIS.md
+++ b/STANDARD-APIS.md
@@ -72,7 +72,7 @@ inherit from EventTarget will also be patched.
 on properties, such as onclick, onreadystatechange, the following on properties will 
 be patched as EventTask, the following is the on properties zone.js patched  
 
- |||||||||
+ |||||
  |---|---|---|---|
  |copy|cut|paste|abort|
  |blur|focus|canplay|canplaythrough|

--- a/test/browser/registerElement.spec.ts
+++ b/test/browser/registerElement.spec.ts
@@ -31,7 +31,7 @@ describe(
         callbackNames.map(function(callbackName) {
           const fullCallbackName = callbackName + 'Callback';
           const proto = Object.create(HTMLElement.prototype);
-          proto[fullCallbackName] = function(arg: any) {
+          (proto as any)[fullCallbackName] = function(arg: any) {
             callbacks[callbackName](arg);
           };
           return (<any>document).registerElement('x-' + callbackName.toLowerCase(), {


### PR DESCRIPTION
1. fix #725, in previous typo PR, forget to change the markdown table columns in STANDARD API document
2. fix a typescript compile warning in test/browser/registerElement.spec.ts 