### PR TITLE
fix double patched timers in older node versions

### DIFF
--- a/lib/node/node.ts
+++ b/lib/node/node.ts
@@ -19,11 +19,12 @@ const _global = typeof window === 'object' && window || typeof self === 'object'
 
 // Timers
 const timers = require('timers');
+const shouldPatchGlobalTimers = global.setTimeout === timers.setTimeout;
+
 patchTimer(timers, set, clear, 'Timeout');
 patchTimer(timers, set, clear, 'Interval');
 patchTimer(timers, set, clear, 'Immediate');
 
-const shouldPatchGlobalTimers = global.setTimeout !== timers.setTimeout;
 
 if (shouldPatchGlobalTimers) {
   patchTimer(_global, set, clear, 'Timeout');


### PR DESCRIPTION
Differences between the node versions with regards to patching timers are:

* In node v0.10 the global timers are methods, which are - as @JiaLiPassion stated in #736 - lazy loading the  `timers`-module and executing the appropriete function.
* In node v7.8.0 these are just references: `global.clearImmediate = timers.clearImmediate;`
* I found no other variant doing a simple git blame on the lines in [nodejs](https://github.com/nodejs/).

This means:

* For v7.8.0 both entry points must be patched, because the assignment always happens before patching.
* For v0.10 *only* timers should be patched, to avoid 'double-wrap'

Because the tests aren't compatible to v0.10, I have no testcase for this. But getting exact stacktraces is simple:

```
$ node -v
v7.8.0
$ node -e 'require("./dist/zone-node.js");var a = function (){ throw new Error("test");};setImmediate(a);'
dist/zone-node.js:169
                        throw error;
                        ^

Error: test
    at Immediate.a ([eval]:1:59) [<root>]
    at Zone.runTask (dist/zone-node.js:165:47) [<root> => <root>]
    at Immediate.ZoneTask.invoke (dist/zone-node.js:460:38) [<root>]
    at Immediate.timer (dist/zone-node.js:1643:29) [<root>]
    at runCallback (timers.js:672:20) [<root>]
    at tryOnImmediate (timers.js:645:5) [<root>]
    at processImmediate [as _immediateCallback] (timers.js:617:5) [<root>]

```

```
$ node -v
v0.10.29
$ node -e 'require("./dist/zone-node.js");var a = function (){ throw new Error("test");};setImmediate(a);'

dist/zone-node.js:169
                        throw error;
                              ^
Error: test
    at new Error (<anonymous>)
    at Object.a ([eval]:1:59) [<root>]
    at Zone.runTask (dist/zone-node.js:165:47) [<root> => <root>]
    at Object.ZoneTask.invoke (dist/zone-node.js:460:38) [<root>]
    at Object.timer (dist/zone-node.js:1643:29) [<root>]
    at Zone.runTask (dist/zone-node.js:165:47) [<root> => <root>]
    at Object.ZoneTask.invoke (dist/zone-node.js:460:38) [<root>]
    at Object.timer [as _onImmediate] (dist/zone-node.js:1643:29) [<root>]
    at processImmediate [as _immediateCallback] (timers.js:336:15) [<root>]

```

Problem is: `shouldPatchGlobalTimers` is always `true`, because the method in old node, which does the lazy loading is not equal to the patched method from timers.

If this was the reason behind `shouldPatchGlobalTimers`, the linked commit should do the trick:

* Before timers are patched, timers and globals are equal in newer node versions
* Because the tests don't run in older node anyway, no testcase for that
* Existing tests ensure current node patches both.

At least the stacktraces look great after the change:
```
$ node -v
v7.8.0
$ node -e 'require("./dist/zone-node.js");var a = function (){ throw new Error("test");};setImmediate(a);'
dist/zone-node.js:169
                        throw error;
                        ^

Error: test
    at Immediate.a ([eval]:1:59) [<root>]
    at Zone.runTask (dist/zone-node.js:165:47) [<root> => <root>]
    at Immediate.ZoneTask.invoke (dist/zone-node.js:460:38) [<root>]
    at Immediate.timer (dist/zone-node.js:1642:29) [<root>]
    at runCallback (timers.js:672:20) [<root>]
    at tryOnImmediate (timers.js:645:5) [<root>]
    at processImmediate [as _immediateCallback] (timers.js:617:5) [<root>]


```

```
$ node -v
v0.10.29
$ node -e 'require("./dist/zone-node.js");var a = function (){ throw new Error("test");};setImmediate(a);'

dist/zone-node.js:169
                        throw error;
                              ^
Error: test
    at new Error (<anonymous>)
    at Object.a ([eval]:1:59) [<root>]
    at Zone.runTask (dist/zone-node.js:165:47) [<root> => <root>]
    at Object.ZoneTask.invoke (dist/zone-node.js:460:38) [<root>]
    at Object.timer [as _onImmediate] (dist/zone-node.js:1642:29) [<root>]
    at processImmediate [as _immediateCallback] (timers.js:336:15) [<root>]

```