### PR TITLE
fix(promise): can set native promise after loading zone.js

### DIFF
--- a/karma-base.conf.js
+++ b/karma-base.conf.js
@@ -16,6 +16,7 @@ module.exports = function (config) {
       {pattern: 'node_modules/rxjs/**/**/*.js', included: false, watched: false },
       {pattern: 'node_modules/rxjs/**/**/*.js.map', included: false, watched: false },
       {pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false },
+      {pattern: 'node_modules/es6-promise/**/*.js', included: false, watched: false },
       {pattern: 'node_modules/rxjs/**/*.js.map', included: false, watched: false },
       {pattern: 'test/assets/**/*.*', watched: true, served: true, included: false},
       {pattern: 'build/**/*.js.map', watched: true, served: true, included: false},

--- a/karma-dist-sauce-jasmine.conf.js
+++ b/karma-dist-sauce-jasmine.conf.js
@@ -8,5 +8,5 @@
 
 module.exports = function (config) {
   require('./karma-dist-jasmine.conf.js')(config);
-  require('./sauce.conf')(config);
+  require('./sauce.conf')(config, ['SL_IOS9']);
 };

--- a/lib/common/promise.ts
+++ b/lib/common/promise.ts
@@ -330,6 +330,44 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
   ZoneAwarePromise['all'] = ZoneAwarePromise.all;
 
   const NativePromise = global[symbolPromise] = global['Promise'];
+  const ZONE_AWARE_PROMISE = Zone.__symbol__('ZoneAwarePromise');
+
+  let desc = Object.getOwnPropertyDescriptor(global, 'Promise');
+  if (!desc || desc.configurable) {
+    desc && delete desc.writable;
+    desc && delete desc.value;
+    if (!desc) {
+      desc = {configurable: true, enumerable: true};
+    }
+    desc.get = function() {
+      // if we already set ZoneAwarePromise, use patched one
+      // otherwise return native one.
+      return global[ZONE_AWARE_PROMISE] ? global[ZONE_AWARE_PROMISE] : global[symbolPromise];
+    };
+    desc.set = function(NewNativePromise) {
+      if (NewNativePromise === ZoneAwarePromise) {
+        // if the NewNativePromise is ZoneAwarePromise
+        // save to global
+        global[ZONE_AWARE_PROMISE] = NewNativePromise;
+      } else {
+        // if the NewNativePromise is not ZoneAwarePromise
+        // for example: after load zone.js, some library just
+        // set es6-promise to global, if we set it to global
+        // directly, assertZonePatched will fail and angular
+        // will not loaded, so we just set the NewNativePromise
+        // to global[symbolPromise], so the result is just like
+        // we load ES6 Promise before zone.js
+        global[symbolPromise] = NewNativePromise;
+        if (!NewNativePromise.prototype[symbolThen]) {
+          patchThen(NewNativePromise);
+        }
+        api.setNativePromise(NewNativePromise);
+      }
+    };
+
+    Object.defineProperty(global, 'Promise', desc);
+  }
+
   global['Promise'] = ZoneAwarePromise;
 
   const symbolThenPatched = __symbol__('thenPatched');

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -322,6 +322,7 @@ interface _ZonePrivate {
   showUncaughtError: () => boolean;
   patchEventTarget: (global: any, apis: any[], options?: any) => boolean[];
   patchOnProperties: (obj: any, properties: string[]) => void;
+  setNativePromise: (nativePromise: any) => void;
   patchMethod:
       (target: any, name: string,
        patchFn: (delegate: Function, delegateName: string, name: string) =>
@@ -1318,6 +1319,9 @@ const Zone: ZoneType = (function(global: any) {
     patchEventTarget: () => [],
     patchOnProperties: noop,
     patchMethod: () => noop,
+    setNativePromise: (NativePromise: any) => {
+      nativeMicroTaskQueuePromise = NativePromise.resolve(0);
+    },
   };
   let _currentZoneFrame: _ZoneFrame = {parent: null, zone: new Zone(null, null)};
   let _currentTask: Task = null;

--- a/sauce.conf.js
+++ b/sauce.conf.js
@@ -1,10 +1,10 @@
 // Sauce configuration
 
-module.exports = function (config) {
+module.exports = function (config, ignoredLaunchers) {
   // The WS server is not available with Sauce
   config.files.unshift('test/saucelabs.js');
 
-  var customLaunchers = {
+  var basicLaunchers = {
     'SL_CHROME': {
       base: 'SauceLabs',
       browserName: 'chrome',
@@ -152,6 +152,17 @@ module.exports = function (config) {
       platformVersion: '7.1'
     }
   };
+
+  var customLaunchers = {};
+  if (!ignoredLaunchers) {
+    customLaunchers = basicLaunchers;
+  } else {
+    Object.keys(basicLaunchers).forEach(function(key) {
+      if (ignoredLaunchers.filter(function(ignore) {return ignore === key;}).length === 0) {
+        customLaunchers[key] = basicLaunchers[key];
+      }
+    });
+  }
 
   config.set({
     captureTimeout: 120000,

--- a/test/common/Promise.spec.ts
+++ b/test/common/Promise.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {isNode} from '../../lib/common/utils';
+import {isNode, zoneSymbol} from '../../lib/common/utils';
 import {ifEnvSupports} from '../test-util';
 
 declare const global: any;
@@ -56,6 +56,31 @@ describe(
         queueZone = Zone.current.fork(new MicroTaskQueueZoneSpec());
 
         log = [];
+      });
+
+      xit('should allow set es6 Promise after load ZoneAwarePromise', (done) => {
+        const ES6Promise = require('es6-promise').Promise;
+        const NativePromise = global[zoneSymbol('Promise')];
+
+        try {
+          global['Promise'] = ES6Promise;
+          Zone.assertZonePatched();
+          expect(global[zoneSymbol('Promise')]).toBe(ES6Promise);
+          const promise = Promise.resolve(0);
+          console.log('promise', promise);
+          promise
+              .then(value => {
+                expect(value).toBe(0);
+                done();
+              })
+              .catch(error => {
+                fail(error);
+              });
+        } finally {
+          global['Promise'] = NativePromise;
+          Zone.assertZonePatched();
+          expect(global[zoneSymbol('Promise')]).toBe(NativePromise);
+        }
       });
 
       it('should pretend to be a native code', () => {

--- a/test/common/zone.spec.ts
+++ b/test/common/zone.spec.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {zoneSymbol} from '../../lib/common/utils';
 
 describe('Zone', function() {
   const rootZone = Zone.current;
@@ -326,17 +327,23 @@ describe('Zone', function() {
         Zone.assertZonePatched();
       });
 
-      it('should throw when Promise has been patched', () => {
-        class WrongPromise {}
+      it('should keep ZoneAwarePromise has been patched', () => {
+        class WrongPromise {
+          static resolve(value: any) {}
+
+          then() {}
+        }
 
         const ZoneAwarePromise = global.Promise;
+        const NativePromise = (global as any)[zoneSymbol('Promise')];
         global.Promise = WrongPromise;
         try {
           expect(ZoneAwarePromise).toBeTruthy();
-          expect(() => Zone.assertZonePatched()).toThrow();
+          Zone.assertZonePatched();
+          expect(global.Promise).toBe(ZoneAwarePromise);
         } finally {
           // restore it.
-          global.Promise = ZoneAwarePromise;
+          global.Promise = NativePromise;
         }
         Zone.assertZonePatched();
       });

--- a/test/main.ts
+++ b/test/main.ts
@@ -16,7 +16,10 @@ __karma__.loaded = function() {};
 (window as any).global = window;
 System.config({
   defaultJSExtensions: true,
-  map: {'rxjs': 'base/node_modules/rxjs'},
+  map: {
+    'rxjs': 'base/node_modules/rxjs',
+    'es6-promise': 'base/node_modules/es6-promise/dist/es6-promise'
+  },
 });
 
 let browserPatchedPromise: any = null;

--- a/test/rxjs/rxjs.Observable.combine.spec.ts
+++ b/test/rxjs/rxjs.Observable.combine.spec.ts
@@ -51,13 +51,11 @@ describe('Observable.combine', () => {
        const constructorZone1: Zone = Zone.current.fork({name: 'Constructor Zone1'});
        const subscriptionZone: Zone = Zone.current.fork({name: 'Subscription Zone'});
        observable1 = constructorZone1.run(() => {
-         const source = Rx.Observable.interval(10);
-         const highOrder = source
-                               .map((src: any) => {
-                                 expect(Zone.current.name).toEqual(constructorZone1.name);
-                                 return Rx.Observable.interval(50).take(3);
-                               })
-                               .take(2);
+         const source = Rx.Observable.of(1, 2, 3);
+         const highOrder = source.map((src: any) => {
+           expect(Zone.current.name).toEqual(constructorZone1.name);
+           return Rx.Observable.of(src);
+         });
          return highOrder.combineAll((x: any, y: any) => {
            expect(Zone.current.name).toEqual(constructorZone1.name);
            return {x: x, y: y};
@@ -76,14 +74,10 @@ describe('Observable.combine', () => {
              () => {
                log.push('completed');
                expect(Zone.current.name).toEqual(subscriptionZone.name);
-               expect(log).toEqual([
-                 {x: 0, y: 0}, {x: 1, y: 0}, {x: 1, y: 1}, {x: 2, y: 1}, {x: 2, y: 2}, 'completed'
-               ]);
+               expect(log).toEqual([{x: 1, y: 2}, 'completed']);
                done();
              });
        });
-
-       expect(log).toEqual([]);
      }, Zone.root));
 
   it('combineLatest func callback should run in the correct zone', () => {


### PR DESCRIPTION
fix #898, #891, #783 

currently after loading `zone.js`, if we load some libraries which will override `global Promise`, `Zone.assertZonePatched` will throw error, and `angular` will not started. 
Sometimes we use 3rd party libraries and hard to control the load orders. So we need a better way to handle this process.

in this PR.

1. patch `global.Promise` with a setter by using Object.defineProperty , so after loading `zone.js`, if a new Promise want to override `global.Promise`, it will not update the `global.Promise`, but update the underlying `NativePromise`, so the whole process will be:

   - before loading `zone.js`, `NativePromise` is Browser built in Promise.
   - load `zone.js`, global.Promise is `ZoneAwarePromise`, global[symbolPromise] is `NativePromise`.
   - after loading `zone.js`, set other Promise, such as `es6-promise`, global.Promise is still `ZoneAwarePromise`, and global[symbolPromise] will be updated to `es6-promise`.

2. Zone.assertZonePatched will only throw error when user set this before loading `zone.js`

```javascript
__Zone_disable_Promise = true;
```