### PR TITLE
fix(toString): fix #802, fix ios 9 MutationObserver toString error

### DIFF
--- a/lib/common/to-string.ts
+++ b/lib/common/to-string.ts
@@ -14,8 +14,13 @@ Zone.__load_patch('toString', (global: any, Zone: ZoneType, api: _ZonePrivate) =
   const originalFunctionToString = Function.prototype.toString;
   Function.prototype.toString = function() {
     if (typeof this === 'function') {
-      if (this[zoneSymbol('OriginalDelegate')]) {
-        return originalFunctionToString.apply(this[zoneSymbol('OriginalDelegate')], arguments);
+      const originalDelegate = this[zoneSymbol('OriginalDelegate')];
+      if (originalDelegate) {
+        if (typeof originalDelegate === 'function') {
+          return originalFunctionToString.apply(this[zoneSymbol('OriginalDelegate')], arguments);
+        } else {
+          return Object.prototype.toString.call(originalDelegate);
+        }
       }
       if (this === Promise) {
         const nativePromise = global[zoneSymbol('Promise')];

--- a/test/common/toString.spec.ts
+++ b/test/common/toString.spec.ts
@@ -17,6 +17,18 @@ describe('global function patch', () => {
       expect(Function.prototype.toString.call(setTimeout))
           .toEqual(Function.prototype.toString.call(g[zoneSymbol('setTimeout')]));
     });
+
+    it('MutationObserver toString should be the same with native version',
+       ifEnvSupports('MutationObserver', () => {
+         const nativeMutationObserver = g[zoneSymbol('MutationObserver')];
+         if (typeof nativeMutationObserver === 'function') {
+           expect(Function.prototype.toString.call(g['MutationObserver']))
+               .toEqual(Function.prototype.toString.call(nativeMutationObserver));
+         } else {
+           expect(Function.prototype.toString.call(g['MutationObserver']))
+               .toEqual(Object.prototype.toString.call(nativeMutationObserver));
+         }
+       }));
   });
 
   describe('isNative', () => {


### PR DESCRIPTION
fix #802,

in ios 9, webkt `MutationObserver` is not a function, is a object, so in `zone.js` patched `Function.prototype.toString`, we should check the `native` object's type is `function` or `object`. 