### PR TITLE
fix(task): fix #778, sometimes task will run after being canceled

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -756,10 +756,22 @@ const Zone: ZoneType = (function(global: any) {
 
 
     runTask(task: Task, applyThis?: any, applyArgs?: any): any {
-      if (task.zone != this)
+      if (task.zone != this) {
         throw new Error(
             'A task can only be run in the zone of creation! (Creation: ' +
             (task.zone || NO_ZONE).name + '; Execution: ' + this.name + ')');
+      }
+      // https://github.com/angular/zone.js/issues/778, sometimes eventTask
+      // will run in notScheduled(canceled) state, we should not try to
+      // run such kind of task but just return
+
+      // we have to define an variable here, if not
+      // typescript compiler will complain below
+      const isNotScheduled = task.state === notScheduled;
+      if (isNotScheduled && task.type === eventTask) {
+        return;
+      }
+
       const reEntryGuard = task.state != running;
       reEntryGuard && (task as ZoneTask<any>)._transitionTo(running, scheduled);
       task.runCount++;

--- a/test/common/task.spec.ts
+++ b/test/common/task.spec.ts
@@ -873,6 +873,26 @@ describe('task lifecycle', () => {
                {toState: 'notScheduled', fromState: 'running'}
              ]);
        }));
+
+    it('task should not run if task transite to notScheduled state which was canceled',
+       testFnWithLoggedTransitionTo(() => {
+         let task: Task;
+         Zone.current.fork({name: 'testCancelZone'}).run(() => {
+           const task = Zone.current.scheduleEventTask('testEventTask', noop, null, noop, noop);
+           Zone.current.cancelTask(task);
+           task.invoke();
+         });
+         expect(log.map(item => {
+           return {toState: item.toState, fromState: item.fromState};
+         }))
+             .toEqual([
+               {toState: 'scheduling', fromState: 'notScheduled'},
+               {toState: 'scheduled', fromState: 'scheduling'},
+               {toState: 'canceling', fromState: 'scheduled'},
+               {toState: 'notScheduled', fromState: 'canceling'}
+             ]);
+       }));
+
   });
 
   describe('reschedule zone', () => {


### PR DESCRIPTION
fix #778.

In normal case, ZoneTask can only transit to `running` state from `scheduled` state.
But in some complex cases, ZoneTask will try to run after being canceled.

```javascript
var createInterface = require('readline').createInterface;
var Observable = require('rx').Observable;
require('zone.js');

var rl = createInterface({ terminal: true, input: process.stdin, output: process.stdout });
var keypress = Observable.fromEvent(rl.input, 'keypress');
var line = Observable.fromEvent(rl, 'line');
keypress.takeUntil(line).toPromise();
```

The case above describe such issue.

Be simplified, a `target` have `2` listeners for `1` event, and when the event trigger, the `1st` event listener remove the `2nd`, and then `2nd` listener run will cause this issue.

The detailed process is:

1. createInterface and Observable.fromEvent('keypress') will create two eventListeners of `keypress` event on ReadableStream target.
2. keypress (fromEvent) also subscribe `line` Observable.
3. when user enter key in command line.
    - `keypress` eventlisteners (2 listeners) will begin to run.
    -  listeners[0] `createInterface` listener https://github.com/nodejs/node/blob/master/lib/readline.js#L187 will run normally, and trigger `line` Observable
    - `line` Observable will then trigger `keypress` Observable
    - `keypress` Observable will auto dispose and being removed from ReadableStream, so the Task is canceled
    - now ReadableStream only have `one` listener, but in memory listeners from the beginning still have 2
    - listeners[1] begin to run, but it has been canceled, and error occurs.

It is a little tricky, I tried without zone.js, the removed listener will also run again but do nothing (in this case, the observable has been stopped). 

So in this PR, I just check whether ZoneTask is `notScheduled` (canceled) or not before runTask, if it is the case, just return and do nothing. 