### PR TITLE
fix(websocket), fix #862, in old safari, patchEventTarget for WebSocket use wrong API

### DIFF
--- a/lib/browser/websocket.ts
+++ b/lib/browser/websocket.ts
@@ -15,7 +15,7 @@ export function apply(api: _ZonePrivate, _global: any) {
   // On Safari window.EventTarget doesn't exist so need to patch WS add/removeEventListener
   // On older Chrome, no need since EventTarget was already patched
   if (!(<any>_global).EventTarget) {
-    patchEventTarget(api, _global, [WS.prototype]);
+    patchEventTarget(_global, [WS.prototype]);
   }
   (<any>_global).WebSocket = function(a: any, b: any) {
     const socket = arguments.length > 1 ? new WS(a, b) : new WS(a);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "tsc:w": "tsc -w -p .",
     "test": "npm run tsc && concurrently \"npm run tsc:w\" \"npm run ws-server\" \"npm run karma-jasmine\"",
     "test:phantomjs": "npm run tsc && concurrently \"npm run tsc:w\" \"npm run ws-server\" \"npm run karma-jasmine:phantomjs\"",
-    "test:phantomjs-single": "concurrently \"npm run ws-server\" \"npm run karma-jasmine-phantomjs:autoclose\"",
+    "test:phantomjs-single": "npm run tsc && concurrently \"npm run ws-server\" \"npm run karma-jasmine-phantomjs:autoclose\"",
     "test:single": "npm run tsc && concurrently \"npm run ws-server\" \"npm run karma-jasmine:autoclose\"",
     "test-dist": "concurrently \"npm run tsc:w\" \"npm run ws-server\" \"karma start karma-dist-jasmine.conf.js\"",
     "test-node": "gulp test/node",


### PR DESCRIPTION
fix #862, fix wrong API usage for patchEventTarget of Websocket in old browsers.