### PR TITLE
fix(test): fix websocket test server will crash when test in chrome

### DIFF
--- a/test/zone_worker_entry_point.ts
+++ b/test/zone_worker_entry_point.ts
@@ -18,6 +18,7 @@ System.import('../lib/browser/browser').then(() => {
         } else {
           (<any>self).postMessage('fail');
         }
+        websocket.close();
       };
       websocket.send('text');
     });


### PR DESCRIPTION
when test webworker websocket, the websocket is not closed, so it will cause ws-server crash sometimes when test in chrome or other environment which support websocket.