### PR TITLE
fix(event): fix #883, fix RTCPeerConnection Safari event not triggered issue.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,6 +137,14 @@ gulp.task('build/webapis-notification.min.js', ['compile-esm'], function(cb) {
     return generateScript('./lib/browser/webapis-notification.ts', 'webapis-notification.min.js', true, cb);
 });
 
+gulp.task('build/webapis-rtc-peer-connection.js', ['compile-esm'], function(cb) {
+  return generateScript('./lib/browser/webapis-rtc-peer-connection.ts', 'webapis-rtc-peer-connection.js', false, cb);
+});
+
+gulp.task('build/webapis-rtc-peer-connection.min.js', ['compile-esm'], function(cb) {
+  return generateScript('./lib/browser/webapis-rtc-peer-connection.ts', 'webapis-rtc-peer-connection.min.js', true, cb);
+});
+
 gulp.task('build/webapis-shadydom.js', ['compile-esm'], function(cb) {
     return generateScript('./lib/browser/shadydom.ts', 'webapis-shadydom.js', false, cb);
 });
@@ -245,6 +253,8 @@ gulp.task('build', [
   'build/webapis-media-query.min.js',
   'build/webapis-notification.js',
   'build/webapis-notification.min.js',
+  'build/webapis-rtc-peer-connection.js',
+  'build/webapis-rtc-peer-connection.min.js',
   'build/webapis-shadydom.js',
   'build/webapis-shadydom.min.js',
   'build/zone-patch-cordova.js',

--- a/lib/browser/webapis-rtc-peer-connection.ts
+++ b/lib/browser/webapis-rtc-peer-connection.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+Zone.__load_patch('RTCPeerConnection', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  const RTCPeerConnection = global['RTCPeerConnection'];
+  if (!RTCPeerConnection) {
+    return;
+  }
+
+  const addSymbol = api.symbol('addEventListener');
+  const removeSymbol = api.symbol('removeEventListener');
+
+  RTCPeerConnection.prototype.addEventListener = RTCPeerConnection.prototype[addSymbol];
+  RTCPeerConnection.prototype.removeEventListener = RTCPeerConnection.prototype[removeSymbol];
+
+  // RTCPeerConnection extends EventTarget, so we must clear the symbol
+  // to allow pathc RTCPeerConnection.prototype.addEventListener again
+  RTCPeerConnection.prototype[addSymbol] = null;
+  RTCPeerConnection.prototype[removeSymbol] = null;
+
+  api.patchEventTarget(global, [RTCPeerConnection.prototype], {useGlobalCallback: false});
+});


### PR DESCRIPTION
fix #883.

in safari, when trigger RTCPeerConnection event handler `this` context is not the same with the event target when `addEventListener`.

```javascript
<html>
  <head>
    <!--<script src="https://cdnjs.cloudflare.com/ajax/libs/zone.js/0.8.16/zone.js"></script>-->
    <script>
      window.onload = function () {
          console.log('Create RTCPeerConnection')
          const pc = new RTCPeerConnection()

          console.log('Add "track" event listener')
          let event
          pc.addEventListener('track', function(_event) {
            console.log('this === pc', this === pc);
            console.log('track event', _event);
            event = _event
          });
          /*pc.ontrack = function(_event) {
            console.log('this === pc', this === pc);
            console.log('track event', _event);
            event = _event
          };*/

          console.log('Dispatch "track" event')
          pc.dispatchEvent(new Event('track'))

          if (event) {
            console.log('Success!')
          } else {
            console.error('Failure!')
       }
      }
    </script>
  </head>
</html>
```

in above case, `this === pc` will be false.

So in this PR, we allow user to load an additional js `webapis-rtc-peer-connection.js` to let `zone.js` patch `RTCPeerConnection` without using the `globalCallback`.

to make this PR available, please load the js as following order.

```javascript
 <script src="node_modules/zone.js/dist/zone.js"></script>
 <script src="node_modules/zone.js/dist/webapis-rtc-peer-connection.js"></script>
```