### PR TITLE
fix(event): ignoreOnProperties also apply on addEventListener

### DIFF
--- a/STANDARD-APIS.md
+++ b/STANDARD-APIS.md
@@ -126,3 +126,23 @@ ZoneAwareError makes sure that `this` is ZoneAwareError even without new.
 
 ZoneAwarePromise wraps the global Promise and makes it run in zones as a MicroTask.
 It also passes promise A+ tests.
+
+## BlackListEvents
+
+Sometimes we don't want some `event` to be patched by `zone.js`, we can blacklist events
+by following settings.
+
+```javascript
+    // disable on properties
+    var targets = [window, Document, HTMLBodyElement, HTMLElement];
+    __Zone_ignore_on_properties = [];
+    targets.forEach(function (target) {
+      __Zone_ignore_on_properties.push({
+        target: target,
+        ignoreProperties: ['scroll']
+      });
+    });
+
+    // disable addEventListener
+    global['__zone_symbol__BLACK_LISTED_EVENTS'] = ['scroll'];
+```

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -51,6 +51,12 @@ Zone.__load_patch('blocking', (global: any, Zone: ZoneType, api: _ZonePrivate) =
 });
 
 Zone.__load_patch('EventTarget', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  // load blackListEvents from global
+  const SYMBOL_BLACK_LISTED_EVENTS = Zone.__symbol__('BLACK_LISTED_EVENTS');
+  if (global[SYMBOL_BLACK_LISTED_EVENTS]) {
+    (Zone as any)[SYMBOL_BLACK_LISTED_EVENTS] = global[SYMBOL_BLACK_LISTED_EVENTS];
+  }
+
   patchEvent(global, api);
   eventTargetPatch(global, api);
   // patch XMLHttpRequestEventTarget's addEventListener/removeEventListener

--- a/lib/common/events.ts
+++ b/lib/common/events.ts
@@ -298,6 +298,8 @@ export function patchEventTarget(
         patchOptions.compareTaskCallbackVsDelegate :
         compareTaskCallbackVsDelegate;
 
+    const blackListedEvents: string[] = (Zone as any)[Zone.__symbol__('BLACK_LISTED_EVENTS')];
+
     const makeAddListener = function(
         nativeListener: any, addSource: string, customScheduleFn: any, customCancelFn: any,
         returnTarget = false, prepend = false) {
@@ -326,6 +328,15 @@ export function patchEventTarget(
 
         const eventName = arguments[0];
         const options = arguments[2];
+
+        if (blackListedEvents) {
+          // check black list
+          for (let i = 0; i < blackListedEvents.length; i++) {
+            if (eventName === blackListedEvents[i]) {
+              return nativeListener.apply(this, arguments);
+            }
+          }
+        }
 
         let capture;
         let once = false;

--- a/test/browser/browser.spec.ts
+++ b/test/browser/browser.spec.ts
@@ -208,6 +208,23 @@ describe('Zone', function() {
             });
           });
 
+          it('should not patch ignored eventListener', function() {
+            let scrollEvent = document.createEvent('Event');
+            scrollEvent.initEvent('scroll', true, true);
+
+            const zone = Zone.current.fork({name: 'run'});
+
+            Zone.current.fork({name: 'scroll'}).run(() => {
+              document.addEventListener('scroll', () => {
+                expect(Zone.current.name).toEqual(zone.name);
+              });
+            });
+
+            zone.run(() => {
+              document.dispatchEvent(scrollEvent);
+            });
+          });
+
           it('window onclick should be in zone',
              ifEnvSupports(canPatchOnProperty(window, 'onmousedown'), function() {
                zone.run(function() {

--- a/test/test_fake_polyfill.ts
+++ b/test/test_fake_polyfill.ts
@@ -65,4 +65,5 @@
   global['__Zone_ignore_on_properties'] =
       [{target: TestTarget.prototype, ignoreProperties: ['prop1']}];
   global['__zone_symbol__FakeAsyncTestMacroTask'] = [{source: 'TestClass.myTimeout'}];
+  global['__zone_symbol__BLACK_LISTED_EVENTS'] = ['scroll'];
 })(typeof window === 'object' && window || typeof self === 'object' && self || global);


### PR DESCRIPTION
now `angular` blackList events work for 
- onProperty, such as `document.onscroll`
- HostListener, such as `  @HostListener('document:scroll')`

but not for `addEventListener` such as `document.addEventListener('scroll')`.

in this PR, I use `__zone_symbol__BLACK_LISTED_EVENTS` to also blacklist `addEventListener`.