### PR TITLE
Add newline to separate @fileoverview comment from a node.

### DIFF
--- a/lib/common/events.ts
+++ b/lib/common/events.ts
@@ -9,6 +9,7 @@
  * @fileoverview
  * @suppress {missingRequire}
  */
+
 import {attachOriginToPatched, zoneSymbol} from './utils';
 
 export const TRUE_STR = 'true';


### PR DESCRIPTION
The recent change in tsickle to handle @fileoverview comments in a transformer slightly changed our semantics, so the @fileoverview comment was getting lost.  A proper fix in tsickle is forthcoming.