### PR TITLE
WIP(core): use asynchooks to resolve es2017 native async/await issue

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,6 +82,10 @@ gulp.task('compile-node', function(cb) {
   tsc('tsconfig-node.json', cb);
 });
 
+gulp.task('compile-node-es2017', function(cb) {
+  tsc('tsconfig-node.es2017.json', cb);
+});
+
 gulp.task('compile-esm', function(cb) {
   tsc('tsconfig-esm.json', cb);
 });
@@ -281,6 +285,11 @@ gulp.task('build', [
   'build/rxjs.min.js',
   'build/closure.js'
 ]);
+
+gulp.task('test/node2017', ['compile-node-es2017'], function(cb) {
+  var testAsyncPromise = require('./build/test/node_async').testAsyncPromise;
+  testAsyncPromise();
+});
 
 gulp.task('test/node', ['compile-node'], function(cb) {
   var JasmineRunner = require('jasmine');

--- a/lib/browser/define-property.ts
+++ b/lib/browser/define-property.ts
@@ -22,7 +22,7 @@ const OBJECT = 'object';
 const UNDEFINED = 'undefined';
 
 export function propertyPatch() {
-  Object.defineProperty = function(obj, prop, desc) {
+  Object.defineProperty = function(obj: any, prop: string, desc: any) {
     if (isUnconfigurable(obj, prop)) {
       throw new TypeError('Cannot assign to read only property \'' + prop + '\' of ' + obj);
     }
@@ -49,7 +49,7 @@ export function propertyPatch() {
     return _create(obj, proto);
   };
 
-  Object.getOwnPropertyDescriptor = function(obj, prop) {
+  Object.getOwnPropertyDescriptor = function(obj: any, prop: string) {
     const desc = _getOwnPropertyDescriptor(obj, prop);
     if (isUnconfigurable(obj, prop)) {
       desc.configurable = false;

--- a/lib/common/promise.ts
+++ b/lib/common/promise.ts
@@ -225,10 +225,15 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
   }
 
   const ZONE_AWARE_PROMISE_TO_STRING = 'function ZoneAwarePromise() { [native code] }';
+  type PROMISE = 'Promise';
 
   class ZoneAwarePromise<R> implements Promise<R> {
     static toString() {
       return ZONE_AWARE_PROMISE_TO_STRING;
+    }
+
+    get[Symbol.toStringTag]() {
+      return 'Promise' as PROMISE;
     }
 
     static resolve<R>(value: R): Promise<R> {

--- a/lib/node/async_promise.ts
+++ b/lib/node/async_promise.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * patch nodejs async operations (timer, promise, net...) with
+ * nodejs async_hooks
+ */
+Zone.__load_patch('node_async_hooks_promise', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  let async_hooks;
+  try {
+    async_hooks = require('async_hooks');
+  } catch (err) {
+    print(err.message);
+    return;
+  }
+
+  const PROMISE_PROVIDER = 'PROMISE';
+  const noop = function() {};
+
+  const idPromise: {[key: number]: any} = {};
+
+  function print(...args: string[]) {
+    if (!args) {
+      return;
+    }
+    (process as any)._rawDebug(args.join(' '));
+  }
+
+  function init(id: number, provider: string, triggerId: number, parentHandle: any) {
+    if (provider === PROMISE_PROVIDER) {
+      if (!parentHandle) {
+        print('no parenthandle');
+        return;
+      }
+      const promise = parentHandle.promise;
+      const originalThen = promise.then;
+
+      const zone = Zone.current;
+      if (zone.name === 'promise') {
+        print('init promise', id.toString());
+      }
+      if (!zone.parent) {
+        print('root zone');
+        return;
+      }
+      const currentAsyncContext: any = {};
+      currentAsyncContext.id = id;
+      currentAsyncContext.zone = zone;
+      idPromise[id] = currentAsyncContext;
+      promise.then = function(onResolve: any, onReject: any) {
+        const wrapped = new Promise((resolve, reject) => {
+          originalThen.call(this, resolve, reject);
+        });
+        if (zone) {
+          (wrapped as any).zone = zone;
+        }
+        return zone.run(() => {
+          return wrapped.then(onResolve, onReject);
+        });
+      };
+    }
+  }
+
+  function before(id: number) {
+    const currentAsyncContext = idPromise[id];
+    if (currentAsyncContext) {
+      print('before ' + id, currentAsyncContext.zone.name);
+      api.setAsyncContext(currentAsyncContext);
+    }
+  }
+
+  function after(id: number) {
+    const currentAsyncContext = idPromise[id];
+    if (currentAsyncContext) {
+      print('after ' + id, currentAsyncContext.zone.name);
+      idPromise[id] = null;
+      api.setAsyncContext(null);
+    }
+  }
+
+  function destroy(id: number) {
+    print('destroy ' + id);
+  }
+
+  async_hooks.createHook({init, before, after, destroy}).enable();
+});

--- a/test/node_async.ts
+++ b/test/node_async.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import '../lib/zone';
+import '../lib/common/promise';
+import '../lib/node/async_promise';
+import '../lib/common/to-string';
+import '../lib/node/node';
+
+const log: string[] = [];
+declare let process: any;
+
+function print(...args: string[]) {
+  if (!args) {
+    return;
+  }
+  (process as any)._rawDebug(args.join(' '));
+}
+
+const zone = Zone.current.fork({
+  name: 'promise',
+  onScheduleTask: (delegate: ZoneDelegate, curr: Zone, target: Zone, task: any) => {
+    log.push('scheduleTask');
+    return delegate.scheduleTask(target, task);
+  },
+  onInvokeTask: (delegate: ZoneDelegate, curr: Zone, target: Zone, task: any, applyThis: any,
+                 applyArgs: any) => {
+    log.push('invokeTask');
+    return delegate.invokeTask(target, task, applyThis, applyArgs);
+  }
+});
+
+print('before asyncoutside define');
+async function asyncOutside() {
+  return 'asyncOutside';
+}
+
+const neverResolved = new Promise(() => {});
+const waitForNever = new Promise((res, _) => {
+  res(neverResolved);
+});
+
+async function getNever() {
+  return waitForNever;
+} print('after asyncoutside define');
+
+export function testAsyncPromise() {
+  zone.run(async() => {
+    print('run async', Zone.current.name);
+    const outside = await asyncOutside();
+    print('get outside', Zone.current.name);
+    log.push(outside);
+
+    async function asyncInside() {
+      return 'asyncInside';
+    } print('define inside', Zone.current.name);
+
+    const inside = await asyncInside();
+    print('get inside', Zone.current.name);
+    log.push(inside);
+
+    print('log', log.join(' '));
+
+    const waitForNever = await getNever();
+    print('never');
+  });
+};

--- a/tsconfig-esm-node.json
+++ b/tsconfig-esm-node.json
@@ -21,6 +21,7 @@
     "build",
     "build-esm",
     "dist",
-    "lib/closure"
+    "lib/closure",
+    "test/node_async.ts"
   ]
 }

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -21,6 +21,7 @@
     "build",
     "build-esm",
     "dist",
-    "lib/closure"
+    "lib/closure",
+    "test/node_async.ts"
   ]
 }

--- a/tsconfig-node.es2017.json
+++ b/tsconfig-node.es2017.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
+    "target": "ES2017",
     "noImplicitAny": true,
     "noImplicitReturns": false,
     "noImplicitThis": false,
@@ -9,16 +9,16 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "declaration": false,
+    "downlevelIteration": true,
     "noEmitOnError": false,
     "stripInternal": false,
-    "lib": ["es5", "dom", "es2015.promise"]
+    "lib": ["es5", "dom", "es2017", "es2015.symbol"]
   },
   "exclude": [
     "node_modules",
     "build",
     "build-esm",
     "dist",
-    "lib/closure",
-    "test/node_async.ts"
+    "lib/closure"
   ]
 }

--- a/tsconfig-node.json
+++ b/tsconfig-node.json
@@ -12,7 +12,7 @@
     "downlevelIteration": true,
     "noEmitOnError": false,
     "stripInternal": false,
-    "lib": ["es5", "dom", "es2015.promise"]
+    "lib": ["es5", "dom", "es2017", "es2015.symbol"]
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
fix #740, #715

use `async/hooks` to resolve `es2017 native async/await` not in zone issue.
Because `PromiseHook.kResolve` will only fire when `resolve` is called, we don't know whether or not the promise is really resolved or not, so we still need the `ZoneAwarePromise` monkey-patch.

And I will remove other monkey-patch later to make an `asynchooks` based zone which is 
- promise use `asynchooks` + `ZoneAwarePromise`.
- other async operations such as `setTimeout/setInterval...` will just use `asynchooks`.

now I made a basic test, when build in `es2017`, the code still in zone.

```javascript
zone.run(async() => {
    print('run async', Zone.current.name);
    const outside = await asyncOutside();
    print('get outside', Zone.current.name);
    log.push(outside);

    async function asyncInside() {
      return 'asyncInside';
    } print('define inside', Zone.current.name);

    const inside = await asyncInside();
    print('get inside', Zone.current.name);
    log.push(inside);

    print('log', log.join(' '));
  });
```