### PR TITLE
fix: remove eval-based createNamedFn

### DIFF
--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -551,14 +551,9 @@ export function patchClass(className: string) {
 }
 
 export function createNamedFn(name: string, delegate: (self: any, args: any[]) => any): Function {
-  try {
-    return (Function('f', `return function ${name}(){return f(this, arguments)}`))(delegate);
-  } catch (error) {
-    // if we fail, we must be CSP, just return delegate.
-    return function() {
-      return delegate(this, <any>arguments);
-    };
-  }
+  return function() {
+    return delegate(this, <any>arguments);
+  };
 }
 
 export function patchMethod(


### PR DESCRIPTION
Close #749

- there was no way to turn off the bad implementation, causing a CSP violation every time.
- try..catch is quite expensive, defeating the point of using an "optimized" version.