### PR TITLE
fix(showError): fix ignoreConsoleErrorUncaughtError may change during drain microtask

### DIFF
--- a/lib/common/promise.ts
+++ b/lib/common/promise.ts
@@ -18,8 +18,8 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
   const symbolPromise = __symbol__('Promise');
   const symbolThen = __symbol__('then');
 
-  api.onUnhandledError = (showError: boolean, e: any) => {
-    if (showError) {
+  api.onUnhandledError = (e: any) => {
+    if (api.showUncaughtError()) {
       const rejection = e && e.rejection;
       if (rejection) {
         console.error(
@@ -32,7 +32,7 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
     }
   };
 
-  api.microtaskDrainDone = (showError: boolean) => {
+  api.microtaskDrainDone = () => {
     while (_uncaughtPromiseErrors.length) {
       while (_uncaughtPromiseErrors.length) {
         const uncaughtPromiseError: UncaughtPromiseError = _uncaughtPromiseErrors.shift();
@@ -41,14 +41,14 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
             throw uncaughtPromiseError;
           });
         } catch (error) {
-          handleUnhandledRejection(showError, error);
+          handleUnhandledRejection(error);
         }
       }
     }
   };
 
-  function handleUnhandledRejection(showError: boolean, e: any) {
-    api.onUnhandledError(showError, e);
+  function handleUnhandledRejection(e: any) {
+    api.onUnhandledError(e);
     try {
       const handler = (Zone as any)[__symbol__('unhandledPromiseRejectionHandler')];
       if (handler && typeof handler === 'function') {

--- a/lib/common/promise.ts
+++ b/lib/common/promise.ts
@@ -47,8 +47,8 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
     }
   };
 
-  function handleUnhandledRejection(ignoreError: boolean, e: any) {
-    api.onUnhandledError(ignoreError, e);
+  function handleUnhandledRejection(showError: boolean, e: any) {
+    api.onUnhandledError(showError, e);
     try {
       const handler = (Zone as any)[__symbol__('unhandledPromiseRejectionHandler')];
       if (handler && typeof handler === 'function') {

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1235,7 +1235,6 @@ const Zone: ZoneType = (function(global: any) {
   }
 
   function drainMicroTaskQueue() {
-    const showError: boolean = !(Zone as any)[__symbol__('ignoreConsoleErrorUncaughtError')];
     if (!_isDrainingMicrotaskQueue) {
       _isDrainingMicrotaskQueue = true;
       while (_microTaskQueue.length) {
@@ -1246,13 +1245,13 @@ const Zone: ZoneType = (function(global: any) {
           try {
             task.zone.runTask(task, null, null);
           } catch (error) {
-            if ((Zone as any)[__symbol__('ignoreConsoleErrorUncaughtError')]) {
-              return;
-            }
+            const showError: boolean =
+                !(Zone as any)[__symbol__('ignoreConsoleErrorUncaughtError')];
             _api.onUnhandledError(showError, error);
           }
         }
       }
+      const showError: boolean = !(Zone as any)[__symbol__('ignoreConsoleErrorUncaughtError')];
       _api.microtaskDrainDone(showError);
       _isDrainingMicrotaskQueue = false;
     }

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -317,8 +317,9 @@ interface _ZonePrivate {
   currentZoneFrame(): _ZoneFrame;
   symbol(name: string): string;
   scheduleMicroTask(task?: MicroTask): void;
-  onUnhandledError: (showError: boolean, error: Error) => void;
-  microtaskDrainDone: (showError: boolean) => void;
+  onUnhandledError: (error: Error) => void;
+  microtaskDrainDone: () => void;
+  showUncaughtError: () => boolean;
 }
 
 /** @internal */
@@ -1245,14 +1246,12 @@ const Zone: ZoneType = (function(global: any) {
           try {
             task.zone.runTask(task, null, null);
           } catch (error) {
-            const showError: boolean =
-                !(Zone as any)[__symbol__('ignoreConsoleErrorUncaughtError')];
-            _api.onUnhandledError(showError, error);
+            _api.onUnhandledError(error);
           }
         }
       }
       const showError: boolean = !(Zone as any)[__symbol__('ignoreConsoleErrorUncaughtError')];
-      _api.microtaskDrainDone(showError);
+      _api.microtaskDrainDone();
       _isDrainingMicrotaskQueue = false;
     }
   }
@@ -1277,7 +1276,8 @@ const Zone: ZoneType = (function(global: any) {
     currentZoneFrame: () => _currentZoneFrame,
     onUnhandledError: noop,
     microtaskDrainDone: noop,
-    scheduleMicroTask: scheduleMicroTask
+    scheduleMicroTask: scheduleMicroTask,
+    showUncaughtError: () => !(Zone as any)[__symbol__('ignoreConsoleErrorUncaughtError')]
   };
   let _currentZoneFrame: _ZoneFrame = {parent: null, zone: new Zone(null, null)};
   let _currentTask: Task = null;

--- a/test/common/Promise.spec.ts
+++ b/test/common/Promise.spec.ts
@@ -244,7 +244,42 @@ describe(
             });
           });
 
-          it('should notify Zone.onError if no one catches promise', (done) => {
+          it('should output error to console if ignoreConsoleErrorUncaughtError is false',
+             (done) => {
+               Zone.current.fork({name: 'promise-error'}).run(() => {
+                 (Zone as any)[Zone.__symbol__('ignoreConsoleErrorUncaughtError')] = false;
+                 const originalConsoleError = console.error;
+                 console.error = jasmine.createSpy('consoleErr');
+                 const p = new Promise((resolve, reject) => {
+                   throw new Error('promise error');
+                 });
+                 setTimeout(() => {
+                   expect(console.error).toHaveBeenCalled();
+                   console.error = originalConsoleError;
+                   done();
+                 }, 10);
+               });
+             });
+
+          it('should not output error to console if ignoreConsoleErrorUncaughtError is true',
+             (done) => {
+               Zone.current.fork({name: 'promise-error'}).run(() => {
+                 (Zone as any)[Zone.__symbol__('ignoreConsoleErrorUncaughtError')] = true;
+                 const originalConsoleError = console.error;
+                 console.error = jasmine.createSpy('consoleErr');
+                 const p = new Promise((resolve, reject) => {
+                   throw new Error('promise error');
+                 });
+                 setTimeout(() => {
+                   expect(console.error).not.toHaveBeenCalled();
+                   console.error = originalConsoleError;
+                   (Zone as any)[Zone.__symbol__('ignoreConsoleErrorUncaughtError')] = false;
+                   done();
+                 }, 10);
+               });
+             });
+
+          it('should notify Zone.onHandleError if no one catches promise', (done) => {
             let promiseError: Error = null;
             let zone: Zone = null;
             let task: Task = null;


### PR DESCRIPTION
1. fix showError flag issue.
showError flag may change when drain microTask queue. So if we change the flag in one of the microTask, the flag will not be updated.

2. refactor parameter name in `promise.handleUnhandledRejection`

3. refactor showError, because we change the showError logic above, so maybe we provide 
`showUncaughtError()` in ZonePrivate is better. 

@mhevery, please review that ZonePrivate API change is ok or not. Thank you!