### PR TITLE
feat(performance): onProperty handler use global wrapFn, other performance improve.

### DIFF
--- a/lib/browser/define-property.ts
+++ b/lib/browser/define-property.ts
@@ -17,6 +17,9 @@ const _getOwnPropertyDescriptor = (Object as any)[zoneSymbol('getOwnPropertyDesc
     Object.getOwnPropertyDescriptor;
 const _create = Object.create;
 const unconfigurablesKey = zoneSymbol('unconfigurables');
+const PROTOTYPE = 'prototype';
+const OBJECT = 'object';
+const UNDEFINED = 'undefined';
 
 export function propertyPatch() {
   Object.defineProperty = function(obj, prop, desc) {
@@ -24,7 +27,7 @@ export function propertyPatch() {
       throw new TypeError('Cannot assign to read only property \'' + prop + '\' of ' + obj);
     }
     const originalConfigurableFlag = desc.configurable;
-    if (prop !== 'prototype') {
+    if (prop !== PROTOTYPE) {
       desc = rewriteDescriptor(obj, prop, desc);
     }
     return _tryDefineProperty(obj, prop, desc, originalConfigurableFlag);
@@ -38,7 +41,7 @@ export function propertyPatch() {
   };
 
   Object.create = <any>function(obj: any, proto: any) {
-    if (typeof proto === 'object' && !Object.isFrozen(proto)) {
+    if (typeof proto === OBJECT && !Object.isFrozen(proto)) {
       Object.keys(proto).forEach(function(prop) {
         proto[prop] = rewriteDescriptor(obj, prop, proto[prop]);
       });
@@ -83,7 +86,7 @@ function _tryDefineProperty(obj: any, prop: string, desc: any, originalConfigura
     if (desc.configurable) {
       // In case of errors, when the configurable flag was likely set by rewriteDescriptor(), let's
       // retry with the original flag value
-      if (typeof originalConfigurableFlag == 'undefined') {
+      if (typeof originalConfigurableFlag == UNDEFINED) {
         delete desc.configurable;
       } else {
         desc.configurable = originalConfigurableFlag;

--- a/lib/browser/property-descriptor.ts
+++ b/lib/browser/property-descriptor.ts
@@ -215,7 +215,7 @@ const webglEventNames = ['webglcontextrestored', 'webglcontextlost', 'webglconte
 const formEventNames = ['autocomplete', 'autocompleteerror'];
 const detailEventNames = ['toggle'];
 const frameEventNames = ['load'];
-const frameSetEventNames = ['blur', 'error', 'focus', 'load', 'resize', 'scroll'];
+const frameSetEventNames = ['blur', 'error', 'focus', 'load', 'resize', 'scroll', 'messageerror'];
 const marqueeEventNames = ['bounce', 'finish', 'start'];
 
 const XMLHttpRequestEventNames = [
@@ -241,7 +241,7 @@ export function propertyDescriptorPatch(api: _ZonePrivate, _global: any) {
     if (isBrowser) {
       // in IE/Edge, onProp not exist in window object, but in WindowPrototype
       // so we need to pass WindowPrototype to check onProp exist or not
-      patchOnProperties(window, eventNames, Object.getPrototypeOf(window));
+      patchOnProperties(window, eventNames.concat(['messageerror']), Object.getPrototypeOf(window));
       patchOnProperties(Document.prototype, eventNames);
 
       if (typeof(<any>window)['SVGElement'] !== 'undefined') {
@@ -319,20 +319,21 @@ function canPatchViaPropertyDescriptor() {
     Object.defineProperty(XMLHttpRequest.prototype, 'onreadystatechange', xhrDesc || {});
     return result;
   } else {
+    const SYMBOL_FAKE_ONREADYSTATECHANGE = zoneSymbol('fakeonreadystatechange');
     Object.defineProperty(XMLHttpRequest.prototype, 'onreadystatechange', {
       enumerable: true,
       configurable: true,
       get: function() {
-        return this[zoneSymbol('fakeonreadystatechange')];
+        return this[SYMBOL_FAKE_ONREADYSTATECHANGE];
       },
       set: function(value) {
-        this[zoneSymbol('fakeonreadystatechange')] = value;
+        this[SYMBOL_FAKE_ONREADYSTATECHANGE] = value;
       }
     });
     const req = new XMLHttpRequest();
     const detectFunc = () => {};
     req.onreadystatechange = detectFunc;
-    const result = (req as any)[zoneSymbol('fakeonreadystatechange')] === detectFunc;
+    const result = (req as any)[SYMBOL_FAKE_ONREADYSTATECHANGE] === detectFunc;
     req.onreadystatechange = null;
     return result;
   }

--- a/lib/common/timers.ts
+++ b/lib/common/timers.ts
@@ -24,6 +24,12 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
   cancelName += nameSuffix;
 
   const tasksByHandleId: {[id: number]: Task} = {};
+  const NUMBER = 'number';
+  const STRING = 'string';
+  const FUNCTION = 'function';
+  const INTERVAL = 'Interval';
+  const TIMEOUT = 'Timeout';
+  const NOT_SCHEDULED = 'notScheduled';
 
   function scheduleTask(task: Task) {
     const data = <TimerOptions>task.data;
@@ -31,7 +37,7 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
       try {
         task.invoke.apply(this, arguments);
       } finally {
-        if (typeof data.handleId === 'number') {
+        if (typeof data.handleId === NUMBER) {
           // Node returns complex objects as handleIds
           delete tasksByHandleId[data.handleId];
         }
@@ -39,7 +45,7 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
     }
     data.args[0] = timer;
     data.handleId = setNative.apply(window, data.args);
-    if (typeof data.handleId === 'number') {
+    if (typeof data.handleId === NUMBER) {
       // Node returns complex objects as handleIds -> no need to keep them around. Additionally,
       // this throws an
       // exception in older node versions and has no effect there, because of the stringified key.
@@ -49,7 +55,7 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
   }
 
   function clearTask(task: Task) {
-    if (typeof(<TimerOptions>task.data).handleId === 'number') {
+    if (typeof(<TimerOptions>task.data).handleId === NUMBER) {
       // Node returns complex objects as handleIds
       delete tasksByHandleId[(<TimerOptions>task.data).handleId];
     }
@@ -58,12 +64,12 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
 
   setNative =
       patchMethod(window, setName, (delegate: Function) => function(self: any, args: any[]) {
-        if (typeof args[0] === 'function') {
+        if (typeof args[0] === FUNCTION) {
           const zone = Zone.current;
           const options: TimerOptions = {
             handleId: null,
-            isPeriodic: nameSuffix === 'Interval',
-            delay: (nameSuffix === 'Timeout' || nameSuffix === 'Interval') ? args[1] || 0 : null,
+            isPeriodic: nameSuffix === INTERVAL,
+            delay: (nameSuffix === TIMEOUT || nameSuffix === INTERVAL) ? args[1] || 0 : null,
             args: args
           };
           const task = zone.scheduleMacroTask(setName, args[0], options, scheduleTask, clearTask);
@@ -74,8 +80,8 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
           const handle: any = (<TimerOptions>task.data).handleId;
           // check whether handle is null, because some polyfill or browser
           // may return undefined from setTimeout/setInterval/setImmediate/requestAnimationFrame
-          if (handle && handle.ref && handle.unref && typeof handle.ref === 'function' &&
-              typeof handle.unref === 'function') {
+          if (handle && handle.ref && handle.unref && typeof handle.ref === FUNCTION &&
+              typeof handle.unref === FUNCTION) {
             (<any>task).ref = (<any>handle).ref.bind(handle);
             (<any>task).unref = (<any>handle).unref.bind(handle);
           }
@@ -88,9 +94,9 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
 
   clearNative =
       patchMethod(window, cancelName, (delegate: Function) => function(self: any, args: any[]) {
-        const task: Task = typeof args[0] === 'number' ? tasksByHandleId[args[0]] : args[0];
-        if (task && typeof task.type === 'string') {
-          if (task.state !== 'notScheduled' &&
+        const task: Task = typeof args[0] === NUMBER ? tasksByHandleId[args[0]] : args[0];
+        if (task && typeof task.type === STRING) {
+          if (task.state !== NOT_SCHEDULED &&
               (task.cancelFn && task.data.isPeriodic || task.runCount === 0)) {
             // Do not cancel already canceled functions
             task.zone.cancelTask(task);

--- a/lib/common/to-string.ts
+++ b/lib/common/to-string.ts
@@ -13,24 +13,29 @@ Zone.__load_patch('toString', (global: any, Zone: ZoneType, api: _ZonePrivate) =
   // patch Func.prototype.toString to let them look like native
   const originalFunctionToString = (Zone as any)['__zone_symbol__originalToString'] =
       Function.prototype.toString;
+
+  const FUNCTION = 'function';
+  const ORIGINAL_DELEGATE_SYMBOL = zoneSymbol('OriginalDelegate');
+  const PROMISE_SYMBOL = zoneSymbol('Promise');
+  const ERROR_SYMBOL = zoneSymbol('Error');
   Function.prototype.toString = function() {
-    if (typeof this === 'function') {
-      const originalDelegate = this[zoneSymbol('OriginalDelegate')];
+    if (typeof this === FUNCTION) {
+      const originalDelegate = this[ORIGINAL_DELEGATE_SYMBOL];
       if (originalDelegate) {
-        if (typeof originalDelegate === 'function') {
-          return originalFunctionToString.apply(this[zoneSymbol('OriginalDelegate')], arguments);
+        if (typeof originalDelegate === FUNCTION) {
+          return originalFunctionToString.apply(this[ORIGINAL_DELEGATE_SYMBOL], arguments);
         } else {
           return Object.prototype.toString.call(originalDelegate);
         }
       }
       if (this === Promise) {
-        const nativePromise = global[zoneSymbol('Promise')];
+        const nativePromise = global[PROMISE_SYMBOL];
         if (nativePromise) {
           return originalFunctionToString.apply(nativePromise, arguments);
         }
       }
       if (this === Error) {
-        const nativeError = global[zoneSymbol('Error')];
+        const nativeError = global[ERROR_SYMBOL];
         if (nativeError) {
           return originalFunctionToString.apply(nativeError, arguments);
         }
@@ -42,9 +47,10 @@ Zone.__load_patch('toString', (global: any, Zone: ZoneType, api: _ZonePrivate) =
 
   // patch Object.prototype.toString to let them look like native
   const originalObjectToString = Object.prototype.toString;
+  const PROMISE_OBJECT_TO_STRING = '[object Promise]';
   Object.prototype.toString = function() {
     if (this instanceof Promise) {
-      return '[object Promise]';
+      return PROMISE_OBJECT_TO_STRING;
     }
     return originalObjectToString.apply(this, arguments);
   };

--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -170,7 +170,7 @@ export function patchProperty(obj: any, prop: string, prototype?: any) {
     if (!target) {
       return null;
     }
-    if (target.hasOwnProperty(eventNameSymbol)) {
+    if (target[eventNameSymbol]) {
       return wrapFn;
     } else if (originalDescGet) {
       // result will be null when use inline event attribute,

--- a/lib/extra/bluebird.ts
+++ b/lib/extra/bluebird.ts
@@ -11,9 +11,10 @@ Zone.__load_patch('bluebird', (global: any, Zone: ZoneType, api: _ZonePrivate) =
   // global.Promise is not Bluebird, and Bluebird is just be
   // used by other libraries such as sequelize, so I think it is
   // safe to just expose a method to patch Bluebird explicitly
-  (Zone as any)[Zone.__symbol__('bluebird')] = function patchBluebird(Bluebird: any) {
+  const BLUEBIRD = 'bluebird';
+  (Zone as any)[Zone.__symbol__(BLUEBIRD)] = function patchBluebird(Bluebird: any) {
     Bluebird.setScheduler((fn: Function) => {
-      Zone.current.scheduleMicroTask('bluebird', fn);
+      Zone.current.scheduleMicroTask(BLUEBIRD, fn);
     });
   };
 });

--- a/lib/extra/cordova.ts
+++ b/lib/extra/cordova.ts
@@ -7,13 +7,16 @@
  */
 Zone.__load_patch('cordova', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   if (global.cordova) {
+    const SUCCESS_SOURCE = 'cordova.exec.success';
+    const ERROR_SOURCE = 'cordova.exec.error';
+    const FUNCTION = 'function';
     const nativeExec: Function = api.patchMethod(
         global.cordova, 'exec', (delegate: Function) => function(self: any, args: any[]) {
-          if (args.length > 0 && typeof args[0] === 'function') {
-            args[0] = Zone.current.wrap(args[0], 'cordova.exec.success');
+          if (args.length > 0 && typeof args[0] === FUNCTION) {
+            args[0] = Zone.current.wrap(args[0], SUCCESS_SOURCE);
           }
-          if (args.length > 1 && typeof args[1] === 'function') {
-            args[1] = Zone.current.wrap(args[1], 'cordova.exec.error');
+          if (args.length > 1 && typeof args[1] === FUNCTION) {
+            args[1] = Zone.current.wrap(args[1], ERROR_SOURCE);
           }
           return nativeExec.apply(self, args);
         });

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -624,6 +624,8 @@ type AmbientZone = Zone;
 type AmbientZoneDelegate = ZoneDelegate;
 
 const Zone: ZoneType = (function(global: any) {
+  const FUNCTION = 'function';
+
   const performance: {mark(name: string): void; measure(name: string, label: string): void;} =
       global['performance'];
   function mark(name: string) {
@@ -720,7 +722,7 @@ const Zone: ZoneType = (function(global: any) {
     }
 
     public wrap<T extends Function>(callback: T, source: string): T {
-      if (typeof callback !== 'function') {
+      if (typeof callback !== FUNCTION) {
         throw new Error('Expecting function got: ' + callback);
       }
       const _callback = this._zoneDelegate.intercept(this, callback, source);

--- a/test/browser/browser.spec.ts
+++ b/test/browser/browser.spec.ts
@@ -127,11 +127,14 @@ describe('Zone', function() {
 
           function checkIsOnPropertiesPatched(target: any) {
             for (let prop in target) {
-              if (prop.substr(0, 2) === 'on') {
+              if (prop.substr(0, 2) === 'on' && prop.length > 2) {
                 target[prop] = noop;
-                expect(target[Zone.__symbol__('_' + prop)]).toBeTruthy();
+                if (!target[Zone.__symbol__('ON_PROPERTY' + prop.substr(2))]) {
+                  console.log('prop', prop);
+                }
+                expect(target[Zone.__symbol__('ON_PROPERTY' + prop.substr(2))]).toBeTruthy();
                 target[prop] = null;
-                expect(!target[Zone.__symbol__('_' + prop)]).toBeTruthy();
+                expect(!target[Zone.__symbol__('ON_PROPERTY' + prop.substr(2))]).toBeTruthy();
               }
             }
           }
@@ -188,7 +191,7 @@ describe('Zone', function() {
           it('window onresize should be patched',
              ifEnvSupports(canPatchOnProperty(window, 'onmousedown'), function() {
                window.onresize = eventListenerSpy;
-               const innerResizeProp: any = (window as any)[zoneSymbol('_onresize')];
+               const innerResizeProp: any = (window as any)[zoneSymbol('ON_PROPERTYresize')];
                expect(innerResizeProp).toBeTruthy();
                innerResizeProp();
                expect(eventListenerSpy).toHaveBeenCalled();

--- a/test/rxjs/rxjs.Observable.combine.spec.ts
+++ b/test/rxjs/rxjs.Observable.combine.spec.ts
@@ -20,13 +20,11 @@ describe('Observable.combine', () => {
        const constructorZone1: Zone = Zone.current.fork({name: 'Constructor Zone1'});
        const subscriptionZone: Zone = Zone.current.fork({name: 'Subscription Zone'});
        observable1 = constructorZone1.run(() => {
-         const source = Rx.Observable.interval(10);
-         const highOrder = source
-                               .map((src: any) => {
-                                 expect(Zone.current.name).toEqual(constructorZone1.name);
-                                 return Rx.Observable.interval(50).take(3);
-                               })
-                               .take(2);
+         const source = Rx.Observable.of(1, 2);
+         const highOrder = source.map((src: any) => {
+           expect(Zone.current.name).toEqual(constructorZone1.name);
+           return Rx.Observable.of(src);
+         });
          return highOrder.combineAll();
        });
 
@@ -42,12 +40,10 @@ describe('Observable.combine', () => {
              () => {
                log.push('completed');
                expect(Zone.current.name).toEqual(subscriptionZone.name);
-               expect(log).toEqual([[0, 0], [1, 0], [1, 1], [2, 1], [2, 2], 'completed']);
+               expect(log).toEqual([[1, 2], 'completed']);
                done();
              });
        });
-
-       expect(log).toEqual([]);
      }, Zone.root));
 
   it('combineAll func callback should run in the correct zone with project function',


### PR DESCRIPTION
1. we have use `global callback` in `EventTarget.addEventListener`, we should also use the same mechanism for `onProperty=listener` logic. We can use a global `wrapFn` instead of create a new function every time.

2. other small improvements, basically use `const string` to make sure not create too many strings.

3. Chrome 60 support `HTMLFrameSetElement.prototype.onmessageerror`, patch it.