### PR TITLE
fix(patch): fix #791, fix mediaQuery/Notification patch use wrong global

### DIFF
--- a/lib/browser/webapis-media-query.ts
+++ b/lib/browser/webapis-media-query.ts
@@ -10,7 +10,7 @@ Zone.__load_patch('mediaQuery', (global: any, Zone: ZoneType, api: _ZonePrivate)
     return;
   }
   api.patchEventTargetMethods(
-      _global['MediaQueryList'].prototype, 'addListener', 'removeListener',
+      global['MediaQueryList'].prototype, 'addListener', 'removeListener',
       (self: any, args: any[]) => {
         return {
           useCapturing: false,

--- a/lib/browser/webapis-notification.ts
+++ b/lib/browser/webapis-notification.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 Zone.__load_patch('notification', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
-  const Notification = _global['Notification'];
+  const Notification = global['Notification'];
   if (!Notification || !Notification.prototype) {
     return;
   }


### PR DESCRIPTION
a typo which will cause `meduaQuery` and `Notification` use wrong `_global` variable which will be undefined.