### PR TITLE
fix(fakeAsyncTest): fix #937, let user be able to customize testable macroTask

### DIFF
--- a/lib/zone-spec/fake-async-test.ts
+++ b/lib/zone-spec/fake-async-test.ts
@@ -181,6 +181,11 @@
         namePrefix: string, private trackPendingRequestAnimationFrame = false,
         private macroTaskOptions?: MacroTaskOptions[]) {
       this.name = 'fakeAsyncTestZone for ' + namePrefix;
+      // in case user can't access the construction of FakyAsyncTestSpec
+      // user can also define macroTaskOptions by define a global variable.
+      if (!this.macroTaskOptions) {
+        this.macroTaskOptions = global[Zone.__symbol__('FakeAsyncTestMacroTask')];
+      }
     }
 
     private _fnAndFlush(fn: Function, completers: {onSuccess?: Function, onError?: Function}):

--- a/lib/zone-spec/fake-async-test.ts
+++ b/lib/zone-spec/fake-async-test.ts
@@ -26,6 +26,7 @@
   interface MacroTaskOptions {
     source: string;
     isPeriodic?: boolean;
+    callbackArgs?: any;
   }
 
   class Scheduler {
@@ -370,15 +371,15 @@
               if (macroTaskOption) {
                 const args = task.data && (task.data as any)['args'];
                 const delay = args && args.length > 1 ? args[1] : 0;
+                let callbackArgs =
+                    macroTaskOption.callbackArgs ? macroTaskOption.callbackArgs : args;
                 if (!!macroTaskOption.isPeriodic) {
                   // periodic macroTask, use setInterval to simulate
-                  task.data['handleId'] =
-                      this._setInterval(task.invoke, delay, (task.data as any)['args']);
+                  task.data['handleId'] = this._setInterval(task.invoke, delay, callbackArgs);
                   task.data.isPeriodic = true;
                 } else {
                   // not periodic, use setTimout to simulate
-                  task.data['handleId'] =
-                      this._setTimeout(task.invoke, delay, (task.data as any)['args']);
+                  task.data['handleId'] = this._setTimeout(task.invoke, delay, callbackArgs);
                 }
                 break;
               }

--- a/test/test_fake_polyfill.ts
+++ b/test/test_fake_polyfill.ts
@@ -64,4 +64,5 @@
 
   global['__Zone_ignore_on_properties'] =
       [{target: TestTarget.prototype, ignoreProperties: ['prop1']}];
+  global['__zone_symbol__FakeAsyncTestMacroTask'] = [{source: 'TestClass.myTimeout'}];
 })(typeof window === 'object' && window || typeof self === 'object' && self || global);

--- a/test/zone-spec/fake-async-test.spec.ts
+++ b/test/zone-spec/fake-async-test.spec.ts
@@ -8,7 +8,7 @@
 
 import '../../lib/zone-spec/fake-async-test';
 
-import {isNode} from '../../lib/common/utils';
+import {isNode, patchMacroTask} from '../../lib/common/utils';
 import {ifEnvSupports} from '../test-util';
 
 function supportNode() {
@@ -715,4 +715,66 @@ describe('FakeAsyncTestZoneSpec', () => {
 
              });
            }));
+
+  describe('should allow user define which macroTask fakeAsyncTest', () => {
+    let FakeAsyncTestZoneSpec = (Zone as any)['FakeAsyncTestZoneSpec'];
+    let testZoneSpec: any;
+    let fakeAsyncTestZone: Zone;
+    it('should support custom non perodic macroTask', () => {
+      testZoneSpec = new FakeAsyncTestZoneSpec('name', false, [{source: 'TestClass.myTimeout'}]);
+      class TestClass {
+        myTimeout(callback: Function) {}
+      }
+      fakeAsyncTestZone = Zone.current.fork(testZoneSpec);
+      fakeAsyncTestZone.run(() => {
+        let ran = false;
+        patchMacroTask(
+            TestClass.prototype, 'myTimeout',
+            (self: any, args: any[]) =>
+                ({name: 'TestClass.myTimeout', target: self, callbackIndex: 0, args: args}));
+
+        const testClass = new TestClass();
+        testClass.myTimeout(() => {
+          ran = true;
+        });
+
+        expect(ran).toEqual(false);
+
+        testZoneSpec.tick();
+        expect(ran).toEqual(true);
+      });
+    });
+
+    it('should support custom perodic macroTask', () => {
+      testZoneSpec = new FakeAsyncTestZoneSpec(
+          'name', false, [{source: 'TestClass.myInterval', isPeriodic: true}]);
+      fakeAsyncTestZone = Zone.current.fork(testZoneSpec);
+      fakeAsyncTestZone.run(() => {
+        let cycle = 0;
+        class TestClass {
+          myInterval(callback: Function, interval: number): any {
+            return null;
+          }
+        }
+        patchMacroTask(
+            TestClass.prototype, 'myInterval',
+            (self: any, args: any[]) =>
+                ({name: 'TestClass.myInterval', target: self, callbackIndex: 0, args: args}));
+
+        const testClass = new TestClass();
+        const id = testClass.myInterval(() => {
+          cycle++;
+        }, 10);
+
+        expect(cycle).toEqual(0);
+
+        testZoneSpec.tick(10);
+        expect(cycle).toEqual(1);
+
+        testZoneSpec.tick(10);
+        expect(cycle).toEqual(2);
+        clearInterval(id);
+      });
+    });
+  });
 });

--- a/test/zone-spec/fake-async-test.spec.ts
+++ b/test/zone-spec/fake-async-test.spec.ts
@@ -721,7 +721,8 @@ describe('FakeAsyncTestZoneSpec', () => {
     let testZoneSpec: any;
     let fakeAsyncTestZone: Zone;
     it('should support custom non perodic macroTask', () => {
-      testZoneSpec = new FakeAsyncTestZoneSpec('name', false, [{source: 'TestClass.myTimeout'}]);
+      testZoneSpec = new FakeAsyncTestZoneSpec(
+          'name', false, [{source: 'TestClass.myTimeout', callbackArgs: ['test']}]);
       class TestClass {
         myTimeout(callback: Function) {}
       }
@@ -734,8 +735,9 @@ describe('FakeAsyncTestZoneSpec', () => {
                 ({name: 'TestClass.myTimeout', target: self, callbackIndex: 0, args: args}));
 
         const testClass = new TestClass();
-        testClass.myTimeout(() => {
+        testClass.myTimeout(function(callbackArgs: any) {
           ran = true;
+          expect(callbackArgs).toEqual('test');
         });
 
         expect(ran).toEqual(false);

--- a/test/zone-spec/fake-async-test.spec.ts
+++ b/test/zone-spec/fake-async-test.spec.ts
@@ -745,6 +745,32 @@ describe('FakeAsyncTestZoneSpec', () => {
       });
     });
 
+    it('should support custom non perodic macroTask by global flag', () => {
+      testZoneSpec = new FakeAsyncTestZoneSpec('name');
+      class TestClass {
+        myTimeout(callback: Function) {}
+      }
+      fakeAsyncTestZone = Zone.current.fork(testZoneSpec);
+      fakeAsyncTestZone.run(() => {
+        let ran = false;
+        patchMacroTask(
+            TestClass.prototype, 'myTimeout',
+            (self: any, args: any[]) =>
+                ({name: 'TestClass.myTimeout', target: self, callbackIndex: 0, args: args}));
+
+        const testClass = new TestClass();
+        testClass.myTimeout(() => {
+          ran = true;
+        });
+
+        expect(ran).toEqual(false);
+
+        testZoneSpec.tick();
+        expect(ran).toEqual(true);
+      });
+    });
+
+
     it('should support custom perodic macroTask', () => {
       testZoneSpec = new FakeAsyncTestZoneSpec(
           'name', false, [{source: 'TestClass.myInterval', isPeriodic: true}]);


### PR DESCRIPTION
fix #937 
let user be able to customize which macroTasks can be test with `fakeAsyncTestSpec`.
for example, in #937, user want to test `cavans.toBlob()`. with this PR, user can achieve it in two ways.

1. pass the options from `FakeAsyncTestSpec` constructor

```javascript
const testZoneSpec = new FakeAsyncTestZoneSpec('name', false, [{source: 'HTMLCanvasElement.toBlob'}]);
```

2. sometimes application test code can't access `FakeAsyncTestSpec` initialize process, so user can also define a global variable before load `fakeAsyncTest`.

- browser
```javascript
 window['__zone_symbol__FakeAsyncTestMacroTask'] = [{
     source: 'HTMLCanvasElement.toBlob',
     callbackArgs: ['testBlobData']  // the test blob data which will be passed back to callback
}];
```

- Node
```javascript
 global['__zone_symbol__FakeAsyncTestMacroTask'] = [{
     source: 'HTMLCanvasElement.toBlob',
     callbackArgs: ['testBlobData']  // the test blob data which will be passed back to callback
}];
```

@vikerman , please review.

And the CI will pass after #935 is merged (because rxjs 5.5.0's issue).