### PR TITLE
fix(task): fix closure compatibility issue with ZoneDelegate._updateT…

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1123,16 +1123,16 @@ const Zone: ZoneType = (function(global: any) {
 
     _updateTaskCount(type: TaskType, count: number) {
       const counts = this._taskCounts;
-      const prev = (counts as any)[type];
-      const next = (counts as any)[type] = prev + count;
+      const prev = counts[type];
+      const next = counts[type] = prev + count;
       if (next < 0) {
         throw new Error('More tasks executed then were scheduled.');
       }
       if (prev == 0 || next == 0) {
         const isEmpty: HasTaskState = {
-          microTask: counts.microTask > 0,
-          macroTask: counts.macroTask > 0,
-          eventTask: counts.eventTask > 0,
+          microTask: counts['microTask'] > 0,
+          macroTask: counts['macroTask'] > 0,
+          eventTask: counts['eventTask'] > 0,
           change: type
         };
         this.hasTask(this.zone, isEmpty);


### PR DESCRIPTION
…askCount

onHasTask wasn't getting triggerred for the Angular Zone for setTimeout
when the application was closure compiled. This was causing errors with
Protractor not being able to wait for a closure compiled application using setTimeout.