### PR TITLE
fix(core): fix #969, should be able to access target/eventName info in onScheduleTask

### DIFF
--- a/lib/common/events.ts
+++ b/lib/common/events.ts
@@ -396,12 +396,23 @@ export function patchEventTarget(
         taskData.isExisting = isExisting;
 
         const data = useGlobalCallback ? OPTIMIZED_ZONE_EVENT_TASK_DATA : null;
+
+        // keep taskData into data to allow onScheduleEventTask to acess the task information
+        if (data) {
+          (data as any).taskData = taskData;
+        }
+
         const task: any =
             zone.scheduleEventTask(source, delegate, data, customScheduleFn, customCancelFn);
 
         // should clear taskData.target to avoid memory leak
         // issue, https://github.com/angular/angular/issues/20442
         taskData.target = null;
+
+        // need to clear up taskData because it is a global object
+        if (data) {
+          (data as any).taskData = null;
+        }
 
         // have to save those information to task in case
         // application may call task.zone.cancelTask() directly

--- a/test/browser/browser.spec.ts
+++ b/test/browser/browser.spec.ts
@@ -378,6 +378,40 @@ describe('Zone', function() {
         expect(eventListenerSpy).toHaveBeenCalled();
       });
 
+      it('should be able to access addEventListener information in onScheduleTask', function() {
+        const hookSpy = jasmine.createSpy('hook');
+        const eventListenerSpy = jasmine.createSpy('eventListener');
+        let scheduleButton;
+        let scheduleEventName;
+        let scheduleCapture;
+        let scheduleTask;
+        const zone = rootZone.fork({
+          name: 'spy',
+          onScheduleTask: (parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone,
+                           task: Task): any => {
+            hookSpy();
+            scheduleButton = (task.data as any).taskData.target;
+            scheduleEventName = (task.data as any).taskData.eventName;
+            scheduleCapture = (task.data as any).taskData.capture;
+            scheduleTask = task;
+            return parentZoneDelegate.scheduleTask(targetZone, task);
+          }
+        });
+
+        zone.run(function() {
+          button.addEventListener('click', eventListenerSpy);
+        });
+
+        button.dispatchEvent(clickEvent);
+
+        expect(hookSpy).toHaveBeenCalled();
+        expect(eventListenerSpy).toHaveBeenCalled();
+        expect(scheduleButton).toBe(button);
+        expect(scheduleEventName).toBe('click');
+        expect(scheduleCapture).toBe(false);
+        expect(scheduleTask && (scheduleTask as any).data.taskData).toBe(null);
+      });
+
       it('should support addEventListener on window', ifEnvSupports(windowPrototype, function() {
            const hookSpy = jasmine.createSpy('hook');
            const eventListenerSpy = jasmine.createSpy('eventListener');


### PR DESCRIPTION
fix #969.

Should be able to access `target/eventName/capture` information when using `addEventListener` in `onScheduleTask` callback. 

in `onScheduleTask`.

```javascript
   onScheduleTask: (parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone,
                           task: Task): any => {
            const target = (task.data as any).taskData.target;
            const eventName = (task.data as any).taskData.eventName;
            const capture = (task.data as any).taskData.capture;
            return parentZoneDelegate.scheduleTask(targetZone, task);
    }
```

in `onInvokeTask`, `onCancelTask`.

```javascript
onInvokeTask(
                 parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, task: Task,
                 applyThis: any, applyArgs: any) {
      const target = (task as any).target;
      const eventName = (task as any).eventName;
      const capture = (task as any).capture;
}
```

it is not consistent because of `performance` concern (don't want to create so many object).