### PR TITLE
fix(promise): fix #891, sometimes NativePromise will not ready, and reduce zone.js size

### DIFF
--- a/lib/common/events.ts
+++ b/lib/common/events.ts
@@ -531,7 +531,7 @@ export function patchEventTarget(
           const captureTasks = target[symbolCaptureEventName];
 
           if (tasks) {
-            const removeTasks = [...tasks];
+            const removeTasks = tasks.slice();
             for (let i = 0; i < removeTasks.length; i++) {
               const task = removeTasks[i];
               let delegate = task.originalDelegate ? task.originalDelegate : task.callback;
@@ -540,7 +540,7 @@ export function patchEventTarget(
           }
 
           if (captureTasks) {
-            const removeTasks = [...captureTasks];
+            const removeTasks = captureTasks.slice();
             for (let i = 0; i < removeTasks.length; i++) {
               const task = removeTasks[i];
               let delegate = task.originalDelegate ? task.originalDelegate : task.callback;

--- a/lib/common/promise.ts
+++ b/lib/common/promise.ts
@@ -243,7 +243,8 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
       let resolve: (v: any) => void;
       let reject: (v: any) => void;
       let promise: any = new this((res, rej) => {
-        [resolve, reject] = [res, rej];
+        resolve = res;
+        reject = rej;
       });
       function onResolve(value: any) {
         promise && (promise = null || resolve(value));

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1320,7 +1320,12 @@ const Zone: ZoneType = (function(global: any) {
     patchOnProperties: noop,
     patchMethod: () => noop,
     setNativePromise: (NativePromise: any) => {
-      nativeMicroTaskQueuePromise = NativePromise.resolve(0);
+      // sometimes NativePromise.resolve static function
+      // is not ready yet, (such as core-js/es6.promise)
+      // so we need to check here.
+      if (NativePromise && typeof NativePromise.resolve === FUNCTION) {
+        nativeMicroTaskQueuePromise = NativePromise.resolve(0);
+      }
     },
   };
   let _currentZoneFrame: _ZoneFrame = {parent: null, zone: new Zone(null, null)};

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -9,6 +9,7 @@
     "inlineSourceMap": false,
     "inlineSources": false,
     "declaration": true,
+    "downlevelIteration": false,
     "noEmitOnError": false,
     "stripInternal": true,
     "sourceMap": true,


### PR DESCRIPTION
fix #891 
1. sometimes NativePromise will not be fully ready when override global.Promise, we should add check about it.
2. now by default, typescript 2.3 will compile `iterable` and `spread operator` with new polyfill code and will make `dist/zone.js` bigger, and we don't really have to use `iterable` and `spread`, so we use simple loop to reduce the `zone.js` size.