### PR TITLE
fix(event): add test cases for EventTarget patch for Samsung tv

### DIFF
--- a/lib/common/events.ts
+++ b/lib/common/events.ts
@@ -91,9 +91,12 @@ export function patchEventTarget(
 
   // global shared zoneAwareCallback to handle all event callback with capture = false
   const globalZoneAwareCallback = function(event: Event) {
+    if (!event) {
+      return;
+    }
     // event.target is needed for Samusung TV and SourceBuffer
     // || global is needed https://github.com/angular/zone.js/issues/190
-    const target: any = this || event && event.target || _global;
+    const target: any = this || event.target || _global;
     const tasks = target[zoneSymbolEventNames[event.type][FALSE_STR]];
     if (tasks) {
       // invoke all tasks which attached to current target with given event.type and capture = false
@@ -114,9 +117,12 @@ export function patchEventTarget(
 
   // global shared zoneAwareCallback to handle all event callback with capture = true
   const globalZoneAwareCaptureCallback = function(event: Event) {
+    if (!event) {
+      return;
+    }
     // event.target is needed for Samusung TV and SourceBuffer
     // || global is needed https://github.com/angular/zone.js/issues/190
-    const target: any = this || event && event.target || _global;
+    const target: any = this || event.target || _global;
     const tasks = target[zoneSymbolEventNames[event.type][TRUE_STR]];
     if (tasks) {
       // invoke all tasks which attached to current target with given event.type and capture = false

--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -89,12 +89,14 @@ export const isMix: boolean = typeof _global.process !== 'undefined' &&
 
 const ON_PROPERTY_HANDLER_SYMBOL = zoneSymbol('onPropertyHandler');
 const zoneSymbolEventNames: {[eventName: string]: string} = {};
+
 const wrapFn = function(event: Event) {
   let eventNameSymbol = zoneSymbolEventNames[event.type];
   if (!eventNameSymbol) {
     eventNameSymbol = zoneSymbolEventNames[event.type] = zoneSymbol('ON_PROPERTY' + event.type);
   }
-  const listener = this[eventNameSymbol];
+  const target = this || event && event.target || _global;
+  const listener = target[eventNameSymbol];
   let result = listener && listener.apply(this, arguments);
 
   if (result != undefined && !result) {

--- a/test/browser/browser.spec.ts
+++ b/test/browser/browser.spec.ts
@@ -9,7 +9,7 @@
 import {patchFilteredProperties} from '../../lib/browser/property-descriptor';
 import {patchEventTarget} from '../../lib/common/events';
 import {isBrowser, isIEOrEdge, isMix, zoneSymbol} from '../../lib/common/utils';
-import {ifEnvSupports, ifEnvSupportsWithDone} from '../test-util';
+import {getIEVersion, ifEnvSupports, ifEnvSupportsWithDone} from '../test-util';
 
 import Spy = jasmine.Spy;
 declare const global: any;
@@ -234,6 +234,11 @@ describe('Zone', function() {
 
           it('event handler with null context should use event.target',
              ifEnvSupports(canPatchOnProperty(Document.prototype, 'onmousedown'), function() {
+               const ieVer = getIEVersion();
+               if (ieVer && ieVer === 9) {
+                 // in ie9, this is window object even we call func.apply(undefined)
+                 return;
+               }
                const logs: string[] = [];
                const EventTarget = (window as any)['EventTarget'];
                let oriAddEventListener = EventTarget && EventTarget.prototype ?

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -96,3 +96,11 @@ export function asyncTest(testFn: Function, zone: Zone = Zone.current) {
     asyncTestZone.run(testFn, this, [done]);
   };
 }
+
+export function getIEVersion() {
+  const userAgent = navigator.userAgent.toLowerCase();
+  if (userAgent.indexOf('msie') != -1) {
+    return parseInt(userAgent.split('msie')[1]);
+  }
+  return null;
+}


### PR DESCRIPTION
1. handle `this` maybe null for `onProperty` when user use such as `sourceBuffer.onupdate`.
2. add test cases.