### PR TITLE
fix(promise): fix #850, check Promise.then writable

### DIFF
--- a/lib/common/promise.ts
+++ b/lib/common/promise.ts
@@ -330,6 +330,13 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
     // Keep a reference to the original method.
     proto[symbolThen] = originalThen;
 
+    // check Ctor.prototype.then propertyDescritor is writable or not
+    // in meteor env, writable is false, we have to make it to be true.
+    const prop = Object.getOwnPropertyDescriptor(Ctor.prototype, 'then');
+    if (prop && prop.writable === false && prop.configurable) {
+      Object.defineProperty(Ctor.prototype, 'then', {writable: true});
+    }
+
     Ctor.prototype.then = function(onResolve: any, onReject: any) {
       const wrapped = new ZoneAwarePromise((resolve, reject) => {
         originalThen.call(this, resolve, reject);


### PR DESCRIPTION
in `meteor` environment, `Promise.prototype.then` was defined as 

```javascript
{
  writable: false,
  configurable: true
}
```

so we can't patch it, we have to check if it is the case, we should change the writable to `true`.