### PR TITLE
fix(xhr): inner onreadystatechange should not triigger Zone callback

### DIFF
--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -81,8 +81,11 @@ Zone.__load_patch('XHR', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
       const data = <XHROptions>task.data;
       // remove existing event listener
       const listener = data.target[XHR_LISTENER];
+      const oriAddListener = data.target[zoneSymbol('addEventListener')];
+      const oriRemoveListener = data.target[zoneSymbol('removeEventListener')];
+
       if (listener) {
-        data.target.removeEventListener('readystatechange', listener);
+        oriRemoveListener.apply(data.target, ['readystatechange', listener]);
       }
       const newListener = data.target[XHR_LISTENER] = () => {
         if (data.target.readyState === data.target.DONE) {
@@ -94,7 +97,7 @@ Zone.__load_patch('XHR', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
           }
         }
       };
-      data.target.addEventListener('readystatechange', newListener);
+      oriAddListener.apply(data.target, ['readystatechange', newListener]);
 
       const storedTask: Task = data.target[XHR_TASK];
       if (!storedTask) {

--- a/test/browser/XMLHttpRequest.spec.ts
+++ b/test/browser/XMLHttpRequest.spec.ts
@@ -26,14 +26,12 @@ describe('XMLHttpRequest', function() {
         // The last entry in the log should be the invocation for the current onload,
         // which will vary depending on browser environment. The prior entries
         // should be the invocation of the send macrotask.
-        expect(wtfMock.log[wtfMock.log.length - 5])
-            .toMatch(/\> Zone\:invokeTask.*addEventListener\:readystatechange/);
-        expect(wtfMock.log[wtfMock.log.length - 4])
-            .toEqual('> Zone:invokeTask:XMLHttpRequest.send("<root>::ProxyZone::WTF::TestZone")');
         expect(wtfMock.log[wtfMock.log.length - 3])
-            .toEqual('< Zone:invokeTask:XMLHttpRequest.send');
+            .toEqual('> Zone:invokeTask:XMLHttpRequest.send("<root>::ProxyZone::WTF::TestZone")');
         expect(wtfMock.log[wtfMock.log.length - 2])
-            .toMatch(/\< Zone\:invokeTask.*addEventListener\:readystatechange/);
+            .toEqual('< Zone:invokeTask:XMLHttpRequest.send');
+        expect(wtfMock.log[wtfMock.log.length - 1])
+            .toMatch(/\> Zone\:invokeTask.*addEventListener\:load/);
         done();
       };
 
@@ -42,6 +40,31 @@ describe('XMLHttpRequest', function() {
       const lastScheduled = wtfMock.log[wtfMock.log.length - 1];
       expect(lastScheduled).toMatch('# Zone:schedule:macroTask:XMLHttpRequest.send');
     }, null, null, 'unit-test');
+  });
+
+  it('should not trigger Zone callback of internal onreadystatechange', function(done) {
+    const scheduleSpy = jasmine.createSpy('schedule');
+    const xhrZone = Zone.current.fork({
+      name: 'xhr',
+      onScheduleTask: (delegate: ZoneDelegate, currentZone: Zone, targetZone, task: Task) => {
+        if (task.type === 'eventTask') {
+          scheduleSpy(task.source);
+        }
+        return delegate.scheduleTask(targetZone, task);
+      }
+    });
+
+    xhrZone.run(() => {
+      const req = new XMLHttpRequest();
+      req.onload = function() {
+        expect(Zone.current.name).toEqual('xhr');
+        expect(scheduleSpy.calls.count()).toBe(1);
+        expect(scheduleSpy.calls.mostRecent().args[0]).toMatch('.*.addEventListener:load');
+        done();
+      };
+      req.open('get', '/', true);
+      req.send();
+    });
   });
 
   it('should work with onreadystatechange', function(done) {


### PR DESCRIPTION
fix https://github.com/angular/angular/issues/17167

zone.js will patch xhr, and add onreadystatechange internally,
this onreadystatechange just for invoke the xhr MacroTask, so it should
not trigger ZoneSpec's callback.

in this commit, use original native addEventListener/removeEventListener
to add internal onreadystatechange event listener.