### PR TITLE
feat(patch): fix #499, let promise instance toString active like native

### DIFF
--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -7,7 +7,7 @@
  */
 
 import {patchTimer} from '../common/timers';
-import {patchFuncToString} from '../common/to-string';
+import {patchFuncToString, patchObjectToString} from '../common/to-string';
 import {findEventTask, patchClass, patchEventTargetMethods, patchMethod, patchPrototype, zoneSymbol} from '../common/utils';
 
 import {propertyPatch} from './define-property';
@@ -154,6 +154,8 @@ if (_global['navigator'] && _global['navigator'].geolocation) {
 
 // patch Func.prototype.toString to let them look like native
 patchFuncToString();
+// patch Object.prototype.toString to let them look like native
+patchObjectToString();
 
 // handle unhandled promise rejection
 function findPromiseRejectionHandler(evtName: string) {

--- a/lib/common/to-string.ts
+++ b/lib/common/to-string.ts
@@ -34,3 +34,13 @@ export function patchFuncToString() {
     return originalFunctionToString.apply(this, arguments);
   };
 }
+
+export function patchObjectToString() {
+  const originalObjectToString = Object.prototype.toString;
+  Object.prototype.toString = function() {
+    if (this instanceof Promise) {
+      return '[object Promise]';
+    }
+    return originalObjectToString.apply(this, arguments);
+  };
+}

--- a/lib/node/node.ts
+++ b/lib/node/node.ts
@@ -11,7 +11,7 @@ import './events';
 import './fs';
 
 import {patchTimer} from '../common/timers';
-import {patchFuncToString} from '../common/to-string';
+import {patchFuncToString, patchObjectToString} from '../common/to-string';
 import {findEventTask, patchMacroTask, patchMicroTask, zoneSymbol} from '../common/utils';
 
 const set = 'set';
@@ -38,6 +38,8 @@ handleUnhandledPromiseRejection();
 
 // patch Function.prototyp.toString
 patchFuncToString();
+// patch Object.prototyp.toString
+patchObjectToString();
 
 // Crypto
 let crypto: any;

--- a/test/common/Promise.spec.ts
+++ b/test/common/Promise.spec.ts
@@ -60,6 +60,10 @@ describe(
         expect(String(Promise).indexOf('[native code]') >= 0).toBe(true);
       });
 
+      it('should use native toString for promise instance', () => {
+        expect(Object.prototype.toString.call(Promise.resolve())).toEqual('[object Promise]');
+      });
+
       it('should make sure that new Promise is instance of Promise', () => {
         expect(Promise.resolve(123) instanceof Promise).toBe(true);
         expect(new Promise(() => null) instanceof Promise).toBe(true);


### PR DESCRIPTION
fix #499, let 
```
object.prototype.toString(Promise.resolve())
```

active as native to output

```
[object Promise]
```

instead of current

```
[object Object]
```

in ES6, we can use Symbol.toStringTag, in ES5, I didn't find a better way to do this.