### PR TITLE
fix(spec): FakeAsyncTestZoneSpec.flush() passes limit along to scheduler

### DIFF
--- a/lib/zone-spec/fake-async-test.ts
+++ b/lib/zone-spec/fake-async-test.ts
@@ -249,10 +249,10 @@
       flushErrors();
     }
 
-    flush(): number {
+    flush(limit?: number): number {
       FakeAsyncTestZoneSpec.assertInZone();
       this.flushMicrotasks();
-      let elapsed = this._scheduler.flush();
+      let elapsed = this._scheduler.flush(limit);
       if (this._lastError !== null) {
         this._resetLastErrorAndThrow();
       }

--- a/test/zone-spec/fake-async-test.spec.ts
+++ b/test/zone-spec/fake-async-test.spec.ts
@@ -501,6 +501,26 @@ describe('FakeAsyncTestZoneSpec', () => {
           .toThrowError(
               'flush failed after reaching the limit of 20 tasks. Does your code use a polling timeout?');
     });
+
+    it('accepts a custom limit', function() {
+      expect(() => {
+        fakeAsyncTestZone.run(() => {
+          let z = 0;
+
+          let poll = () => {
+            setTimeout(() => {
+              z++;
+              poll();
+            }, 10);
+          };
+
+          poll();
+          testZoneSpec.flush(10);
+        });
+      })
+          .toThrowError(
+              'flush failed after reaching the limit of 10 tasks. Does your code use a polling timeout?');
+    });
   });
 
   describe('outside of FakeAsync Zone', () => {


### PR DESCRIPTION
`flush()` in Angular's `fakeAsync` accepts a limit argument, which is passed to `FakeAsyncTestZoneSpec.flush()`

`flush()` on the `Scheduler` also accepts the limit argument. But `FakeAsyncTestZoneSpec.flush()` was not passing it along.