### PR TITLE
fix(console): console.log in nodejs should run in root Zone

### DIFF
--- a/lib/node/node.ts
+++ b/lib/node/node.ts
@@ -134,3 +134,21 @@ Zone.__load_patch('crypto', (global: any, Zone: ZoneType, api: _ZonePrivate) => 
     });
   }
 });
+
+Zone.__load_patch('console', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  const consoleMethods =
+      ['dir', 'log', 'info', 'error', 'warn', 'assert', 'debug', 'timeEnd', 'trace'];
+  consoleMethods.forEach((m: string) => {
+    const originalMethod = (console as any)[Zone.__symbol__(m)] = (console as any)[m];
+    if (originalMethod) {
+      (console as any)[m] = function() {
+        const args = Array.prototype.slice.call(arguments);
+        if (Zone.current === Zone.root) {
+          return originalMethod.apply(this, args);
+        } else {
+          return Zone.root.run(originalMethod, this, args);
+        }
+      };
+    }
+  });
+});

--- a/test/node/console.spec.ts
+++ b/test/node/console.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+describe('node console', () => {
+  const log: string[] = [];
+  const zone = Zone.current.fork({
+    name: 'console',
+    onScheduleTask: function(
+        delegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, task: Task) {
+      log.push(task.source);
+      return delegate.scheduleTask(targetZone, task);
+    }
+  });
+
+  beforeEach(() => {
+    log.length = 0;
+  });
+
+  it('console methods should run in root zone', () => {
+    zone.run(() => {
+      console.log('test');
+      console.warn('test');
+      console.error('test');
+      console.info('test');
+      console.trace('test');
+      try {
+        console.assert(false, 'test');
+      } catch (error) {
+      }
+      console.dir('.');
+      console.time('start');
+      console.timeEnd('start');
+      console.debug && console.debug('test');
+    });
+    expect(log).toEqual([]);
+  });
+});

--- a/test/node_tests.ts
+++ b/test/node_tests.ts
@@ -12,6 +12,7 @@ import './node/process.spec';
 import './node/Error.spec';
 import './node/crypto.spec';
 import './node/http.spec';
+import './node/console.spec';
 
 // before test bluebird, must run npm install bluebird first.
 // then remove the comment below


### PR DESCRIPTION
fix https://github.com/angular/angular/issues/17180

in nodejs, `console.log` will use `process.nextTick` and schedule a microTask which will cause 
infinite loop, so we need to make sure it run in `Zone.root`.
