### PR TITLE
fix(patch): fix #744, add namespace to load patch name

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -74,7 +74,7 @@ gulp.task('build/zone.js.d.ts', ['compile-esm'], function() {
 
 // Zone for Node.js environment.
 gulp.task('build/zone-node.js', ['compile-esm'], function(cb) {
-  return generateScript('./lib/node/node.ts', 'zone-node.js', false, cb);
+  return generateScript('./lib/node/rollup-main.ts', 'zone-node.js', false, cb);
 });
 
 // Zone for the browser.

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import '../common/to-string';
-
 import {patchTimer} from '../common/timers';
 import {findEventTask, patchClass, patchEventTargetMethods, patchMethod, patchPrototype, zoneSymbol} from '../common/utils';
 

--- a/lib/browser/rollup-main.ts
+++ b/lib/browser/rollup-main.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-
 import '../zone';
 import '../common/promise';
+import '../common/to-string';
 import './browser';

--- a/lib/node/events.ts
+++ b/lib/node/events.ts
@@ -8,7 +8,7 @@
 
 import {makeZoneAwareAddListener, makeZoneAwareListeners, makeZoneAwareRemoveAllListeners, makeZoneAwareRemoveListener, patchMethod} from '../common/utils';
 
-Zone.__load_patch('node_events', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('EventEmitter', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   const callAndReturnFirstParam = (fn: (self: any, args: any[]) => any) => {
     return (self: any, args: any[]) => {
       fn(self, args);

--- a/lib/node/events.ts
+++ b/lib/node/events.ts
@@ -8,52 +8,54 @@
 
 import {makeZoneAwareAddListener, makeZoneAwareListeners, makeZoneAwareRemoveAllListeners, makeZoneAwareRemoveListener, patchMethod} from '../common/utils';
 
-const callAndReturnFirstParam = (fn: (self: any, args: any[]) => any) => {
-  return (self: any, args: any[]) => {
-    fn(self, args);
-    return self;
+Zone.__load_patch('node_events', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  const callAndReturnFirstParam = (fn: (self: any, args: any[]) => any) => {
+    return (self: any, args: any[]) => {
+      fn(self, args);
+      return self;
+    };
   };
-};
 
-// For EventEmitter
-const EE_ADD_LISTENER = 'addListener';
-const EE_PREPEND_LISTENER = 'prependListener';
-const EE_REMOVE_LISTENER = 'removeListener';
-const EE_REMOVE_ALL_LISTENER = 'removeAllListeners';
-const EE_LISTENERS = 'listeners';
-const EE_ON = 'on';
+  // For EventEmitter
+  const EE_ADD_LISTENER = 'addListener';
+  const EE_PREPEND_LISTENER = 'prependListener';
+  const EE_REMOVE_LISTENER = 'removeListener';
+  const EE_REMOVE_ALL_LISTENER = 'removeAllListeners';
+  const EE_LISTENERS = 'listeners';
+  const EE_ON = 'on';
 
-const zoneAwareAddListener = callAndReturnFirstParam(
-    makeZoneAwareAddListener(EE_ADD_LISTENER, EE_REMOVE_LISTENER, false, true, false));
-const zoneAwarePrependListener = callAndReturnFirstParam(
-    makeZoneAwareAddListener(EE_PREPEND_LISTENER, EE_REMOVE_LISTENER, false, true, true));
-const zoneAwareRemoveListener =
-    callAndReturnFirstParam(makeZoneAwareRemoveListener(EE_REMOVE_LISTENER, false));
-const zoneAwareRemoveAllListeners =
-    callAndReturnFirstParam(makeZoneAwareRemoveAllListeners(EE_REMOVE_ALL_LISTENER));
-const zoneAwareListeners = makeZoneAwareListeners(EE_LISTENERS);
+  const zoneAwareAddListener = callAndReturnFirstParam(
+      makeZoneAwareAddListener(EE_ADD_LISTENER, EE_REMOVE_LISTENER, false, true, false));
+  const zoneAwarePrependListener = callAndReturnFirstParam(
+      makeZoneAwareAddListener(EE_PREPEND_LISTENER, EE_REMOVE_LISTENER, false, true, true));
+  const zoneAwareRemoveListener =
+      callAndReturnFirstParam(makeZoneAwareRemoveListener(EE_REMOVE_LISTENER, false));
+  const zoneAwareRemoveAllListeners =
+      callAndReturnFirstParam(makeZoneAwareRemoveAllListeners(EE_REMOVE_ALL_LISTENER));
+  const zoneAwareListeners = makeZoneAwareListeners(EE_LISTENERS);
 
-export function patchEventEmitterMethods(obj: any): boolean {
-  if (obj && obj.addListener) {
-    patchMethod(obj, EE_ADD_LISTENER, () => zoneAwareAddListener);
-    patchMethod(obj, EE_PREPEND_LISTENER, () => zoneAwarePrependListener);
-    patchMethod(obj, EE_REMOVE_LISTENER, () => zoneAwareRemoveListener);
-    patchMethod(obj, EE_REMOVE_ALL_LISTENER, () => zoneAwareRemoveAllListeners);
-    patchMethod(obj, EE_LISTENERS, () => zoneAwareListeners);
-    obj[EE_ON] = obj[EE_ADD_LISTENER];
-    return true;
-  } else {
-    return false;
+  function patchEventEmitterMethods(obj: any): boolean {
+    if (obj && obj.addListener) {
+      patchMethod(obj, EE_ADD_LISTENER, () => zoneAwareAddListener);
+      patchMethod(obj, EE_PREPEND_LISTENER, () => zoneAwarePrependListener);
+      patchMethod(obj, EE_REMOVE_LISTENER, () => zoneAwareRemoveListener);
+      patchMethod(obj, EE_REMOVE_ALL_LISTENER, () => zoneAwareRemoveAllListeners);
+      patchMethod(obj, EE_LISTENERS, () => zoneAwareListeners);
+      obj[EE_ON] = obj[EE_ADD_LISTENER];
+      return true;
+    } else {
+      return false;
+    }
   }
-}
 
-// EventEmitter
-let events;
-try {
-  events = require('events');
-} catch (err) {
-}
+  // EventEmitter
+  let events;
+  try {
+    events = require('events');
+  } catch (err) {
+  }
 
-if (events && events.EventEmitter) {
-  patchEventEmitterMethods(events.EventEmitter.prototype);
-}
+  if (events && events.EventEmitter) {
+    patchEventEmitterMethods(events.EventEmitter.prototype);
+  }
+});

--- a/lib/node/fs.ts
+++ b/lib/node/fs.ts
@@ -8,7 +8,7 @@
 
 import {patchMacroTask} from '../common/utils';
 
-Zone.__load_patch('node_fs', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('fs', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   let fs: any;
   try {
     fs = require('fs');

--- a/lib/node/fs.ts
+++ b/lib/node/fs.ts
@@ -8,32 +8,34 @@
 
 import {patchMacroTask} from '../common/utils';
 
-let fs: any;
-try {
-  fs = require('fs');
-} catch (err) {
-}
+Zone.__load_patch('node_fs', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  let fs: any;
+  try {
+    fs = require('fs');
+  } catch (err) {
+  }
 
-// watch, watchFile, unwatchFile has been patched
-// because EventEmitter has been patched
-const TO_PATCH_MACROTASK_METHODS = [
-  'access',  'appendFile', 'chmod',    'chown',    'close',     'exists',    'fchmod',
-  'fchown',  'fdatasync',  'fstat',    'fsync',    'ftruncate', 'futimes',   'lchmod',
-  'lchown',  'link',       'lstat',    'mkdir',    'mkdtemp',   'open',      'read',
-  'readdir', 'readFile',   'readlink', 'realpath', 'rename',    'rmdir',     'stat',
-  'symlink', 'truncate',   'unlink',   'utimes',   'write',     'writeFile',
-];
+  // watch, watchFile, unwatchFile has been patched
+  // because EventEmitter has been patched
+  const TO_PATCH_MACROTASK_METHODS = [
+    'access',  'appendFile', 'chmod',    'chown',    'close',     'exists',    'fchmod',
+    'fchown',  'fdatasync',  'fstat',    'fsync',    'ftruncate', 'futimes',   'lchmod',
+    'lchown',  'link',       'lstat',    'mkdir',    'mkdtemp',   'open',      'read',
+    'readdir', 'readFile',   'readlink', 'realpath', 'rename',    'rmdir',     'stat',
+    'symlink', 'truncate',   'unlink',   'utimes',   'write',     'writeFile',
+  ];
 
-if (fs) {
-  TO_PATCH_MACROTASK_METHODS.filter(name => !!fs[name] && typeof fs[name] === 'function')
-      .forEach(name => {
-        patchMacroTask(fs, name, (self: any, args: any[]) => {
-          return {
-            name: 'fs.' + name,
-            args: args,
-            callbackIndex: args.length > 0 ? args.length - 1 : -1,
-            target: self
-          };
+  if (fs) {
+    TO_PATCH_MACROTASK_METHODS.filter(name => !!fs[name] && typeof fs[name] === 'function')
+        .forEach(name => {
+          patchMacroTask(fs, name, (self: any, args: any[]) => {
+            return {
+              name: 'fs.' + name,
+              args: args,
+              callbackIndex: args.length > 0 ? args.length - 1 : -1,
+              target: self
+            };
+          });
         });
-      });
-}
+  }
+});

--- a/lib/node/node.ts
+++ b/lib/node/node.ts
@@ -18,7 +18,7 @@ import {findEventTask, patchMacroTask, patchMicroTask} from '../common/utils';
 const set = 'set';
 const clear = 'clear';
 
-Zone.__load_patch('timers', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('node_timers', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   // Timers
   let globalUseTimeoutFromTimer = false;
   try {
@@ -63,7 +63,7 @@ Zone.__load_patch('timers', (global: any, Zone: ZoneType, api: _ZonePrivate) => 
 });
 
 // patch process related methods
-Zone.__load_patch('nextTick', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('node_nextTick', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   // patch nextTick as microTask
   patchMicroTask(process, 'nextTick', (self: any, args: any[]) => {
     return {
@@ -76,7 +76,7 @@ Zone.__load_patch('nextTick', (global: any, Zone: ZoneType, api: _ZonePrivate) =
 });
 
 Zone.__load_patch(
-    'handleUnhandledPromiseRejection', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+    'node_handleUnhandledPromiseRejection', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
       (Zone as any)[api.symbol('unhandledPromiseRejectionHandler')] =
           findProcessPromiseRejectionHandler('unhandledRejection');
 
@@ -103,7 +103,7 @@ Zone.__load_patch(
 
 
 // Crypto
-Zone.__load_patch('crypto', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('node_crypto', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   let crypto: any;
   try {
     crypto = require('crypto');

--- a/lib/node/node.ts
+++ b/lib/node/node.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import '../zone';
-import '../common/promise';
-import '../common/to-string';
 import './events';
 import './fs';
 
@@ -72,7 +69,7 @@ Zone.__load_patch('node_timers', (global: any, Zone: ZoneType, api: _ZonePrivate
 });
 
 // patch process related methods
-Zone.__load_patch('node_nextTick', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('nextTick', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   // patch nextTick as microTask
   patchMicroTask(process, 'nextTick', (self: any, args: any[]) => {
     return {
@@ -85,7 +82,7 @@ Zone.__load_patch('node_nextTick', (global: any, Zone: ZoneType, api: _ZonePriva
 });
 
 Zone.__load_patch(
-    'node_handleUnhandledPromiseRejection', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+    'handleUnhandledPromiseRejection', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
       (Zone as any)[api.symbol('unhandledPromiseRejectionHandler')] =
           findProcessPromiseRejectionHandler('unhandledRejection');
 
@@ -112,7 +109,7 @@ Zone.__load_patch(
 
 
 // Crypto
-Zone.__load_patch('node_crypto', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('crypto', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   let crypto: any;
   try {
     crypto = require('crypto');

--- a/lib/node/rollup-main.ts
+++ b/lib/node/rollup-main.ts
@@ -9,5 +9,4 @@
 import '../zone';
 import '../common/promise';
 import '../common/to-string';
-import '../browser/browser';
-import '../node/node';
+import './node';

--- a/test/browser-zone-setup.ts
+++ b/test/browser-zone-setup.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import '../lib/common/to-string';
 import '../lib/browser/browser';
 import '../lib/zone-spec/async-test';
 import '../lib/zone-spec/fake-async-test';

--- a/test/node_entry_point.ts
+++ b/test/node_entry_point.ts
@@ -12,6 +12,8 @@ import './custom_error';
 
 // Setup tests for Zone without microtask support
 import '../lib/zone';
+import '../lib/common/promise';
+import '../lib/common/to-string';
 import '../lib/node/node';
 import '../lib/zone-spec/async-test';
 import '../lib/zone-spec/fake-async-test';


### PR DESCRIPTION
1. patch node's timer setTimeout with `node_timer` name
2. patch `fs` and `events` of nodejs with `Zone.__load_patch` function
3. make some modification for file structure, zone-node will also have a `rollup-main`, so we have a clear structure.

- common (toString, error, promise)
- browser
- node
- mix(electron)