### PR TITLE
fix: don't save handleIds for node

### DIFF
--- a/lib/common/timers.ts
+++ b/lib/common/timers.ts
@@ -27,17 +27,28 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
       try {
         task.invoke.apply(this, arguments);
       } finally {
-        delete tasksByHandleId[data.handleId];
+        if (typeof data.handleId === 'number') {
+          // Node returns complex objects as handleIds
+          delete tasksByHandleId[data.handleId];
+        }
       }
     };
     data.args[0] = timer;
     data.handleId = setNative.apply(window, data.args);
-    tasksByHandleId[data.handleId] = task;
+    if (typeof data.handleId === 'number') {
+      // Node returns complex objects as handleIds -> no need to keep them around. Additionally,
+      // this throws an
+      // exception in older node versions and has no effect there, because of the stringified key.
+      tasksByHandleId[data.handleId] = task;
+    }
     return task;
   }
 
   function clearTask(task: Task) {
-    delete tasksByHandleId[(<TimerOptions>task.data).handleId];
+    if (typeof(<TimerOptions>task.data).handleId === 'number') {
+      // Node returns complex objects as handleIds
+      delete tasksByHandleId[(<TimerOptions>task.data).handleId];
+    }
     return clearNative((<TimerOptions>task.data).handleId);
   }
 


### PR DESCRIPTION
Older node versions (0.10, still default in debian stable) will throw exceptions while trying to use the objects returned nodes Timers implementation as keys -> don't make them try it.
For the same reason - as far as I understand it - this has never worked in node, also newer versions, anyway. Therefore this shouldn't break anything.