### PR TITLE
feat(compile): fix #892, upgrade to typescript 2.3.4, support for...of when build zone-node

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,6 +78,10 @@ gulp.task('compile', function(cb) {
   tsc('tsconfig.json', cb);
 });
 
+gulp.task('compile-node', function(cb) {
+  tsc('tsconfig-node.json', cb);
+});
+
 gulp.task('compile-esm', function(cb) {
   tsc('tsconfig-esm.json', cb);
 });
@@ -268,7 +272,7 @@ gulp.task('build', [
   'build/closure.js'
 ]);
 
-gulp.task('test/node', ['compile'], function(cb) {
+gulp.task('test/node', ['compile-node'], function(cb) {
   var JasmineRunner = require('jasmine');
   var jrunner = new JasmineRunner();
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,6 +23,13 @@ function generateScript(inFile, outFile, minify, callback) {
         .pipe(rollup({
           entry: inFile,
           format: 'umd',
+          onwarn: function (warning) {
+            // https://github.com/rollup/rollup/wiki/Troubleshooting#this-is-undefined
+            if (warning.code === 'THIS_IS_UNDEFINED') {
+              return;
+            }
+            console.error(warning.message);
+          },
           banner: '/**\n'
               + '* @license\n'
               + '* Copyright Google Inc. All Rights Reserved.\n'
@@ -75,12 +82,16 @@ gulp.task('compile-esm', function(cb) {
   tsc('tsconfig-esm.json', cb);
 });
 
+gulp.task('compile-esm-node', function(cb) {
+  tsc('tsconfig-esm-node.json', cb);
+});
+
 gulp.task('build/zone.js.d.ts', ['compile-esm'], function() {
   return gulp.src('./build-esm/lib/zone.d.ts').pipe(rename('zone.js.d.ts')).pipe(gulp.dest('./dist'));
 });
 
 // Zone for Node.js environment.
-gulp.task('build/zone-node.js', ['compile-esm'], function(cb) {
+gulp.task('build/zone-node.js', ['compile-esm-node'], function(cb) {
   return generateScript('./lib/node/rollup-main.ts', 'zone-node.js', false, cb);
 });
 
@@ -90,7 +101,7 @@ gulp.task('build/zone.js', ['compile-esm'], function(cb) {
 });
 
 // Zone for electron/nw environment.
-gulp.task('build/zone-mix.js', ['compile-esm'], function(cb) {
+gulp.task('build/zone-mix.js', ['compile-esm-node'], function(cb) {
     return generateScript('./lib/mix/rollup-mix.ts', 'zone-mix.js', false, cb);
 });
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "ts-loader": "^0.6.0",
     "tslint": "^4.1.1",
     "tslint-eslint-rules": "^3.1.0",
-    "typescript": "2.2.1",
+    "typescript": "2.3.4",
     "vrsource-tslint-rules": "^4.0.0",
     "webdriver-manager": "^12.0.6",
     "webdriverio": "^4.8.0",

--- a/tsconfig-esm-node.json
+++ b/tsconfig-esm-node.json
@@ -12,6 +12,7 @@
     "noEmitOnError": false,
     "stripInternal": true,
     "sourceMap": true,
+    "downlevelIteration": true,
     "moduleResolution": "node",
     "lib": ["es5", "dom", "es2015.promise"]
   },

--- a/tsconfig-node.json
+++ b/tsconfig-node.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5",
+    "noImplicitAny": true,
+    "noImplicitReturns": false,
+    "noImplicitThis": false,
+    "outDir": "build",
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "noEmitOnError": false,
+    "stripInternal": false,
+    "lib": ["es5", "dom", "es2015.promise"]
+  },
+  "exclude": [
+    "node_modules",
+    "build",
+    "build-esm",
+    "dist",
+    "lib/closure"
+  ]
+}


### PR DESCRIPTION
fix #892 

1. upgrade to `typescript` 2.3.4 (current `angular` version)
2. set `downlevelIteration` to true in `tsconfig` when building `zone-node.js` to compile `for..of` which can handle `generators`.

travis build failed because `saucelabs` failed to start `safari 10` on `macOS 10.12`, so it will be passed after #896  to be merged.