### PR TITLE
refactor(util): replace zoneSymbol with Zone.__symbol__

### DIFF
--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -14,7 +14,7 @@
 // Hack since TypeScript isn't compiling this for a worker.
 declare const WorkerGlobalScope: any;
 
-export const zoneSymbol: (name: string) => string = (n) => `__zone_symbol__${n}`;
+export const zoneSymbol = Zone.__symbol__;
 const _global: any =
     typeof window === 'object' && window || typeof self === 'object' && self || global;
 


### PR DESCRIPTION
Some refactor.

1. replace `zoneSymbol` in util.ts to `Zone.__symbol__`, so we will only have one version of `Zone Symbol` method.

2. rename `findEventTask` method to `findEventTasksByEventName`