### PR TITLE
fix(event): should handle event.stopImmediatePropagration

### DIFF
--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -15,9 +15,14 @@ import {patchTimer} from '../common/timers';
 import {patchClass, patchMacroTask, patchMethod, patchOnProperties, patchPrototype, zoneSymbol} from '../common/utils';
 
 import {propertyPatch} from './define-property';
-import {eventTargetPatch} from './event-target';
+import {eventTargetPatch, patchEvent} from './event-target';
 import {propertyDescriptorPatch} from './property-descriptor';
 import {registerElementPatch} from './register-element';
+
+Zone.__load_patch('util', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  api.patchOnProperties = patchOnProperties;
+  api.patchMethod = patchMethod;
+});
 
 Zone.__load_patch('timers', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   const set = 'set';
@@ -46,6 +51,7 @@ Zone.__load_patch('blocking', (global: any, Zone: ZoneType, api: _ZonePrivate) =
 });
 
 Zone.__load_patch('EventTarget', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  patchEvent(global, api);
   eventTargetPatch(global, api);
   // patch XMLHttpRequestEventTarget's addEventListener/removeEventListener
   const XMLHttpRequestEventTarget = (global as any)['XMLHttpRequestEventTarget'];
@@ -239,9 +245,4 @@ Zone.__load_patch('PromiseRejectionEvent', (global: any, Zone: ZoneType, api: _Z
     (Zone as any)[zoneSymbol('rejectionHandledHandler')] =
         findPromiseRejectionHandler('rejectionhandled');
   }
-});
-
-Zone.__load_patch('util', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
-  api.patchOnProperties = patchOnProperties;
-  api.patchMethod = patchMethod;
 });

--- a/lib/browser/event-target.ts
+++ b/lib/browser/event-target.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {FALSE_STR, globalSources, patchEventTarget, TRUE_STR, ZONE_SYMBOL_PREFIX, zoneSymbolEventNames} from '../common/events';
+import {FALSE_STR, globalSources, patchEventPrototype, patchEventTarget, TRUE_STR, ZONE_SYMBOL_PREFIX, zoneSymbolEventNames} from '../common/events';
 import {attachOriginToPatched, isIEOrEdge, zoneSymbol} from '../common/utils';
 
 import {eventNames} from './property-descriptor';
@@ -105,4 +105,8 @@ export function eventTargetPatch(_global: any, api: _ZonePrivate) {
   api.patchEventTarget = patchEventTarget;
 
   return true;
+}
+
+export function patchEvent(global: any, api: _ZonePrivate) {
+  patchEventPrototype(global, api);
 }


### PR DESCRIPTION
should handle `event.stopImmediatePropagation`, so if multiple listeners was added, one listener call event.stopImmediatePropagation, the remaining listeners should not be invoked.