### PR TITLE
fix(rxjs): asap should runGuarded to let error inZone

### DIFF
--- a/lib/rxjs/rxjs.ts
+++ b/lib/rxjs/rxjs.ts
@@ -340,7 +340,7 @@ import {rxSubscriber} from 'rxjs/symbol/rxSubscriber';
         const action = workArgs.length > 0 ? workArgs[0] : undefined;
         const scheduleZone = action && action[zoneSymbol];
         if (scheduleZone && scheduleZone !== Zone.current) {
-          return scheduleZone.run(work, this, arguments);
+          return scheduleZone.runGuarded(work, this, arguments);
         } else {
           return work.apply(this, arguments);
         }

--- a/test/rxjs/rxjs.asap.spec.ts
+++ b/test/rxjs/rxjs.asap.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as Rx from 'rxjs/Rx';
+import {asyncTest} from '../test-util';
+
+describe('Scheduler.asap', () => {
+  let log: string[];
+  let errorCallback: Function;
+  const constructorZone: Zone = Zone.root.fork({
+    name: 'Constructor Zone',
+    onHandleError: (delegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, error: Error) => {
+      log.push('error' + error.message);
+      const result = delegate.handleError(targetZone, error);
+      errorCallback && errorCallback();
+      return false;
+    }
+  });
+
+  beforeEach(() => {
+    log = [];
+  });
+
+  it('scheduler asap error should run in correct zone', asyncTest((done: any) => {
+       let observable: any;
+       constructorZone.run(() => {
+         observable = Rx.Observable.of(1, 2, 3).observeOn(Rx.Scheduler.asap);
+       });
+
+       errorCallback = () => {
+         expect(log).toEqual(['erroroops']);
+         setTimeout(done, 0);
+       };
+
+       Zone.root.run(() => {
+         observable
+             .map((value: number) => {
+               if (value === 3) {
+                 throw new Error('oops');
+               }
+               return value;
+             })
+             .subscribe((value: number) => {});
+       });
+     }, Zone.root));
+});

--- a/test/rxjs/rxjs.spec.ts
+++ b/test/rxjs/rxjs.spec.ts
@@ -7,6 +7,7 @@
  */
 import '../../lib/rxjs/rxjs';
 import './rxjs.common.spec';
+import './rxjs.asap.spec';
 import './rxjs.bindCallback.spec';
 import './rxjs.bindNodeCallback.spec';
 import './rxjs.combineLatest.spec';


### PR DESCRIPTION
fix https://github.com/angular/angular/issues/14316.

```javascript
    const constructorZone: Zone = Zone.root.fork({
    name: 'Constructor Zone',
    onHandleError: (delegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, error: Error) => {
      log.push('error' + error.message);
      const result = delegate.handleError(targetZone, error);
      errorCallback && errorCallback();
      return false;
    }
  });
     let observable: any;
       constructorZone.run(() => {
         observable = Rx.Observable.of(1, 2, 3).observeOn(Rx.Scheduler.asap);
       });

       errorCallback = () => {
         expect(log).toEqual(['erroroops']);
         setTimeout(done, 0);
       };

       Zone.root.run(() => {
         observable
             .map((value: number) => {
               if (value === 3) {
                 throw new Error('oops');
               }
               return value;
             })
             .subscribe((value: number) => {});
       });
```

the case like this will reproduce the error, error will not in constructor zone if error throws with asap.
we should use `zone.runGuarded` in patched Immediate.