### PR TITLE
fix(promise): Update ZoneAwarePromise to better match Promise

### DIFF
--- a/lib/common/promise.ts
+++ b/lib/common/promise.ts
@@ -207,9 +207,9 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
     }
   }
 
-  function scheduleResolveOrReject<R, U1, U2>(
+  function scheduleResolveOrReject<R, U, V>(
       promise: ZoneAwarePromise<any>, zone: AmbientZone, chainPromise: ZoneAwarePromise<any>,
-      onFulfilled?: (value: R) => U1, onRejected?: (error: any) => U2): void {
+      onFulfilled?: (value: R) => U, onRejected?: (error: any) => V): void {
     clearRejectedNoCatch(promise);
     const delegate = (promise as any)[symbolState] ?
         (typeof onFulfilled === FUNCTION) ? onFulfilled : forwardResolution :
@@ -310,7 +310,7 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
         onFulfilled?: ((value: R) => TResult1 | PromiseLike<TResult1>)|undefined|null,
         onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>)|undefined|
         null): Promise<TResult1|TResult2> {
-      const chainPromise: Promise<TResult1|TResult2> =
+      const chainPromise: Promise<TResult1> =
           new (this.constructor as typeof ZoneAwarePromise)(null);
       const zone = Zone.current;
       if ((this as any)[symbolState] == UNRESOLVED) {


### PR DESCRIPTION
This allows zone.js to compile on Typescript 2.4 and above.

ZoneAwarePromise doesn't correctly extend Promise: `then` and `catch` both need to have different types for the `onRejected` return type (same is true of `scheduleResolveOrReject`). And the `value` parameter of `onFulfilled` should not be the same as the promised return type.

Typescript 2.6 also catches a location where type inference fails and requires a type argument.

I fixed the `ZoneAwarePromise` definition basically by copying the definition of `then` from `Promise`.

Fixes #939.