### PR TITLE
Use bare unpkg URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,12 @@
 
 Implements _Zones_ for JavaScript, inspired by [Dart](https://www.dartlang.org/articles/zones/).
 
-> If you're using zone.js via unpkg please provide a query param `?main=browser`  
-`https://unpkg.com/zone.js?main=browser`  
-> If you're using any of the following libraries, make sure you import them first 
+> If you're using zone.js via unpkg (i.e. using `https://unpkg.com/zone.js`)
+> and you're using any of the following libraries, make sure you import them first 
 
 > * 'newrelic' as it patches global.Promise before zone.js does
 > * 'async-listener' as it patches global.setTimeout, global.setInterval before zone.js does
-> * 'continuation-local-storage' as it uses async-listener 
+> * 'continuation-local-storage' as it uses async-listener
 
 # NEW Zone.js POST-v0.6.0
 
@@ -36,7 +35,7 @@ See this video from ng-conf 2014 for a detailed explanation:
 
 ## Standard API support
 
-zone.js patched most standard web APIs(such as DOM events, XMLHttpRequest...) and nodejs APIs 
+zone.js patched most standard web APIs(such as DOM events, XMLHttpRequest...) and nodejs APIs
 (EventEmitter,fs ...), for more details, please see [STANDARD-APIS.md](STANDARD-APIS.md).
 
 ## Non standard API support
@@ -47,8 +46,8 @@ Notification. Please see [NON-STANDARD-APIS.md](NON-STANDARD-APIS.md) for more d
 ## Modules
 
 zone.js patches the async APIs described above, but those patches will have some overhead.
-Starting from zone.js v0.8.9, you can choose which web API module you want to patch. 
-For more details, please 
+Starting from zone.js v0.8.9, you can choose which web API module you want to patch.
+For more details, please
 see [MODULE.md](MODULE.md).
 
 ## Promise A+ test passed

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Zones for JavaScript",
   "main": "dist/zone-node.js",
   "browser": "dist/zone.js",
+  "unpkg": "dist/zone.js",
   "typings": "dist/zone.js.d.ts",
   "files": [
     "lib",


### PR DESCRIPTION
This change adds an `unpkg` field to package.json that will allow users to load zone.js via https://unpkg.com/zone.js (i.e. w/out using the ?main=browser query parameter).

Also, just FYI, we're removing support for using the `browser` fallback on unpkg.com due to the fact that it was originally intended to be used by bundlers, which unpkg is not.

For more info, please see https://github.com/unpkg/unpkg/issues/63