### PR TITLE
fix(patch): fix #925, patch navigator.getUserMedia

### DIFF
--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -12,7 +12,7 @@
 
 import {findEventTasks} from '../common/events';
 import {patchTimer} from '../common/timers';
-import {patchClass, patchMacroTask, patchMethod, patchOnProperties, patchPrototype, zoneSymbol} from '../common/utils';
+import {patchClass, patchMacroTask, patchMethod, patchOnProperties, patchPrototype, wrapFunctionArgs, zoneSymbol} from '../common/utils';
 
 import {propertyPatch} from './define-property';
 import {eventTargetPatch, patchEvent} from './event-target';
@@ -218,6 +218,13 @@ Zone.__load_patch('geolocation', (global: any, Zone: ZoneType, api: _ZonePrivate
   /// GEO_LOCATION
   if (global['navigator'] && global['navigator'].geolocation) {
     patchPrototype(global['navigator'].geolocation, ['getCurrentPosition', 'watchPosition']);
+  }
+});
+
+Zone.__load_patch('getUserMedia', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  let navigator = global['navigator'];
+  if (navigator && navigator.getUserMedia) {
+    navigator.getUserMedia = wrapFunctionArgs(navigator.getUserMedia);
   }
 });
 

--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -31,6 +31,14 @@ export function bindArguments(args: any[], source: string): any[] {
   return args;
 }
 
+export function wrapFunctionArgs(func: Function, source?: string): Function {
+  return function() {
+    const args = Array.prototype.slice.call(arguments);
+    const wrappedArgs = bindArguments(args, source ? source : (func as any).name);
+    return func.apply(this, wrappedArgs);
+  };
+}
+
 export function patchPrototype(prototype: any, fnNames: string[]) {
   const source = prototype.constructor['name'];
   for (let i = 0; i < fnNames.length; i++) {

--- a/test/common/util.spec.ts
+++ b/test/common/util.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {patchMethod, patchProperty, patchPrototype, zoneSymbol} from '../../lib/common/utils';
+import {patchMethod, patchProperty, patchPrototype, wrapFunctionArgs, zoneSymbol} from '../../lib/common/utils';
 
 describe('utils', function() {
 
@@ -327,6 +327,32 @@ describe('utils', function() {
         });
       });
       expect(log).toEqual(['property2<root>']);
+    });
+  });
+
+  describe('wrapFunctionArgs', () => {
+    it('wrapFunctionArgs should make function arguments in zone', () => {
+      const func = function(arg1: string, arg2: Function, arg3: Function) {
+        arg2(arg1);
+        arg3(arg1);
+      };
+
+      const zone = Zone.current.fork({name: 'wrap'});
+
+      wrapFunctionArgs(func);
+
+      zone.run(() => {
+        func(
+            'test',
+            function(arg: string) {
+              expect(arg).toEqual('test');
+              expect(Zone.current.name).toEqual(zone.name);
+            },
+            function(arg: string) {
+              expect(arg).toEqual('test');
+              expect(Zone.current.name).toEqual(zone.name);
+            });
+      });
     });
   });
 });

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -104,3 +104,8 @@ export function getIEVersion() {
   }
   return null;
 }
+
+export function isEdge() {
+  const userAgent = navigator.userAgent.toLowerCase();
+  return userAgent.indexOf('edge') !== -1;
+}


### PR DESCRIPTION
fix #925.

1. patch `navigator.getUserMedia(constraints, successCallback, errorCallback)` successCallback, errorCallback
2. provide a util method to patch function arguments.