### PR TITLE
feat(spec): log URL in error when attempting XHR from FakeAsyncTestZone

### DIFF
--- a/lib/zone-spec/fake-async-test.ts
+++ b/lib/zone-spec/fake-async-test.ts
@@ -339,7 +339,9 @@
                   this._setInterval(task.invoke, task.data['delay'], (task.data as any)['args']);
               break;
             case 'XMLHttpRequest.send':
-              throw new Error('Cannot make XHRs from within a fake async test.');
+              throw new Error(
+                  'Cannot make XHRs from within a fake async test. Request URL: ' +
+                  (task.data as any)['url']);
             case 'requestAnimationFrame':
             case 'webkitRequestAnimationFrame':
             case 'mozRequestAnimationFrame':

--- a/test/zone-spec/fake-async-test.spec.ts
+++ b/test/zone-spec/fake-async-test.spec.ts
@@ -664,25 +664,26 @@ describe('FakeAsyncTestZoneSpec', () => {
     });
   });
 
-  describe('XHRs', ifEnvSupports('XMLHttpRequest', () => {
-             it('should throw an exception if an XHR is initiated in the zone', () => {
-               expect(() => {
-                 fakeAsyncTestZone.run(() => {
-                   let finished = false;
-                   let req = new XMLHttpRequest();
+  describe(
+      'XHRs', ifEnvSupports('XMLHttpRequest', () => {
+        it('should throw an exception if an XHR is initiated in the zone', () => {
+          expect(() => {
+            fakeAsyncTestZone.run(() => {
+              let finished = false;
+              let req = new XMLHttpRequest();
 
-                   req.onreadystatechange = () => {
-                     if (req.readyState === XMLHttpRequest.DONE) {
-                       finished = true;
-                     }
-                   };
+              req.onreadystatechange = () => {
+                if (req.readyState === XMLHttpRequest.DONE) {
+                  finished = true;
+                }
+              };
 
-                   req.open('GET', '/', true);
-                   req.send();
-                 });
-               }).toThrowError('Cannot make XHRs from within a fake async test.');
-             });
-           }));
+              req.open('GET', '/test', true);
+              req.send();
+            });
+          }).toThrowError('Cannot make XHRs from within a fake async test. Request URL: /test');
+        });
+      }));
 
   describe('node process', ifEnvSupports(supportNode, () => {
              it('should be able to schedule microTask with additional arguments', () => {


### PR DESCRIPTION
Save the URL from xhr.open and log it when throwing an error from FakeAsyncTestZone when the XHR send it attempted. This would make it easier to debug such errors from a fakeAsync test.