### PR TITLE
fix(event): fix #911, in IE, event handler event maybe undefined

### DIFF
--- a/lib/common/events.ts
+++ b/lib/common/events.ts
@@ -94,6 +94,9 @@ export function patchEventTarget(
 
   // global shared zoneAwareCallback to handle all event callback with capture = false
   const globalZoneAwareCallback = function(event: Event) {
+    // https://github.com/angular/zone.js/issues/911, in IE, sometimes
+    // event will be undefined, so we need to use window.event
+    event = event || _global.event;
     if (!event) {
       return;
     }
@@ -123,6 +126,9 @@ export function patchEventTarget(
 
   // global shared zoneAwareCallback to handle all event callback with capture = true
   const globalZoneAwareCaptureCallback = function(event: Event) {
+    // https://github.com/angular/zone.js/issues/911, in IE, sometimes
+    // event will be undefined, so we need to use window.event
+    event = event || _global.event;
     if (!event) {
       return;
     }

--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -87,15 +87,20 @@ export const isMix: boolean = typeof _global.process !== 'undefined' &&
     {}.toString.call(_global.process) === '[object process]' && !isWebWorker &&
     !!(typeof window !== 'undefined' && (window as any)['HTMLElement']);
 
-const ON_PROPERTY_HANDLER_SYMBOL = zoneSymbol('onPropertyHandler');
 const zoneSymbolEventNames: {[eventName: string]: string} = {};
 
 const wrapFn = function(event: Event) {
+  // https://github.com/angular/zone.js/issues/911, in IE, sometimes
+  // event will be undefined, so we need to use window.event
+  event = event || _global.event;
+  if (!event) {
+    return;
+  }
   let eventNameSymbol = zoneSymbolEventNames[event.type];
   if (!eventNameSymbol) {
     eventNameSymbol = zoneSymbolEventNames[event.type] = zoneSymbol('ON_PROPERTY' + event.type);
   }
-  const target = this || event && event.target || _global;
+  const target = this || event.target || _global;
   const listener = target[eventNameSymbol];
   let result = listener && listener.apply(this, arguments);
 


### PR DESCRIPTION
fix #911,
sometimes in `IE`, event handler will have an `undefined` event parameter.
we can use `window.event` in this case. 
https://developer.mozilla.org/en-US/docs/Web/API/Window/event