### PR TITLE
fix(error): fix #979, should not attach non serializable info on error

### DIFF
--- a/lib/common/promise.ts
+++ b/lib/common/promise.ts
@@ -17,6 +17,7 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
   const _uncaughtPromiseErrors: UncaughtPromiseError[] = [];
   const symbolPromise = __symbol__('Promise');
   const symbolThen = __symbol__('then');
+  const creationTrace = '__creationTrace__';
 
   api.onUnhandledError = (e: any) => {
     if (api.showUncaughtError()) {
@@ -109,7 +110,7 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
   const TYPE_ERROR = 'Promise resolved with itself';
   const OBJECT = 'object';
   const FUNCTION = 'function';
-  const CURRENT_TASK_SYMBOL = __symbol__('currentTask');
+  const CURRENT_TASK_TRACE_SYMBOL = __symbol__('currentTaskTrace');
 
   // Promise Resolution
   function resolvePromise(
@@ -155,7 +156,15 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
         // record task information in value when error occurs, so we can
         // do some additional work such as render longStackTrace
         if (state === REJECTED && value instanceof Error) {
-          (value as any)[CURRENT_TASK_SYMBOL] = Zone.currentTask;
+          // check if longStackTraceZone is here
+          const trace = Zone.currentTask && Zone.currentTask.data &&
+              (Zone.currentTask.data as any)[creationTrace];
+          if (trace) {
+            // only keep the long stack trace into error when in longStackTraceZone
+            Object.defineProperty(
+                value, CURRENT_TASK_TRACE_SYMBOL,
+                {configurable: true, enumerable: false, writable: true, value: trace});
+          }
         }
 
         for (let i = 0; i < queue.length;) {

--- a/lib/zone-spec/long-stack-trace.ts
+++ b/lib/zone-spec/long-stack-trace.ts
@@ -87,8 +87,7 @@ function renderLongStackTrace(frames: LongStackTrace[], stack: string): string {
     if (!error) {
       return undefined;
     }
-    const task = (error as any)[(Zone as any).__symbol__('currentTask')];
-    const trace = task && task.data && task.data[creationTrace];
+    const trace = (error as any)[(Zone as any).__symbol__('currentTaskTrace')];
     if (!trace) {
       return error.stack;
     }

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1233,11 +1233,7 @@ const Zone: ZoneType = (function(global: any) {
         state: this.state,
         source: this.source,
         zone: this.zone.name,
-        invoke: this.invoke,
-        scheduleFn: this.scheduleFn,
-        cancelFn: this.cancelFn,
-        runCount: this.runCount,
-        callback: this.callback
+        runCount: this.runCount
       };
     }
   }


### PR DESCRIPTION
fix #979.

- should not keep a non serializable `ZoneTask` on `error` when `Promise.reject`.
- and don't save the `ZoneTask` instead save the error stacks to avoid memory leak.
- only save the information when `longStackTraceZone` in there.
