### PR TITLE
fix(xhr): inner onreadystatechange should not use zoneAwareListener

### DIFF
--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -91,8 +91,11 @@ Zone.__load_patch('XHR', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
       const data = <XHROptions>task.data;
       // remove existing event listener
       const listener = data.target[XHR_LISTENER];
+      const oriAddListener = data.target[zoneSymbol('addEventListener')];
+      const oriRemoveListener = data.target[zoneSymbol('removeEventListener')];
+
       if (listener) {
-        data.target.removeEventListener('readystatechange', listener);
+        oriRemoveListener.apply(data.target, ['readystatechange', listener]);
       }
       const newListener = data.target[XHR_LISTENER] = () => {
         if (data.target.readyState === data.target.DONE) {
@@ -104,7 +107,7 @@ Zone.__load_patch('XHR', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
           }
         }
       };
-      data.target.addEventListener('readystatechange', newListener);
+      oriAddListener.apply(data.target, ['readystatechange', newListener]);
 
       const storedTask: Task = data.target[XHR_TASK];
       if (!storedTask) {

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -57,3 +57,14 @@ function _runTest(test: any, block: Function, done: Function) {
     });
   }
 }
+
+export function supportPatchXHROnProperty() {
+  let desc = Object.getOwnPropertyDescriptor(XMLHttpRequest.prototype, 'onload');
+  if (!desc && (window as any)['XMLHttpRequestEventTarget']) {
+    desc = Object.getOwnPropertyDescriptor(global['XMLHttpRequestEventTarget'].prototype, 'onload');
+  }
+  if (!desc || !desc.configurable) {
+    return false;
+  }
+  return true;
+}

--- a/test/zone-spec/task-tracking.spec.ts
+++ b/test/zone-spec/task-tracking.spec.ts
@@ -8,6 +8,8 @@
 
 import '../../lib/zone-spec/task-tracking';
 
+import {supportPatchXHROnProperty} from '../test-util';
+
 declare const global: any;
 
 describe('TaskTrackingZone', function() {
@@ -47,7 +49,9 @@ describe('TaskTrackingZone', function() {
             setTimeout(() => {
               expect(taskTrackingZoneSpec.macroTasks.length).toBe(0);
               expect(taskTrackingZoneSpec.microTasks.length).toBe(0);
-              expect(taskTrackingZoneSpec.eventTasks.length).not.toBe(0);
+              if (supportPatchXHROnProperty()) {
+                expect(taskTrackingZoneSpec.eventTasks.length).not.toBe(0);
+              }
               taskTrackingZoneSpec.clearEvents();
               expect(taskTrackingZoneSpec.eventTasks.length).toBe(0);
               done();


### PR DESCRIPTION
fix https://github.com/angular/angular/issues/17167,
zone.js will patch xhr, and add onreadystatechange internally,
this onreadystatechange just for invoke the xhr MacroTask, so it should
not trigger ZoneSpec's callback.

in this commit, use original native addEventListener/removeEventListener
to add internal onreadystatechange event listener.


```javascript
if (listener) {
  // don't use patched removeEventListener
  oriRemoveListener.apply(data.target, ['readystatechange', listener]);
}
const newListener = data.target[XHR_LISTENER] = () => {
    if (data.target.readyState === data.target.DONE) {
    // sometimes on some browsers XMLHttpRequest will fire onreadystatechange with
    // readyState=4 multiple times, so we need to check task state here
    if (!data.aborted && (XMLHttpRequest as any)[XHR_SCHEDULED] &&
        task.state === 'scheduled') {
      task.invoke();   
    }
  }
};      
// don't use patched addEventListener
oriAddListener.apply(data.target, ['readystatechange', newListener]);
```