### PR TITLE
feat(cordova): fix #868, patch cordova FileReader

### DIFF
--- a/lib/extra/cordova.ts
+++ b/lib/extra/cordova.ts
@@ -22,3 +22,20 @@ Zone.__load_patch('cordova', (global: any, Zone: ZoneType, api: _ZonePrivate) =>
         });
   }
 });
+
+Zone.__load_patch('cordova.FileReader', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  if (global.cordova && typeof global['FileReader'] !== 'undefined') {
+    document.addEventListener('deviceReady', () => {
+      const FileReader = global['FileReader'];
+      ['abort', 'error', 'load', 'loadstart', 'loadend', 'progress'].forEach(prop => {
+        const eventNameSymbol = Zone.__symbol__('ON_PROPERTY' + prop);
+        Object.defineProperty(FileReader.prototype, eventNameSymbol, {
+          configurable: true,
+          get: function() {
+            return this._realReader && this._realReader[eventNameSymbol];
+          }
+        });
+      });
+    });
+  }
+});


### PR DESCRIPTION
Cordova FileReader plugin wrap `FileReader` and have some possible bug,
https://issues.apache.org/jira/browse/CB-13179?page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel&focusedCommentId=16127270#comment-16127270

and make `on_property`(such as onload) not being triggered.
So in this PR, add patch to make it work.

to use this patch, import `zone.js/dist/zone-patch-cordova` in your cordova project.
