### PR TITLE
fix(patch): fix #927, should not throw error when defineProperty with frozen desc

### DIFF
--- a/lib/browser/define-property.ts
+++ b/lib/browser/define-property.ts
@@ -69,12 +69,18 @@ function isUnconfigurable(obj: any, prop: any) {
 }
 
 function rewriteDescriptor(obj: any, prop: string, desc: any) {
-  desc.configurable = true;
+  // issue-927, if the desc is frozen, don't try to change the desc
+  if (!Object.isFrozen(desc)) {
+    desc.configurable = true;
+  }
   if (!desc.configurable) {
-    if (!obj[unconfigurablesKey]) {
+    // issue-927, if the obj is frozen, don't try to set the desc to obj
+    if (!obj[unconfigurablesKey] && !Object.isFrozen(obj)) {
       _defineProperty(obj, unconfigurablesKey, {writable: true, value: {}});
     }
-    obj[unconfigurablesKey][prop] = true;
+    if (obj[unconfigurablesKey]) {
+      obj[unconfigurablesKey][prop] = true;
+    }
   }
   return desc;
 }

--- a/test/browser/define-property.spec.ts
+++ b/test/browser/define-property.spec.ts
@@ -14,4 +14,16 @@ describe('defineProperty', function() {
         .not.toThrow();
   });
 
+  it('should not throw error when try to defineProperty with a frozen desc', function() {
+    const obj = {};
+    const desc = Object.freeze({value: null, writable: true});
+    Object.defineProperty(obj, 'prop', desc);
+  });
+
+  it('should not throw error when try to defineProperty with a frozen obj', function() {
+    const obj = {};
+    Object.freeze(obj);
+    Object.defineProperty(obj, 'prop', {configurable: true, writable: true, value: 'value'});
+  });
+
 });


### PR DESCRIPTION
fix #927.
should not throw error when defineProperty with frozen desc