### PR TITLE
refactor(private): move help method to _ZonePrivate

### DIFF
--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -9,7 +9,7 @@
 import '../common/to-string';
 
 import {patchTimer} from '../common/timers';
-import {findEventTask, patchClass, patchEventTargetMethods, patchMethod, patchPrototype, zoneSymbol} from '../common/utils';
+import {findEventTask, patchClass, patchEventTargetMethods, patchMethod, patchOnProperties, patchPrototype, zoneSymbol} from '../common/utils';
 
 import {propertyPatch} from './define-property';
 import {eventTargetPatch} from './event-target';
@@ -189,4 +189,10 @@ Zone.__load_patch('PromiseRejectionEvent', (global: any, Zone: ZoneType, api: _Z
     (Zone as any)[zoneSymbol('rejectionHandledHandler')] =
         findPromiseRejectionHandler('rejectionhandled');
   }
+});
+
+
+Zone.__load_patch('util', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  api.patchEventTargetMethods = patchEventTargetMethods;
+  api.patchOnProperties = patchOnProperties;
 });

--- a/lib/browser/webapis-media-query.ts
+++ b/lib/browser/webapis-media-query.ts
@@ -9,9 +9,7 @@ Zone.__load_patch('mediaQuery', (global: any, Zone: ZoneType, api: _ZonePrivate)
   if (!global['MediaQueryList']) {
     return;
   }
-  const patchEventTargetMethods =
-      (Zone as any)[(Zone as any).__symbol__('patchEventTargetMethods')];
-  patchEventTargetMethods(
+  api.patchEventTargetMethods(
       _global['MediaQueryList'].prototype, 'addListener', 'removeListener',
       (self: any, args: any[]) => {
         return {

--- a/lib/browser/webapis-notification.ts
+++ b/lib/browser/webapis-notification.ts
@@ -14,6 +14,5 @@ Zone.__load_patch('notification', (global: any, Zone: ZoneType, api: _ZonePrivat
   if (!desc || !desc.configurable) {
     return;
   }
-  const patchOnProperties = (Zone as any)[(Zone as any).__symbol__('patchOnProperties')];
-  patchOnProperties(Notification.prototype, null);
+  api.patchOnProperties(Notification.prototype, null);
 });

--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -664,6 +664,3 @@ export function findEventTask(target: any, evtName: string): Task[] {
 export function attachOriginToPatched(patched: Function, original: any) {
   (patched as any)[zoneSymbol('OriginalDelegate')] = original;
 }
-
-(Zone as any)[zoneSymbol('patchEventTargetMethods')] = patchEventTargetMethods;
-(Zone as any)[zoneSymbol('patchOnProperties')] = patchOnProperties;

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -314,12 +314,15 @@ type _PatchFn = (global: Window, Zone: ZoneType, api: _ZonePrivate) => void;
 
 /** @internal */
 interface _ZonePrivate {
-  currentZoneFrame(): _ZoneFrame;
-  symbol(name: string): string;
-  scheduleMicroTask(task?: MicroTask): void;
+  currentZoneFrame: () => _ZoneFrame;
+  symbol: (name: string) => string;
+  scheduleMicroTask: (task?: MicroTask) => void;
   onUnhandledError: (error: Error) => void;
   microtaskDrainDone: () => void;
   showUncaughtError: () => boolean;
+  patchEventTargetMethods:
+      (obj: any, addFnName?: string, removeFnName?: string, metaCreator?: any) => boolean;
+  patchOnProperties: (obj: any, properties: string[]) => void;
 }
 
 /** @internal */
@@ -1277,7 +1280,9 @@ const Zone: ZoneType = (function(global: any) {
     onUnhandledError: noop,
     microtaskDrainDone: noop,
     scheduleMicroTask: scheduleMicroTask,
-    showUncaughtError: () => !(Zone as any)[__symbol__('ignoreConsoleErrorUncaughtError')]
+    showUncaughtError: () => !(Zone as any)[__symbol__('ignoreConsoleErrorUncaughtError')],
+    patchEventTargetMethods: () => false,
+    patchOnProperties: noop
   };
   let _currentZoneFrame: _ZoneFrame = {parent: null, zone: new Zone(null, null)};
   let _currentTask: Task = null;


### PR DESCRIPTION
move `patchEventTargetMethod` and `patchOnProperties` help method from `Zone[__symbol__('patchEventTargetMethod')]` to `_ZonePrivate` api.
it will have type definition and much more clear structure. 