### PR TITLE
fix(mocha): use global if window does not exist

### DIFF
--- a/lib/mocha/mocha.ts
+++ b/lib/mocha/mocha.ts
@@ -170,4 +170,4 @@
 
   })(Mocha.Runner.prototype.runTest, Mocha.Runner.prototype.run);
 
-})(window);
+})(typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || global);


### PR DESCRIPTION
- `window` does not exist in NativeScript applications.
- this removes a hacky workaround where you assign `global.window` to `global` before including the mocha patch.
- preserve existing behavior by using window first if it exists.