### PR TITLE
fix(timer): setInterval should not auto cancel after callback invoked, fix rxjs version to pass CI

### DIFF
--- a/lib/common/timers.ts
+++ b/lib/common/timers.ts
@@ -39,6 +39,12 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
       try {
         task.invoke.apply(this, arguments);
       } finally {
+        if (task.data && task.data.isPeriodic) {
+          // issue-934, task will be cancelled
+          // even it is a periodic task such as
+          // setInterval
+          return;
+        }
         if (typeof data.handleId === NUMBER) {
           // in non-nodejs env, we remove timerId
           // from local cache

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "phantomjs": "^2.1.7",
     "promises-aplus-tests": "^2.1.2",
     "pump": "^1.0.1",
-    "rxjs": "5.4.2",
+    "rxjs": "^5.5.3",
     "selenium-webdriver": "^3.4.0",
     "systemjs": "^0.19.37",
     "ts-loader": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "phantomjs": "^2.1.7",
     "promises-aplus-tests": "^2.1.2",
     "pump": "^1.0.1",
-    "rxjs": "^5.4.2",
+    "rxjs": "5.4.2",
     "selenium-webdriver": "^3.4.0",
     "systemjs": "^0.19.37",
     "ts-loader": "^0.6.0",

--- a/test/browser/requestAnimationFrame.spec.ts
+++ b/test/browser/requestAnimationFrame.spec.ts
@@ -26,7 +26,7 @@ describe('requestAnimationFrame', function() {
 
                it('should bind to same zone when called recursively', function(done) {
                  const originalTimeout: number = (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL;
-                 (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = 5000;
+                 (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = 10000;
                  Zone.current.fork({name: 'TestZone'}).run(() => {
                    let frames = 0;
                    let previousTimeStamp = 0;

--- a/test/common/setInterval.spec.ts
+++ b/test/common/setInterval.spec.ts
@@ -61,30 +61,26 @@ describe('setInterval', function() {
   });
 
   it('should not cancel the task after invoke the setInterval callback', (done) => {
-    const logs: string[] = [];
-    const hasTaskSpy = jasmine.createSpy('hasTask');
+    const logs: HasTaskState[] = [];
     const zone = Zone.current.fork({
       name: 'interval',
       onHasTask:
           (delegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, hasTask: HasTaskState) => {
-            hasTaskSpy(hasTask);
+            logs.push(hasTask);
             return delegate.hasTask(targetZone, hasTask);
           }
     });
 
     zone.run(() => {
-      const timerId = setInterval(() => {
-        logs.push('interval invoked');
-      }, 100);
+      const timerId = setInterval(() => {}, 100);
       (global as any)[Zone.__symbol__('setTimeout')](() => {
         expect(logs.length > 0).toBeTruthy();
-        expect(hasTaskSpy)
-            .toHaveBeenCalledWith(
-                {microTask: false, macroTask: true, eventTask: false, change: 'macroTask'});
+        expect(logs).toEqual(
+            [{microTask: false, macroTask: true, eventTask: false, change: 'macroTask'}]);
         clearInterval(timerId);
-        expect(hasTaskSpy.calls.allArgs()).toEqual([
-          [{microTask: false, macroTask: true, eventTask: false, change: 'macroTask'}],
-          [{microTask: false, macroTask: false, eventTask: false, change: 'macroTask'}]
+        expect(logs).toEqual([
+          {microTask: false, macroTask: true, eventTask: false, change: 'macroTask'},
+          {microTask: false, macroTask: false, eventTask: false, change: 'macroTask'}
         ]);
         done();
       }, 300);

--- a/test/common/setInterval.spec.ts
+++ b/test/common/setInterval.spec.ts
@@ -60,4 +60,35 @@ describe('setInterval', function() {
     }, null, null, 'unit-test');
   });
 
+  it('should not cancel the task after invoke the setInterval callback', (done) => {
+    const logs: string[] = [];
+    const hasTaskSpy = jasmine.createSpy('hasTask');
+    const zone = Zone.current.fork({
+      name: 'interval',
+      onHasTask:
+          (delegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, hasTask: HasTaskState) => {
+            hasTaskSpy(hasTask);
+            return delegate.hasTask(targetZone, hasTask);
+          }
+    });
+
+    zone.run(() => {
+      const timerId = setInterval(() => {
+        logs.push('interval invoked');
+      }, 100);
+      (global as any)[Zone.__symbol__('setTimeout')](() => {
+        expect(logs.length > 0).toBeTruthy();
+        expect(hasTaskSpy)
+            .toHaveBeenCalledWith(
+                {microTask: false, macroTask: true, eventTask: false, change: 'macroTask'});
+        clearInterval(timerId);
+        expect(hasTaskSpy.calls.allArgs()).toEqual([
+          [{microTask: false, macroTask: true, eventTask: false, change: 'macroTask'}],
+          [{microTask: false, macroTask: false, eventTask: false, change: 'macroTask'}]
+        ]);
+        done();
+      }, 300);
+    });
+  });
+
 });


### PR DESCRIPTION
fix #934.
`setInterval` will auto clear timerId  after  first time invoked.
the issue was imported several versions ago, but it doesn't become a problem because we 
return `ZoneTask` from `setInterval` before `zone.js 0.8.17`, from `zone.js 0.8.18` , `setInterval` will return the original `timerId`, so when we call `clearInterval` the `timerId` have been cleared, which will cause zone.js `onHasTask` not be called, the `setInterval` task was always there.
And will cause `ngZone` not stable.

Also fix `rxjs` version to `5.4.2` to avoid `karam` error, I will continue to figure out how to resolve `karam` test error with `rxjs 5.5.0`. 
The issue is here, and it seems it will be fixed in `rxjs 5.5.1`
https://github.com/ReactiveX/rxjs/issues/2971