### PR TITLE
fix(spec): do not count requestAnimationFrame as a pending timer

### DIFF
--- a/test/zone-spec/fake-async-test.spec.ts
+++ b/test/zone-spec/fake-async-test.spec.ts
@@ -555,6 +555,13 @@ describe('FakeAsyncTestZoneSpec', () => {
                      expect(ran).toEqual(true);
                    });
                  });
+                 it('does not count as a pending timer', () => {
+                   fakeAsyncTestZone.run(() => {
+                     requestAnimationFrame(() => {});
+                   });
+                   expect(testZoneSpec.pendingTimers.length).toBe(0);
+                   expect(testZoneSpec.pendingPeriodicTimers.length).toBe(0);
+                 });
                  it('should cancel a scheduled requestAnimatiomFrame', () => {
                    fakeAsyncTestZone.run(() => {
                      let ran = false;


### PR DESCRIPTION
We added a new fature to FakeAsyncTestSpec to treat a
requestAnimationFrame as a timer with 16ms. However this breaks existing
Angular project tests because the RAF is reported as a pending timer at
the end of the test.

This change makes sure that existing Angular tests are not broken by not
counting RAF-s as pending timers at the end of a test.