### PR TITLE
fix(patch): fix #859 readonly property should not be patched in patchPrototype

### DIFF
--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -33,6 +33,10 @@ export function patchPrototype(prototype: any, fnNames: string[]) {
     const name = fnNames[i];
     const delegate = prototype[name];
     if (delegate) {
+      const prototypeDesc = Object.getOwnPropertyDescriptor(prototype, name);
+      if (!isPropertyWritable(prototypeDesc)) {
+        continue;
+      }
       prototype[name] = ((delegate: Function) => {
         const patched: any = function() {
           return delegate.apply(this, bindArguments(<any>arguments, source + '.' + name));
@@ -42,6 +46,22 @@ export function patchPrototype(prototype: any, fnNames: string[]) {
       })(delegate);
     }
   }
+}
+
+export function isPropertyWritable(propertyDesc: any) {
+  if (!propertyDesc) {
+    return true;
+  }
+
+  if (propertyDesc.writable === false) {
+    return false;
+  }
+
+  if (typeof propertyDesc.get === 'function' && typeof propertyDesc.set === 'undefined') {
+    return false;
+  }
+
+  return true;
 }
 
 export const isWebWorker: boolean =


### PR DESCRIPTION
fix #859, `patchPrototype` should not patch `readonly`  property.

PropertyDescriptor
- `writable` === false
- only has getter.

will not be patched. 