### PR TITLE
feat(EventListenerOptions): fix #737, add support to EventListenerOptions

### DIFF
--- a/lib/node/events.ts
+++ b/lib/node/events.ts
@@ -30,7 +30,7 @@ const zoneAwarePrependListener = callAndReturnFirstParam(
 const zoneAwareRemoveListener =
     callAndReturnFirstParam(makeZoneAwareRemoveListener(EE_REMOVE_LISTENER, false));
 const zoneAwareRemoveAllListeners =
-    callAndReturnFirstParam(makeZoneAwareRemoveAllListeners(EE_REMOVE_ALL_LISTENER, false));
+    callAndReturnFirstParam(makeZoneAwareRemoveAllListeners(EE_REMOVE_ALL_LISTENER));
 const zoneAwareListeners = makeZoneAwareListeners(EE_LISTENERS);
 
 export function patchEventEmitterMethods(obj: any): boolean {


### PR DESCRIPTION
fix #737 
add support to (Add)EventListenerOptions which has property 
```javascript
{
  capture: boolean,
  once: boolean,
  passive: boolean
}
```

https://dom.spec.whatwg.org/#dictdef-addeventlisteneroptions