### PR TITLE
fix(patch): fix #886, #885, patchOnProperties getter should return original listener.

### DIFF
--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -170,8 +170,9 @@ export function patchProperty(obj: any, prop: string, prototype?: any) {
     if (!target) {
       return null;
     }
-    if (target[eventNameSymbol]) {
-      return wrapFn;
+    const listener = target[eventNameSymbol];
+    if (listener) {
+      return listener;
     } else if (originalDescGet) {
       // result will be null when use inline event attribute,
       // such as <button onclick="func();">OK</button>


### PR DESCRIPTION
fix #886. 
fix #885.
fix https://github.com/angular/angular-cli/issues/7502.
patchOnProperties getter should return original listener.

the issue can be described as following code.

```javascript
  const req = new XMLHttpRequest();
         req.open('get', '/', true);
         const listener = req.onreadystatechange = function() {
           if (req.readyState === 4) {
             done();
           }
         };
         expect(req.onreadystatechange).toBe(listener);
         req.onreadystatechange = function() {
           return listener.apply(this, arguments);
         };
         req.send();
```

when try to get `onProperty listener` with such as `const listener = req.onreadystatechange`, should not return `wrapFn` but the real listener.