### PR TITLE
fix(core): fix #941, should use desc.toString when desc is not be able to stringify

### DIFF
--- a/lib/browser/define-property.ts
+++ b/lib/browser/define-property.ts
@@ -98,7 +98,7 @@ function _tryDefineProperty(obj: any, prop: string, desc: any, originalConfigura
         try {
           descJson = JSON.stringify(desc);
         } catch (error) {
-          descJson = descJson.toString();
+          descJson = desc.toString();
         }
         console.log(`Attempting to configure '${prop}' with descriptor '${descJson
                     }' on object '${obj}' and got error, giving up: ${error}`);


### PR DESCRIPTION
fix #941,
I think it just a typo.
