### PR TITLE
fix(core): handle hybrid Event.prototype.stopImmediatePropagation

### DIFF
--- a/lib/common/events.ts
+++ b/lib/common/events.ts
@@ -595,6 +595,10 @@ export function patchEventPrototype(global: any, api: _ZonePrivate) {
         Event.prototype, 'stopImmediatePropagation',
         (delegate: Function) => function(self: any, args: any[]) {
           self[IMMEDIATE_PROPAGATION_SYMBOL] = true;
+          // we need to call the native stopImmediatePropagation
+          // in case in some hybrid application, some part of
+          // application will be controlled by zone, some are not
+          delegate && delegate.apply(self, args);
         });
   }
 }


### PR DESCRIPTION
fix #956.

in some hybrid case, some part of application will under control by `zone`, some are not, so in patched `Event.prototype.stopImmediatePropagation` , we need to call native one.