### PR TITLE
fix(core): fix #989, remove unuse code, use shorter name to reduce bundle size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
   - node_modules/.bin/gulp lint
   - node_modules/.bin/gulp format:enforce
   - node_modules/.bin/gulp build
+  - node_modules/.bin/gulp filesize
   - scripts/closure/closure_compiler.sh
   - node_modules/.bin/gulp promisetest
   - npm run test:phantomjs-single

--- a/check-file-size.js
+++ b/check-file-size.js
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+const fs = require('fs');
+
+module.exports = function(config) {
+  let chkResult = true;
+  config.targets.forEach(target => {
+    if (target.checkTarget) {
+      try {
+        const stats = fs.statSync(target.path);
+        if (stats.size > target.limit) {
+          console.error(`file ${target.path} size over limit, limit is ${target.limit}, actual is ${stats.size}`);
+          chkResult = false;
+        }
+      } catch (err) {
+        console.error(`failed to get filesize: ${target.path}`);
+        chkResult = false;
+      }
+    }
+  });
+  return chkResult;
+};

--- a/file-size-limit.json
+++ b/file-size-limit.json
@@ -1,0 +1,9 @@
+{
+  "targets": [
+    {
+      "path": "dist/zone.min.js",
+      "checkTarget": true,
+      "limit": 40000
+    }
+  ]
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -184,6 +184,14 @@ gulp.task('build/zone-patch-electron.min.js', ['compile-esm'], function(cb) {
     return generateScript('./lib/extra/electron.ts', 'zone-patch-electron.min.js', true, cb);
 });
 
+gulp.task('build/zone-patch-user-media.js', ['compile-esm'], function(cb) {
+  return generateScript('./lib/browser/webapis-user-media.ts', 'zone-patch-user-media.js', false, cb);
+});
+
+gulp.task('build/zone-patch-user-media.min.js', ['compile-esm'], function(cb) {
+  return generateScript('./lib/browser/webapis-user-media.ts', 'zone-patch-user-media.min.js', true, cb);
+});
+
 gulp.task('build/bluebird.js', ['compile-esm'], function(cb) {
     return generateScript('./lib/extra/bluebird.ts', 'zone-bluebird.js', false, cb);
 });
@@ -287,6 +295,8 @@ gulp.task('build', [
   'build/zone-patch-cordova.min.js',
   'build/zone-patch-electron.js',
   'build/zone-patch-electron.min.js',
+  'build/zone-patch-user-media.js',
+  'build/zone-patch-user-media.min.js',
   'build/zone-mix.js',
   'build/bluebird.js',
   'build/bluebird.min.js',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -410,3 +410,14 @@ gulp.task('promisetest', ['build/zone-node.js'], (cb) => {
       }
     });
 });
+
+// check dist file size limitation
+gulp.task('filesize', ['build'], (cb) => {
+    const checker = require('./check-file-size');
+    const result = checker(require('./file-size-limit.json'));
+    if (result) {
+      cb();
+    } else {
+      cb('check file size failed');
+    }
+});

--- a/karma-dist.conf.js
+++ b/karma-dist.conf.js
@@ -12,6 +12,7 @@ module.exports = function (config) {
   config.files.push('build/test/test_fake_polyfill.js');
   config.files.push('build/test/custom_error.js');
   config.files.push('dist/zone.js');
+  config.files.push('dist/zone-patch-user-media.js');
   config.files.push('dist/async-test.js');
   config.files.push('dist/fake-async-test.js');
   config.files.push('dist/long-stack-trace-zone.js');

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -12,7 +12,7 @@
 
 import {findEventTasks} from '../common/events';
 import {patchTimer} from '../common/timers';
-import {bindArguments, patchClass, patchMacroTask, patchMethod, patchOnProperties, patchPrototype, ZONE_SYMBOL_ADD_EVENT_LISTENER, ZONE_SYMBOL_REMOVE_EVENT_LISTENER, zoneSymbol} from '../common/utils';
+import {bindArguments, patchClass, patchMacroTask, patchMethod, patchOnProperties, patchPrototype, scheduleMacroTaskWithCurrentZone, ZONE_SYMBOL_ADD_EVENT_LISTENER, ZONE_SYMBOL_REMOVE_EVENT_LISTENER, zoneSymbol} from '../common/utils';
 
 import {propertyPatch} from './define-property';
 import {eventTargetPatch, patchEvent} from './event-target';
@@ -179,7 +179,6 @@ Zone.__load_patch('XHR', (global: any, Zone: ZoneType) => {
     const XMLHTTPREQUEST_SOURCE = 'XMLHttpRequest.send';
     const sendNative: Function =
         patchMethod(XMLHttpRequestPrototype, 'send', () => function(self: any, args: any[]) {
-          const zone = Zone.current;
           if (self[XHR_SYNC]) {
             // if the XHR is sync there is no task to schedule, just execute the code.
             return sendNative.apply(self, args);
@@ -192,7 +191,7 @@ Zone.__load_patch('XHR', (global: any, Zone: ZoneType) => {
               args: args,
               aborted: false
             };
-            return zone.scheduleMacroTask(
+            return scheduleMacroTaskWithCurrentZone(
                 XMLHTTPREQUEST_SOURCE, placeholderCallback, options, scheduleTask, clearTask);
           }
         });

--- a/lib/browser/define-property.ts
+++ b/lib/browser/define-property.ts
@@ -38,6 +38,7 @@ export function propertyPatch() {
   };
 
   Object.create = <any>function(obj: any, proto: any) {
+    // o is 'object' string
     if (typeof proto === p && !Object.isFrozen(proto)) {
       Object.keys(proto).forEach(function(prop) {
         proto[prop] = rewriteDescriptor(obj, prop, proto[prop]);
@@ -89,6 +90,7 @@ function _tryDefineProperty(obj: any, prop: string, desc: any, originalConfigura
     if (desc.configurable) {
       // In case of errors, when the configurable flag was likely set by rewriteDescriptor(), let's
       // retry with the original flag value
+      // o is 'undefined' string
       if (typeof originalConfigurableFlag == o) {
         delete desc.configurable;
       } else {

--- a/lib/browser/define-property.ts
+++ b/lib/browser/define-property.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {zoneSymbol} from '../common/utils';
+import {o, p, zoneSymbol} from '../common/utils';
 /*
  * This is necessary for Chrome and Chrome mobile, to enable
  * things like redefining `createdCallback` on an element.
@@ -17,9 +17,6 @@ const _getOwnPropertyDescriptor = (Object as any)[zoneSymbol('getOwnPropertyDesc
     Object.getOwnPropertyDescriptor;
 const _create = Object.create;
 const unconfigurablesKey = zoneSymbol('unconfigurables');
-const PROTOTYPE = 'prototype';
-const OBJECT = 'object';
-const UNDEFINED = 'undefined';
 
 export function propertyPatch() {
   Object.defineProperty = function(obj, prop, desc) {
@@ -27,7 +24,7 @@ export function propertyPatch() {
       throw new TypeError('Cannot assign to read only property \'' + prop + '\' of ' + obj);
     }
     const originalConfigurableFlag = desc.configurable;
-    if (prop !== PROTOTYPE) {
+    if (prop !== 'prototype') {
       desc = rewriteDescriptor(obj, prop, desc);
     }
     return _tryDefineProperty(obj, prop, desc, originalConfigurableFlag);
@@ -41,7 +38,7 @@ export function propertyPatch() {
   };
 
   Object.create = <any>function(obj: any, proto: any) {
-    if (typeof proto === OBJECT && !Object.isFrozen(proto)) {
+    if (typeof proto === p && !Object.isFrozen(proto)) {
       Object.keys(proto).forEach(function(prop) {
         proto[prop] = rewriteDescriptor(obj, prop, proto[prop]);
       });
@@ -92,7 +89,7 @@ function _tryDefineProperty(obj: any, prop: string, desc: any, originalConfigura
     if (desc.configurable) {
       // In case of errors, when the configurable flag was likely set by rewriteDescriptor(), let's
       // retry with the original flag value
-      if (typeof originalConfigurableFlag == UNDEFINED) {
+      if (typeof originalConfigurableFlag == o) {
         delete desc.configurable;
       } else {
         desc.configurable = originalConfigurableFlag;

--- a/lib/browser/define-property.ts
+++ b/lib/browser/define-property.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {o, p, zoneSymbol} from '../common/utils';
+import {zoneSymbol} from '../common/utils';
 /*
  * This is necessary for Chrome and Chrome mobile, to enable
  * things like redefining `createdCallback` on an element.
@@ -38,8 +38,7 @@ export function propertyPatch() {
   };
 
   Object.create = <any>function(obj: any, proto: any) {
-    // o is 'object' string
-    if (typeof proto === p && !Object.isFrozen(proto)) {
+    if (typeof proto === 'object' && !Object.isFrozen(proto)) {
       Object.keys(proto).forEach(function(prop) {
         proto[prop] = rewriteDescriptor(obj, prop, proto[prop]);
       });
@@ -90,8 +89,7 @@ function _tryDefineProperty(obj: any, prop: string, desc: any, originalConfigura
     if (desc.configurable) {
       // In case of errors, when the configurable flag was likely set by rewriteDescriptor(), let's
       // retry with the original flag value
-      // o is 'undefined' string
-      if (typeof originalConfigurableFlag == o) {
+      if (typeof originalConfigurableFlag == 'undefined') {
         delete desc.configurable;
       } else {
         desc.configurable = originalConfigurableFlag;

--- a/lib/browser/event-target.ts
+++ b/lib/browser/event-target.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ens, gs, patchEventPrototype, patchEventTarget} from '../common/events';
-import {isIEOrEdge, k, l, m} from '../common/utils';
+import {globalSources, patchEventPrototype, patchEventTarget, zoneSymbolEventNames} from '../common/events';
+import {FALSE_STR, isIEOrEdge, TRUE_STR, ZONE_SYMBOL_PREFIX} from '../common/utils';
 
 import {eventNames} from './property-descriptor';
 
@@ -45,27 +45,19 @@ export function eventTargetPatch(_global: any, api: _ZonePrivate) {
   //  predefine all __zone_symbol__ + eventName + true/false string
   for (let i = 0; i < eventNames.length; i++) {
     const eventName = eventNames[i];
-    // l is 'false' string
-    const falseEventName = eventName + l;
-    // k is 'true' string
-    const trueEventName = eventName + k;
-    // m is '__zone_symbol__' string
-    const symbol = m + falseEventName;
-    // m is '__zone_symbol__' string
-    const symbolCapture = m + trueEventName;
-    // ens is globalEventNames cache
-    ens[eventName] = {};
-    // l is 'false' string
-    ens[eventName][l] = symbol;
-    // k is 'true' string
-    ens[eventName][k] = symbolCapture;
+    const falseEventName = eventName + FALSE_STR;
+    const trueEventName = eventName + TRUE_STR;
+    const symbol = ZONE_SYMBOL_PREFIX + falseEventName;
+    const symbolCapture = ZONE_SYMBOL_PREFIX + trueEventName;
+    zoneSymbolEventNames[eventName] = {};
+    zoneSymbolEventNames[eventName][FALSE_STR] = symbol;
+    zoneSymbolEventNames[eventName][TRUE_STR] = symbolCapture;
   }
 
   //  predefine all task.source string
   for (let i = 0; i < WTF_ISSUE_555.length; i++) {
     const target: any = WTF_ISSUE_555_ARRAY[i];
-    // gs is global source cache
-    const targets: any = gs[target] = {};
+    const targets: any = globalSources[target] = {};
     for (let j = 0; j < eventNames.length; j++) {
       const eventName = eventNames[j];
       targets[eventName] = target + ADD_EVENT_LISTENER_SOURCE + eventName;

--- a/lib/browser/event-target.ts
+++ b/lib/browser/event-target.ts
@@ -45,18 +45,26 @@ export function eventTargetPatch(_global: any, api: _ZonePrivate) {
   //  predefine all __zone_symbol__ + eventName + true/false string
   for (let i = 0; i < eventNames.length; i++) {
     const eventName = eventNames[i];
+    // l is 'false' string
     const falseEventName = eventName + l;
+    // k is 'true' string
     const trueEventName = eventName + k;
+    // m is '__zone_symbol__' string
     const symbol = m + falseEventName;
+    // m is '__zone_symbol__' string
     const symbolCapture = m + trueEventName;
+    // ens is globalEventNames cache
     ens[eventName] = {};
+    // l is 'false' string
     ens[eventName][l] = symbol;
+    // k is 'true' string
     ens[eventName][k] = symbolCapture;
   }
 
   //  predefine all task.source string
   for (let i = 0; i < WTF_ISSUE_555.length; i++) {
     const target: any = WTF_ISSUE_555_ARRAY[i];
+    // gs is global source cache
     const targets: any = gs[target] = {};
     for (let j = 0; j < eventNames.length; j++) {
       const eventName = eventNames[j];
@@ -101,6 +109,8 @@ export function eventTargetPatch(_global: any, api: _ZonePrivate) {
     const type = _global[apis[i]];
     apiTypes.push(type && type.prototype);
   }
+  // vh is validateHandler to check event handler
+  // is valid or not(for security check)
   patchEventTarget(_global, apiTypes, {vh: checkIEAndCrossContext});
   api.patchEventTarget = patchEventTarget;
 

--- a/lib/browser/event-target.ts
+++ b/lib/browser/event-target.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {FALSE_STR, globalSources, patchEventPrototype, patchEventTarget, TRUE_STR, ZONE_SYMBOL_PREFIX, zoneSymbolEventNames} from '../common/events';
-import {attachOriginToPatched, isIEOrEdge, zoneSymbol} from '../common/utils';
+import {ens, gs, patchEventPrototype, patchEventTarget} from '../common/events';
+import {isIEOrEdge, k, l, m} from '../common/utils';
 
 import {eventNames} from './property-descriptor';
 
@@ -45,19 +45,19 @@ export function eventTargetPatch(_global: any, api: _ZonePrivate) {
   //  predefine all __zone_symbol__ + eventName + true/false string
   for (let i = 0; i < eventNames.length; i++) {
     const eventName = eventNames[i];
-    const falseEventName = eventName + FALSE_STR;
-    const trueEventName = eventName + TRUE_STR;
-    const symbol = ZONE_SYMBOL_PREFIX + falseEventName;
-    const symbolCapture = ZONE_SYMBOL_PREFIX + trueEventName;
-    zoneSymbolEventNames[eventName] = {};
-    zoneSymbolEventNames[eventName][FALSE_STR] = symbol;
-    zoneSymbolEventNames[eventName][TRUE_STR] = symbolCapture;
+    const falseEventName = eventName + l;
+    const trueEventName = eventName + k;
+    const symbol = m + falseEventName;
+    const symbolCapture = m + trueEventName;
+    ens[eventName] = {};
+    ens[eventName][l] = symbol;
+    ens[eventName][k] = symbolCapture;
   }
 
   //  predefine all task.source string
   for (let i = 0; i < WTF_ISSUE_555.length; i++) {
     const target: any = WTF_ISSUE_555_ARRAY[i];
-    const targets: any = globalSources[target] = {};
+    const targets: any = gs[target] = {};
     for (let j = 0; j < eventNames.length; j++) {
       const eventName = eventNames[j];
       targets[eventName] = target + ADD_EVENT_LISTENER_SOURCE + eventName;
@@ -101,7 +101,7 @@ export function eventTargetPatch(_global: any, api: _ZonePrivate) {
     const type = _global[apis[i]];
     apiTypes.push(type && type.prototype);
   }
-  patchEventTarget(_global, apiTypes, {validateHandler: checkIEAndCrossContext});
+  patchEventTarget(_global, apiTypes, {vh: checkIEAndCrossContext});
   api.patchEventTarget = patchEventTarget;
 
   return true;

--- a/lib/browser/property-descriptor.ts
+++ b/lib/browser/property-descriptor.ts
@@ -10,7 +10,7 @@
  * @suppress {globalThis}
  */
 
-import {isBrowser, isMix, isNode, ObjectDefineProperty, ObjectGetOwnPropertyDescriptor, ObjectGetPrototypeOf, patchClass, patchOnProperties, zoneSymbol} from '../common/utils';
+import {isBrowser, isMix, isNode, ObjectDefineProperty, ObjectGetOwnPropertyDescriptor, ObjectGetPrototypeOf, patchClass, patchOnProperties, wrapWithCurrentZone, zoneSymbol} from '../common/utils';
 
 import * as webSocketPatch from './websocket';
 
@@ -402,7 +402,7 @@ function patchViaCapturingAllTheEvents() {
       }
       while (elt) {
         if (elt[onproperty] && !elt[onproperty][unboundKey]) {
-          bound = Zone.current.wrap(elt[onproperty], source);
+          bound = wrapWithCurrentZone(elt[onproperty], source);
           bound[unboundKey] = elt[onproperty];
           elt[onproperty] = bound;
         }

--- a/lib/browser/property-descriptor.ts
+++ b/lib/browser/property-descriptor.ts
@@ -265,6 +265,7 @@ export function propertyDescriptorPatch(api: _ZonePrivate, _global: any) {
     return;
   }
 
+  // o is 'undefined' string
   const supportsWebSocket = typeof WebSocket !== o;
   if (canPatchViaPropertyDescriptor()) {
     const ignoreProperties: IgnoreProperty[] = _global.__Zone_ignore_on_properties;
@@ -306,6 +307,7 @@ export function propertyDescriptorPatch(api: _ZonePrivate, _global: any) {
           XMLHttpRequestEventTarget && XMLHttpRequestEventTarget.prototype,
           XMLHttpRequestEventNames, ignoreProperties);
     }
+    // o is 'undefined' string
     if (typeof IDBIndex !== o) {
       patchFilteredProperties(IDBIndex.prototype, IDBIndexEventNames, ignoreProperties);
       patchFilteredProperties(IDBRequest.prototype, IDBIndexEventNames, ignoreProperties);
@@ -338,6 +340,7 @@ function canPatchViaPropertyDescriptor() {
   const ON_READY_STATE_CHANGE = 'onreadystatechange';
   const XMLHttpRequestPrototype = XMLHttpRequest.prototype;
 
+  // a is Object.getOwnPropertyDescriptor
   const xhrDesc = a(XMLHttpRequestPrototype, ON_READY_STATE_CHANGE);
 
   // add enumerable and configurable here because in opera
@@ -347,6 +350,7 @@ function canPatchViaPropertyDescriptor() {
   // and if XMLHttpRequest.prototype.onreadystatechange is undefined,
   // we should set a real desc instead a fake one
   if (xhrDesc) {
+    // b is Object.defineProperty
     b(XMLHttpRequestPrototype, ON_READY_STATE_CHANGE, {
       enumerable: true,
       configurable: true,
@@ -398,6 +402,7 @@ function patchViaCapturingAllTheEvents() {
       }
       while (elt) {
         if (elt[onproperty] && !elt[onproperty][unboundKey]) {
+          // Zone.current.wrap
           bound = (Zone as any).c.w(elt[onproperty], source);
           bound[unboundKey] = elt[onproperty];
           elt[onproperty] = bound;

--- a/lib/browser/register-element.ts
+++ b/lib/browser/register-element.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {attachOriginToPatched, isBrowser, isMix} from '../common/utils';
+import {a, attachOriginToPatched, isBrowser, isMix} from '../common/utils';
 
 import {_redefineProperty} from './define-property';
 
@@ -23,16 +23,17 @@ export function registerElementPatch(_global: any) {
     if (opts && opts.prototype) {
       callbacks.forEach(function(callback) {
         const source = 'Document.registerElement::' + callback;
-        if (opts.prototype.hasOwnProperty(callback)) {
-          const descriptor = Object.getOwnPropertyDescriptor(opts.prototype, callback);
+        const p = opts.prototype;
+        if (p.hasOwnProperty(callback)) {
+          const descriptor = a(p, callback);
           if (descriptor && descriptor.value) {
-            descriptor.value = Zone.current.wrap(descriptor.value, source);
+            descriptor.value = (Zone as any).c.w(descriptor.value, source);
             _redefineProperty(opts.prototype, callback, descriptor);
           } else {
-            opts.prototype[callback] = Zone.current.wrap(opts.prototype[callback], source);
+            p[callback] = (Zone as any).c.w(p[callback], source);
           }
-        } else if (opts.prototype[callback]) {
-          opts.prototype[callback] = Zone.current.wrap(opts.prototype[callback], source);
+        } else if (p[callback]) {
+          p[callback] = (Zone as any).c.w(p[callback], source);
         }
       });
     }

--- a/lib/browser/register-element.ts
+++ b/lib/browser/register-element.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {attachOriginToPatched, isBrowser, isMix, ObjectGetOwnPropertyDescriptor} from '../common/utils';
+import {attachOriginToPatched, isBrowser, isMix, ObjectGetOwnPropertyDescriptor, wrapWithCurrentZone} from '../common/utils';
 
 import {_redefineProperty} from './define-property';
 
@@ -27,13 +27,13 @@ export function registerElementPatch(_global: any) {
         if (prototype.hasOwnProperty(callback)) {
           const descriptor = ObjectGetOwnPropertyDescriptor(prototype, callback);
           if (descriptor && descriptor.value) {
-            descriptor.value = Zone.current.wrap(descriptor.value, source);
+            descriptor.value = wrapWithCurrentZone(descriptor.value, source);
             _redefineProperty(opts.prototype, callback, descriptor);
           } else {
-            prototype[callback] = Zone.current.wrap(prototype[callback], source);
+            prototype[callback] = wrapWithCurrentZone(prototype[callback], source);
           }
         } else if (prototype[callback]) {
-          prototype[callback] = Zone.current.wrap(prototype[callback], source);
+          prototype[callback] = wrapWithCurrentZone(prototype[callback], source);
         }
       });
     }

--- a/lib/browser/register-element.ts
+++ b/lib/browser/register-element.ts
@@ -25,6 +25,7 @@ export function registerElementPatch(_global: any) {
         const source = 'Document.registerElement::' + callback;
         const p = opts.prototype;
         if (p.hasOwnProperty(callback)) {
+          // a is Object.getOwnPropertyDescriptor
           const descriptor = a(p, callback);
           if (descriptor && descriptor.value) {
             descriptor.value = (Zone as any).c.w(descriptor.value, source);

--- a/lib/browser/shadydom.ts
+++ b/lib/browser/shadydom.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-(Zone as any).l('shadydom', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('shadydom', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   // https://github.com/angular/zone.js/issues/782
   // in web components, shadydom will patch addEventListener/removeEventListener of
   // Node.prototype and WindowPrototype, this will have conflict with zone.js

--- a/lib/browser/shadydom.ts
+++ b/lib/browser/shadydom.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-Zone.__load_patch('shadydom', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+(Zone as any).l('shadydom', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   // https://github.com/angular/zone.js/issues/782
   // in web components, shadydom will patch addEventListener/removeEventListener of
   // Node.prototype and WindowPrototype, this will have conflict with zone.js

--- a/lib/browser/webapis-media-query.ts
+++ b/lib/browser/webapis-media-query.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-(Zone as any).l('mediaQuery', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('mediaQuery', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   if (!global['MediaQueryList']) {
     return;
   }

--- a/lib/browser/webapis-media-query.ts
+++ b/lib/browser/webapis-media-query.ts
@@ -5,11 +5,10 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-Zone.__load_patch('mediaQuery', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+(Zone as any).l('mediaQuery', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   if (!global['MediaQueryList']) {
     return;
   }
   api.patchEventTarget(
-      global, [global['MediaQueryList'].prototype],
-      {addEventListenerFnName: 'addListener', removeEventListenerFnName: 'removeListener'});
+      global, [global['MediaQueryList'].prototype], {add: 'addListener', rm: 'removeListener'});
 });

--- a/lib/browser/webapis-notification.ts
+++ b/lib/browser/webapis-notification.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-Zone.__load_patch('notification', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+(Zone as any).l('notification', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   const Notification = global['Notification'];
   if (!Notification || !Notification.prototype) {
     return;

--- a/lib/browser/webapis-notification.ts
+++ b/lib/browser/webapis-notification.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-(Zone as any).l('notification', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('notification', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   const Notification = global['Notification'];
   if (!Notification || !Notification.prototype) {
     return;

--- a/lib/browser/webapis-rtc-peer-connection.ts
+++ b/lib/browser/webapis-rtc-peer-connection.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-(Zone as any).l('RTCPeerConnection', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('RTCPeerConnection', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   const RTCPeerConnection = global['RTCPeerConnection'];
   if (!RTCPeerConnection) {
     return;
@@ -18,7 +18,7 @@
   RTCPeerConnection.prototype.removeEventListener = RTCPeerConnection.prototype[removeSymbol];
 
   // RTCPeerConnection extends EventTarget, so we must clear the symbol
-  // to allow pathc RTCPeerConnection.prototype.addEventListener again
+  // to allow patch RTCPeerConnection.prototype.addEventListener again
   RTCPeerConnection.prototype[addSymbol] = null;
   RTCPeerConnection.prototype[removeSymbol] = null;
 

--- a/lib/browser/webapis-rtc-peer-connection.ts
+++ b/lib/browser/webapis-rtc-peer-connection.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-Zone.__load_patch('RTCPeerConnection', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+(Zone as any).l('RTCPeerConnection', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   const RTCPeerConnection = global['RTCPeerConnection'];
   if (!RTCPeerConnection) {
     return;
@@ -22,5 +22,5 @@ Zone.__load_patch('RTCPeerConnection', (global: any, Zone: ZoneType, api: _ZoneP
   RTCPeerConnection.prototype[addSymbol] = null;
   RTCPeerConnection.prototype[removeSymbol] = null;
 
-  api.patchEventTarget(global, [RTCPeerConnection.prototype], {useGlobalCallback: false});
+  api.patchEventTarget(global, [RTCPeerConnection.prototype], {useG: false});
 });

--- a/lib/browser/webapis-user-media.ts
+++ b/lib/browser/webapis-user-media.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-(Zone as any).l('getUserMedia', (global: any, Zone: any, api: _ZonePrivate) => {
+Zone.__load_patch('getUserMedia', (global: any, Zone: any, api: _ZonePrivate) => {
   function wrapFunctionArgs(func: Function, source?: string): Function {
     return function() {
       const args = Array.prototype.slice.call(arguments);

--- a/lib/browser/webapis-user-media.ts
+++ b/lib/browser/webapis-user-media.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+(Zone as any).l('getUserMedia', (global: any, Zone: any, api: _ZonePrivate) => {
+  function wrapFunctionArgs(func: Function, source?: string): Function {
+    return function() {
+      const args = Array.prototype.slice.call(arguments);
+      const wrappedArgs = api.bindArguments(args, source ? source : (func as any).name);
+      return func.apply(this, wrappedArgs);
+    };
+  }
+  let navigator = global['navigator'];
+  if (navigator && navigator.getUserMedia) {
+    navigator.getUserMedia = wrapFunctionArgs(navigator.getUserMedia);
+  }
+});

--- a/lib/browser/websocket.ts
+++ b/lib/browser/websocket.ts
@@ -24,13 +24,16 @@ export function apply(api: _ZonePrivate, _global: any) {
     let proxySocketProto: any;
 
     // Safari 7.0 has non-configurable own 'onmessage' and friends properties on the socket instance
+    // a is Object.getOwnPropertyDescriptor
     const onmessageDesc = a(socket, 'onmessage');
     if (onmessageDesc && onmessageDesc.configurable === false) {
+      // e is Object.create
       proxySocket = e(socket);
       // socket have own property descriptor 'onopen', 'onmessage', 'onclose', 'onerror'
       // but proxySocket not, so we will keep socket as prototype and pass it to
       // patchOnProperties method
       proxySocketProto = socket;
+      // g is `addEventListener`, h is `removeEventListener` string
       [g, h, 'send', 'close'].forEach(function(propName) {
         proxySocket[propName] = function() {
           const args = f.call(arguments);

--- a/lib/browser/websocket.ts
+++ b/lib/browser/websocket.ts
@@ -7,7 +7,7 @@
  */
 
 import {patchEventTarget} from '../common/events';
-import {patchOnProperties} from '../common/utils';
+import {a, e, f, g, h, patchOnProperties} from '../common/utils';
 
 // we have to patch the instance since the proto is non-configurable
 export function apply(api: _ZonePrivate, _global: any) {
@@ -17,27 +17,27 @@ export function apply(api: _ZonePrivate, _global: any) {
   if (!(<any>_global).EventTarget) {
     patchEventTarget(_global, [WS.prototype]);
   }
-  (<any>_global).WebSocket = function(a: any, b: any) {
-    const socket = arguments.length > 1 ? new WS(a, b) : new WS(a);
+  (<any>_global).WebSocket = function(x: any, y: any) {
+    const socket = arguments.length > 1 ? new WS(x, y) : new WS(x);
     let proxySocket: any;
 
     let proxySocketProto: any;
 
     // Safari 7.0 has non-configurable own 'onmessage' and friends properties on the socket instance
-    const onmessageDesc = Object.getOwnPropertyDescriptor(socket, 'onmessage');
+    const onmessageDesc = a(socket, 'onmessage');
     if (onmessageDesc && onmessageDesc.configurable === false) {
-      proxySocket = Object.create(socket);
+      proxySocket = e(socket);
       // socket have own property descriptor 'onopen', 'onmessage', 'onclose', 'onerror'
       // but proxySocket not, so we will keep socket as prototype and pass it to
       // patchOnProperties method
       proxySocketProto = socket;
-      ['addEventListener', 'removeEventListener', 'send', 'close'].forEach(function(propName) {
+      [g, h, 'send', 'close'].forEach(function(propName) {
         proxySocket[propName] = function() {
-          const args = Array.prototype.slice.call(arguments);
-          if (propName === 'addEventListener' || propName === 'removeEventListener') {
+          const args = f.call(arguments);
+          if (propName === g || propName === h) {
             const eventName = args.length > 0 ? args[0] : undefined;
             if (eventName) {
-              const propertySymbol = Zone.__symbol__('ON_PROPERTY' + eventName);
+              const propertySymbol = (Zone as any).s('ON_PROPERTY' + eventName);
               socket[propertySymbol] = proxySocket[propertySymbol];
             }
           }

--- a/lib/closure/zone_externs.js
+++ b/lib/closure/zone_externs.js
@@ -48,7 +48,7 @@ Zone.root;
  * Returns a value associated with the `key`.
  *
  * If the current zone does not have a key, the request is delegated to the parent zone. Use
- * [ZoneSpec.properties] to configure the set of properties asseciated with the current zone.
+ * [ZoneSpec.properties] to configure the set of properties associated with the current zone.
  *
  * @param {!string} key The key to retrieve.
  * @returns {?} The value for the key, or `undefined` if not found.
@@ -206,18 +206,18 @@ ZoneSpec.prototype.onIntercept;
 
 /**
  * Allows interception of the callback invocation.
- * 
+ *
  * @type {
- *   undefined|?function(ZoneDelegate, Zone, Zone, Function, Object, Array, string): * 
+ *   undefined|?function(ZoneDelegate, Zone, Zone, Function, Object, Array, string): *
  * }
  */
-ZoneSpec.prototype.onInvoke; 
+ZoneSpec.prototype.onInvoke;
 
 /**
  * Allows interception of the error handling.
  *
  * @type {
- *   undefined|?function(ZoneDelegate, Zone, Zone, Object): boolean 
+ *   undefined|?function(ZoneDelegate, Zone, Zone, Object): boolean
  * }
  */
 ZoneSpec.prototype.onHandleError;
@@ -226,7 +226,7 @@ ZoneSpec.prototype.onHandleError;
  * Allows interception of task scheduling.
  *
  * @type {
- *   undefined|?function(ZoneDelegate, Zone, Zone, Task): Task 
+ *   undefined|?function(ZoneDelegate, Zone, Zone, Task): Task
  * }
  */
 ZoneSpec.prototype.onScheduleTask;
@@ -238,16 +238,16 @@ ZoneSpec.prototype.onScheduleTask;
  *   undefined|?function(ZoneDelegate, Zone, Zone, Task, Object, Array): *
  * }
  */
-ZoneSpec.prototype.onInvokeTask; 
+ZoneSpec.prototype.onInvokeTask;
 
 /**
  * Allows interception of task cancelation.
  *
  * @type {
- *   undefined|?function(ZoneDelegate, Zone, Zone, Task): * 
+ *   undefined|?function(ZoneDelegate, Zone, Zone, Task): *
  * }
  */
-ZoneSpec.prototype.onCancelTask; 
+ZoneSpec.prototype.onCancelTask;
 /**
  * Notifies of changes to the task queue empty status.
  *
@@ -275,7 +275,7 @@ ZoneDelegate.prototype.fork = function(targetZone, zoneSpec) {};
  * @param {!Zone} targetZone the [Zone] which originally received the request.
  * @param {!Function} callback the callback function passed into `wrap` function
  * @param {string=} source the argument passed into the `wrap` method.
- * @returns {!Function} 
+ * @returns {!Function}
  */
 ZoneDelegate.prototype.intercept = function(targetZone, callback, source) {};
 
@@ -316,7 +316,7 @@ ZoneDelegate.prototype.invokeTask = function(targetZone, task, applyThis, applyA
 ZoneDelegate.prototype.cancelTask = function(targetZone, task) {};
 /**
  * @param {!Zone} targetZone The [Zone] which originally received the request.
- * @param {!HasTaskState} hasTaskState 
+ * @param {!HasTaskState} hasTaskState
  */
 ZoneDelegate.prototype.hasTask = function(targetZone, hasTaskState) {};
 

--- a/lib/common/error-rewrite.ts
+++ b/lib/common/error-rewrite.ts
@@ -189,7 +189,7 @@ Zone.__load_patch('Error', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
             }
           }
         }
-        return value.apply(this, [error, structuredStackTrace]);
+        return value.call(this, error, structuredStackTrace);
       };
     }
   });
@@ -218,7 +218,7 @@ Zone.__load_patch('Error', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
               let frame = frames.shift();
               // On safari it is possible to have stack frame with no line number.
               // This check makes sure that we don't filter frames on name only (must have
-              // linenumber)
+              // line number)
               if (/:\d+:\d+/.test(frame)) {
                 // Get rid of the path so that we don't accidentally find function name in path.
                 // In chrome the separator is `(` and `@` in FF and safari
@@ -283,8 +283,7 @@ Zone.__load_patch('Error', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   // all kinds of tasks with one error thrown.
   childDetectZone.run(() => {
     childDetectZone.runGuarded(() => {
-      const fakeTransitionTo =
-          (toState: TaskState, fromState1: TaskState, fromState2: TaskState) => {};
+      const fakeTransitionTo = () => {};
       childDetectZone.scheduleEventTask(
           blacklistedStackFramesSymbol,
           () => {

--- a/lib/common/events.ts
+++ b/lib/common/events.ts
@@ -75,6 +75,7 @@ export function patchEventTarget(
       return;
     }
     const delegate = task.callback;
+    // p is 'object' string
     if (typeof delegate === p && delegate.handleEvent) {
       // create the bind version of handleEvent when invoke
       task.callback = (event: Event) => delegate.handleEvent(event);
@@ -83,6 +84,7 @@ export function patchEventTarget(
     // invoke static task.invoke
     task.invoke(task, target, [event]);
     const options = task.options;
+    // p is 'object' string
     if (options && typeof options === p && options.once) {
       // if options.once is true, after invoke once remove listener here
       // only browser need to do this, nodejs eventEmitter will cal removeListener
@@ -103,6 +105,7 @@ export function patchEventTarget(
     // event.target is needed for Samusung TV and SourceBuffer
     // || global is needed https://github.com/angular/zone.js/issues/190
     const target: any = this || event.target || _global;
+    // l is 'false' string
     const tasks = target[ens[event.type][l]];
     if (tasks) {
       // invoke all tasks which attached to current target with given event.type and capture = false
@@ -135,6 +138,7 @@ export function patchEventTarget(
     // event.target is needed for Samusung TV and SourceBuffer
     // || global is needed https://github.com/angular/zone.js/issues/190
     const target: any = this || event.target || _global;
+    // k is 'true' string
     const tasks = target[ens[event.type][k]];
     if (tasks) {
       // invoke all tasks which attached to current target with given event.type and capture = false
@@ -179,6 +183,7 @@ export function patchEventTarget(
 
     let proto = obj;
     while (proto && !proto.hasOwnProperty(ADD_EVENT_LISTENER)) {
+      // d is Object.getPrototypeOf
       proto = d(proto);
     }
     if (!proto && obj[ADD_EVENT_LISTENER]) {
@@ -230,9 +235,11 @@ export function patchEventTarget(
       // from Zone.prototype.cancelTask, we should remove the task
       // from tasksList of target first
       if (!task.isRemoved) {
+        // ens is event names cache
         const symbolEventNames = ens[task.eventName];
         let symbolEventName;
         if (symbolEventNames) {
+          // k is 'true' string, l is 'false' string
           symbolEventName = symbolEventNames[task.capture ? k : l];
         }
         const existingTasks = symbolEventName && task.target[symbolEventName];
@@ -286,6 +293,7 @@ export function patchEventTarget(
 
     const compareTaskCallbackVsDelegate = function(task: any, delegate: any) {
       const typeOfDelegate = typeof delegate;
+      // n is 'function' string, p is 'object' string
       if ((typeOfDelegate === n && task.callback === delegate) ||
           (typeOfDelegate === p && task.originalDelegate === delegate)) {
         // same callback, same capture, same event name, just return
@@ -313,6 +321,7 @@ export function patchEventTarget(
         // case here to improve addEventListener performance
         // we will create the bind delegate when invoke
         let isHandleEvent = false;
+        // n is 'function' string
         if (typeof delegate !== n) {
           if (!delegate.handleEvent) {
             return nativeListener.apply(this, arguments);
@@ -349,16 +358,20 @@ export function patchEventTarget(
           once = options ? !!options.once : false;
         }
 
+        // Zone.current
         const zone = (Zone as any).c;
         const symbolEventNames = ens[eventName];
         let symbolEventName;
         if (!symbolEventNames) {
           // the code is duplicate, but I just want to get some better performance
+          // l is 'false' string, k is 'true' string
           const falseEventName = eventName + l;
           const trueEventName = eventName + k;
+          // m is '__zone_symbol__' string
           const symbol = m + falseEventName;
           const symbolCapture = m + trueEventName;
           ens[eventName] = {};
+          // l is 'false' string, k is 'true' string
           ens[eventName][l] = symbol;
           ens[eventName][k] = symbolCapture;
           symbolEventName = capture ? symbolCapture : symbol;
@@ -411,6 +424,7 @@ export function patchEventTarget(
           (data as any).taskData = taskData;
         }
 
+        // Zone.scehduleEventTask
         const task: any =
             (zone as any).se(source, delegate, data, customScheduleFn, customCancelFn);
 
@@ -553,6 +567,7 @@ export function patchEventTarget(
       } else {
         const symbolEventNames = ens[eventName];
         if (symbolEventNames) {
+          // l is 'false' string, k is 'true' string
           const symbolEventName = symbolEventNames[l];
           const symbolCaptureEventName = symbolEventNames[k];
 

--- a/lib/common/timers.ts
+++ b/lib/common/timers.ts
@@ -10,7 +10,7 @@
  * @suppress {missingRequire}
  */
 
-import {patchMethod, zoneSymbol} from './utils';
+import {patchMethod, scheduleMacroTaskWithCurrentZone, zoneSymbol} from './utils';
 
 const taskSymbol = zoneSymbol('zoneTask');
 
@@ -61,15 +61,14 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
   setNative =
       patchMethod(window, setName, (delegate: Function) => function(self: any, args: any[]) {
         if (typeof args[0] === 'function') {
-          // Zone.current
-          const zone = Zone.current;
           const options: TimerOptions = {
             handleId: null,
             isPeriodic: nameSuffix === 'Interval',
             delay: (nameSuffix === 'Timeout' || nameSuffix === 'Interval') ? args[1] || 0 : null,
             args: args
           };
-          const task = zone.scheduleMacroTask(setName, args[0], options, scheduleTask, clearTask);
+          const task =
+              scheduleMacroTaskWithCurrentZone(setName, args[0], options, scheduleTask, clearTask);
           if (!task) {
             return task;
           }

--- a/lib/common/timers.ts
+++ b/lib/common/timers.ts
@@ -39,6 +39,7 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
           // setInterval
           return;
         }
+        // q is 'number' string
         if (typeof data.handleId === q) {
           // in non-nodejs env, we remove timerId
           // from local cache
@@ -61,7 +62,9 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
 
   setNative =
       patchMethod(window, setName, (delegate: Function) => function(self: any, args: any[]) {
+        // n is 'function' string
         if (typeof args[0] === n) {
+          // Zone.current
           const zone = (Zone as any).c;
           const options: TimerOptions = {
             handleId: null,
@@ -69,12 +72,14 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
             delay: (nameSuffix === 'Timeout' || nameSuffix === 'Interval') ? args[1] || 0 : null,
             args: args
           };
+          // Zone.scheduleMacroTask
           const task = (zone as any).sc(setName, args[0], options, scheduleTask, clearTask);
           if (!task) {
             return task;
           }
           // Node.js must additionally support the ref and unref functions.
           const handle: any = (<TimerOptions>task.data).handleId;
+          // q is 'number' string
           if (typeof handle === q) {
             // for non nodejs env, we save handleId: task
             // mapping in local cache for clearTimeout
@@ -87,11 +92,13 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
 
           // check whether handle is null, because some polyfill or browser
           // may return undefined from setTimeout/setInterval/setImmediate/requestAnimationFrame
+          // n is 'function' string
           if (handle && handle.ref && handle.unref && typeof handle.ref === n &&
               typeof handle.unref === n) {
             (<any>task).ref = (<any>handle).ref.bind(handle);
             (<any>task).unref = (<any>handle).unref.bind(handle);
           }
+          // q is 'number' string
           if (typeof handle === q || handle) {
             return handle;
           }
@@ -106,6 +113,7 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
       patchMethod(window, cancelName, (delegate: Function) => function(self: any, args: any[]) {
         const id = args[0];
         let task: Task;
+        // q is 'number' string
         if (typeof id === q) {
           // non nodejs env.
           task = tasksByHandleId[id];
@@ -117,15 +125,18 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
             task = id;
           }
         }
+        // r is 'string'
         if (task && typeof task.type === r) {
           if (task.state !== 'notScheduled' &&
               (task.cancelFn && task.data.isPeriodic || task.runCount === 0)) {
+            // q is 'number' string
             if (typeof id === q) {
               delete tasksByHandleId[id];
             } else if (id) {
               id[taskSymbol] = null;
             }
             // Do not cancel already canceled functions
+            // zone.cancelTask
             (task.zone as any).ct(task);
           }
         } else {

--- a/lib/common/timers.ts
+++ b/lib/common/timers.ts
@@ -10,7 +10,7 @@
  * @suppress {missingRequire}
  */
 
-import {n, patchMethod, q, r, zoneSymbol} from './utils';
+import {patchMethod, zoneSymbol} from './utils';
 
 const taskSymbol = zoneSymbol('zoneTask');
 
@@ -33,21 +33,19 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
       try {
         task.invoke.apply(this, arguments);
       } finally {
-        if (task.data && task.data.isPeriodic) {
-          // issue-934, task will be cancelled
-          // even it is a periodic task such as
-          // setInterval
-          return;
-        }
-        // q is 'number' string
-        if (typeof data.handleId === q) {
-          // in non-nodejs env, we remove timerId
-          // from local cache
-          delete tasksByHandleId[data.handleId];
-        } else if (data.handleId) {
-          // Node returns complex objects as handleIds
-          // we remove task reference from timer object
-          (data.handleId as any)[taskSymbol] = null;
+        // issue-934, task will be cancelled
+        // even it is a periodic task such as
+        // setInterval
+        if (!(task.data && task.data.isPeriodic)) {
+          if (typeof data.handleId === 'number') {
+            // in non-nodejs env, we remove timerId
+            // from local cache
+            delete tasksByHandleId[data.handleId];
+          } else if (data.handleId) {
+            // Node returns complex objects as handleIds
+            // we remove task reference from timer object
+            (data.handleId as any)[taskSymbol] = null;
+          }
         }
       }
     }
@@ -62,25 +60,22 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
 
   setNative =
       patchMethod(window, setName, (delegate: Function) => function(self: any, args: any[]) {
-        // n is 'function' string
-        if (typeof args[0] === n) {
+        if (typeof args[0] === 'function') {
           // Zone.current
-          const zone = (Zone as any).c;
+          const zone = Zone.current;
           const options: TimerOptions = {
             handleId: null,
             isPeriodic: nameSuffix === 'Interval',
             delay: (nameSuffix === 'Timeout' || nameSuffix === 'Interval') ? args[1] || 0 : null,
             args: args
           };
-          // Zone.scheduleMacroTask
-          const task = (zone as any).sc(setName, args[0], options, scheduleTask, clearTask);
+          const task = zone.scheduleMacroTask(setName, args[0], options, scheduleTask, clearTask);
           if (!task) {
             return task;
           }
           // Node.js must additionally support the ref and unref functions.
           const handle: any = (<TimerOptions>task.data).handleId;
-          // q is 'number' string
-          if (typeof handle === q) {
+          if (typeof handle === 'number') {
             // for non nodejs env, we save handleId: task
             // mapping in local cache for clearTimeout
             tasksByHandleId[handle] = task;
@@ -92,14 +87,12 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
 
           // check whether handle is null, because some polyfill or browser
           // may return undefined from setTimeout/setInterval/setImmediate/requestAnimationFrame
-          // n is 'function' string
-          if (handle && handle.ref && handle.unref && typeof handle.ref === n &&
-              typeof handle.unref === n) {
+          if (handle && handle.ref && handle.unref && typeof handle.ref === 'function' &&
+              typeof handle.unref === 'function') {
             (<any>task).ref = (<any>handle).ref.bind(handle);
             (<any>task).unref = (<any>handle).unref.bind(handle);
           }
-          // q is 'number' string
-          if (typeof handle === q || handle) {
+          if (typeof handle === 'number' || handle) {
             return handle;
           }
           return task;
@@ -113,8 +106,7 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
       patchMethod(window, cancelName, (delegate: Function) => function(self: any, args: any[]) {
         const id = args[0];
         let task: Task;
-        // q is 'number' string
-        if (typeof id === q) {
+        if (typeof id === 'number') {
           // non nodejs env.
           task = tasksByHandleId[id];
         } else {
@@ -125,19 +117,16 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
             task = id;
           }
         }
-        // r is 'string'
-        if (task && typeof task.type === r) {
+        if (task && typeof task.type === 'string') {
           if (task.state !== 'notScheduled' &&
               (task.cancelFn && task.data.isPeriodic || task.runCount === 0)) {
-            // q is 'number' string
-            if (typeof id === q) {
+            if (typeof id === 'number') {
               delete tasksByHandleId[id];
             } else if (id) {
               id[taskSymbol] = null;
             }
             // Do not cancel already canceled functions
-            // zone.cancelTask
-            (task.zone as any).ct(task);
+            task.zone.cancelTask(task);
           }
         } else {
           // cause an error by calling it directly.

--- a/lib/common/to-string.ts
+++ b/lib/common/to-string.ts
@@ -5,11 +5,11 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {n, zoneSymbol} from './utils';
+import {zoneSymbol} from './utils';
 
 // override Function.prototype.toString to make zone.js patched function
 // look like native function
-(Zone as any).l('toString', (global: any, Zone: ZoneType) => {
+Zone.__load_patch('toString', (global: any, Zone: ZoneType) => {
   // patch Func.prototype.toString to let them look like native
   const originalFunctionToString = (Zone as any)['__zone_symbol__originalToString'] =
       Function.prototype.toString;
@@ -18,11 +18,10 @@ import {n, zoneSymbol} from './utils';
   const PROMISE_SYMBOL = zoneSymbol('Promise');
   const ERROR_SYMBOL = zoneSymbol('Error');
   Function.prototype.toString = function() {
-    // n is 'function' string
-    if (typeof this === n) {
+    if (typeof this === 'function') {
       const originalDelegate = this[ORIGINAL_DELEGATE_SYMBOL];
       if (originalDelegate) {
-        if (typeof originalDelegate === n) {
+        if (typeof originalDelegate === 'function') {
           return originalFunctionToString.apply(this[ORIGINAL_DELEGATE_SYMBOL], arguments);
         } else {
           return Object.prototype.toString.call(originalDelegate);

--- a/lib/common/to-string.ts
+++ b/lib/common/to-string.ts
@@ -5,24 +5,23 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {zoneSymbol} from './utils';
+import {n, zoneSymbol} from './utils';
 
 // override Function.prototype.toString to make zone.js patched function
 // look like native function
-Zone.__load_patch('toString', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+(Zone as any).l('toString', (global: any, Zone: ZoneType) => {
   // patch Func.prototype.toString to let them look like native
   const originalFunctionToString = (Zone as any)['__zone_symbol__originalToString'] =
       Function.prototype.toString;
 
-  const FUNCTION = 'function';
   const ORIGINAL_DELEGATE_SYMBOL = zoneSymbol('OriginalDelegate');
   const PROMISE_SYMBOL = zoneSymbol('Promise');
   const ERROR_SYMBOL = zoneSymbol('Error');
   Function.prototype.toString = function() {
-    if (typeof this === FUNCTION) {
+    if (typeof this === n) {
       const originalDelegate = this[ORIGINAL_DELEGATE_SYMBOL];
       if (originalDelegate) {
-        if (typeof originalDelegate === FUNCTION) {
+        if (typeof originalDelegate === n) {
           return originalFunctionToString.apply(this[ORIGINAL_DELEGATE_SYMBOL], arguments);
         } else {
           return Object.prototype.toString.call(originalDelegate);

--- a/lib/common/to-string.ts
+++ b/lib/common/to-string.ts
@@ -18,6 +18,7 @@ import {n, zoneSymbol} from './utils';
   const PROMISE_SYMBOL = zoneSymbol('Promise');
   const ERROR_SYMBOL = zoneSymbol('Error');
   Function.prototype.toString = function() {
+    // n is 'function' string
     if (typeof this === n) {
       const originalDelegate = this[ORIGINAL_DELEGATE_SYMBOL];
       if (originalDelegate) {

--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -12,25 +12,43 @@
  */
 
 // issue #989, to reduce bundle size, use short name
-export const a = Object.getOwnPropertyDescriptor;
-export const b = Object.defineProperty;
-export const c = Object.defineProperties;
-export const d = Object.getPrototypeOf;
-export const e = Object.create;
-export const f = Array.prototype.slice;
-export const g = 'addEventListener';
-export const h = 'removeEventListener';
-export const i = (Zone as any).s(g);
-export const j = (Zone as any).s(h);
-export const k = 'true';
-export const l = 'false';
-export const m = '__zone_symbol__';
-export const n = 'function';
-export const o = 'undefined';
-export const p = 'object';
-export const q = 'number';
-export const r = 'string';
 
+/** Object.getOwnPropertyDescriptor */
+export const a = Object.getOwnPropertyDescriptor;
+/** Object.defineProperty */
+export const b = Object.defineProperty;
+/** Object.defineProperties */
+export const c = Object.defineProperties;
+/** Object.getPrototypeOf */
+export const d = Object.getPrototypeOf;
+/** Object.create */
+export const e = Object.create;
+/** Array.prototype.slice */
+export const f = Array.prototype.slice;
+/** addEventListener string const */
+export const g = 'addEventListener';
+/** removeEventListener string const */
+export const h = 'removeEventListener';
+/** zoneSymbol addEventListener */
+export const i = (Zone as any).s(g);
+/** zoneSymbol removeEventListener */
+export const j = (Zone as any).s(h);
+/** true string const */
+export const k = 'true';
+/** false string const */
+export const l = 'false';
+/** __zone_symbol__ string const */
+export const m = '__zone_symbol__';
+/** function type string const */
+export const n = 'function';
+/** undefined type string const */
+export const o = 'undefined';
+/** object type string const */
+export const p = 'object';
+/** number type string const */
+export const q = 'number';
+/** string type string const */
+export const r = 'string';
 
 // Hack since TypeScript isn't compiling this for a worker.
 declare const WorkerGlobalScope: any;

--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -31,11 +31,14 @@ export const p = 'object';
 export const q = 'number';
 export const r = 'string';
 
+
 // Hack since TypeScript isn't compiling this for a worker.
 declare const WorkerGlobalScope: any;
 
 export const zoneSymbol = Zone.__symbol__;
-const _global: any = typeof window === p && window || typeof self === p && self || global;
+const iw = typeof window !== o;
+const w: any = iw ? window : undefined;
+const _global: any = iw && w || typeof self === p && self || global;
 
 const REMOVE_ATTRIBUTE = 'removeAttribute';
 const NULL_ON_PROP_VALUE: any[] = [null];
@@ -95,15 +98,14 @@ export const isNode: boolean =
     (!('nw' in _global) && typeof _global.process !== o &&
      {}.toString.call(_global.process) === '[object process]');
 
-export const isBrowser: boolean =
-    !isNode && !isWebWorker && !!(typeof window !== o && (window as any)['HTMLElement']);
+export const isBrowser: boolean = !isNode && !isWebWorker && !!(iw && w['HTMLElement']);
 
 // we are in electron of nw, so we are both browser and nodejs
 // Make sure to access `process` through `_global` so that WebPack does not accidently browserify
 // this code.
 export const isMix: boolean = typeof _global.process !== o &&
     {}.toString.call(_global.process) === '[object process]' && !isWebWorker &&
-    !!(typeof window !== o && (window as any)['HTMLElement']);
+    !!(iw && w['HTMLElement']);
 
 const zoneSymbolEventNames: {[eventName: string]: string} = {};
 
@@ -430,7 +432,7 @@ export function isIEOrEdge() {
   isDetectedIEOrEdge = true;
 
   try {
-    const ua = window.navigator.userAgent;
+    const ua = w.navigator.userAgent;
     if (ua.indexOf('MSIE ') !== -1 || ua.indexOf('Trident/') !== -1 || ua.indexOf('Edge/') !== -1) {
       ieOrEdge = true;
     }

--- a/lib/extra/bluebird.ts
+++ b/lib/extra/bluebird.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-Zone.__load_patch('bluebird', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+(Zone as any).l('bluebird', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   // TODO: @JiaLiPassion, we can automatically patch bluebird
   // if global.Promise = Bluebird, but sometimes in nodejs,
   // global.Promise is not Bluebird, and Bluebird is just be
@@ -14,7 +14,7 @@ Zone.__load_patch('bluebird', (global: any, Zone: ZoneType, api: _ZonePrivate) =
   const BLUEBIRD = 'bluebird';
   (Zone as any)[Zone.__symbol__(BLUEBIRD)] = function patchBluebird(Bluebird: any) {
     Bluebird.setScheduler((fn: Function) => {
-      Zone.current.scheduleMicroTask(BLUEBIRD, fn);
+      (Zone as any).c.si(BLUEBIRD, fn);
     });
   };
 });

--- a/lib/extra/bluebird.ts
+++ b/lib/extra/bluebird.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-(Zone as any).l('bluebird', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('bluebird', (global: any, Zone: ZoneType) => {
   // TODO: @JiaLiPassion, we can automatically patch bluebird
   // if global.Promise = Bluebird, but sometimes in nodejs,
   // global.Promise is not Bluebird, and Bluebird is just be
@@ -14,7 +14,7 @@
   const BLUEBIRD = 'bluebird';
   (Zone as any)[Zone.__symbol__(BLUEBIRD)] = function patchBluebird(Bluebird: any) {
     Bluebird.setScheduler((fn: Function) => {
-      (Zone as any).c.si(BLUEBIRD, fn);
+      Zone.current.scheduleMicroTask(BLUEBIRD, fn);
     });
   };
 });

--- a/lib/extra/cordova.ts
+++ b/lib/extra/cordova.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-Zone.__load_patch('cordova', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+(Zone as any).l('cordova', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   if (global.cordova) {
     const SUCCESS_SOURCE = 'cordova.exec.success';
     const ERROR_SOURCE = 'cordova.exec.error';
@@ -13,17 +13,17 @@ Zone.__load_patch('cordova', (global: any, Zone: ZoneType, api: _ZonePrivate) =>
     const nativeExec: Function = api.patchMethod(
         global.cordova, 'exec', (delegate: Function) => function(self: any, args: any[]) {
           if (args.length > 0 && typeof args[0] === FUNCTION) {
-            args[0] = Zone.current.wrap(args[0], SUCCESS_SOURCE);
+            args[0] = (Zone as any).c.w(args[0], SUCCESS_SOURCE);
           }
           if (args.length > 1 && typeof args[1] === FUNCTION) {
-            args[1] = Zone.current.wrap(args[1], ERROR_SOURCE);
+            args[1] = (Zone as any).c.w(args[1], ERROR_SOURCE);
           }
           return nativeExec.apply(self, args);
         });
   }
 });
 
-Zone.__load_patch('cordova.FileReader', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+(Zone as any).l('cordova.FileReader', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   if (global.cordova && typeof global['FileReader'] !== 'undefined') {
     document.addEventListener('deviceReady', () => {
       const FileReader = global['FileReader'];

--- a/lib/extra/cordova.ts
+++ b/lib/extra/cordova.ts
@@ -5,25 +5,25 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-(Zone as any).l('cordova', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('cordova', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   if (global.cordova) {
     const SUCCESS_SOURCE = 'cordova.exec.success';
     const ERROR_SOURCE = 'cordova.exec.error';
     const FUNCTION = 'function';
-    const nativeExec: Function = api.patchMethod(
-        global.cordova, 'exec', (delegate: Function) => function(self: any, args: any[]) {
+    const nativeExec: Function =
+        api.patchMethod(global.cordova, 'exec', () => function(self: any, args: any[]) {
           if (args.length > 0 && typeof args[0] === FUNCTION) {
-            args[0] = (Zone as any).c.w(args[0], SUCCESS_SOURCE);
+            args[0] = Zone.current.wrap(args[0], SUCCESS_SOURCE);
           }
           if (args.length > 1 && typeof args[1] === FUNCTION) {
-            args[1] = (Zone as any).c.w(args[1], ERROR_SOURCE);
+            args[1] = Zone.current.wrap(args[1], ERROR_SOURCE);
           }
           return nativeExec.apply(self, args);
         });
   }
 });
 
-(Zone as any).l('cordova.FileReader', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('cordova.FileReader', (global: any, Zone: ZoneType) => {
   if (global.cordova && typeof global['FileReader'] !== 'undefined') {
     document.addEventListener('deviceReady', () => {
       const FileReader = global['FileReader'];

--- a/lib/extra/electron.ts
+++ b/lib/extra/electron.ts
@@ -5,13 +5,13 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-(Zone as any).l('electron', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('electron', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   function patchArguments(target: any, name: string, source: string): Function {
     return api.patchMethod(target, name, (delegate: Function) => (self: any, args: any[]) => {
       return delegate && delegate.apply(self, api.bindArguments(args, source));
     });
   }
-  const {desktopCapturer, shell, CallbackRegistry} = require('electron');
+  const {desktopCapturer, shell, CallbacksRegistry} = require('electron');
   // patch api in renderer process directly
   // desktopCapturer
   if (desktopCapturer) {
@@ -23,9 +23,9 @@
   }
 
   // patch api in main process through CallbackRegistry
-  if (!CallbackRegistry) {
+  if (!CallbacksRegistry) {
     return;
   }
 
-  patchArguments(CallbackRegistry.prototype, 'add', 'CallbackRegistry.add');
+  patchArguments(CallbacksRegistry.prototype, 'add', 'CallbackRegistry.add');
 });

--- a/lib/extra/electron.ts
+++ b/lib/extra/electron.ts
@@ -5,17 +5,21 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-Zone.__load_patch('electron', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
-  const FUNCTION = 'function';
+(Zone as any).l('electron', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  function patchArguments(target: any, name: string, source: string): Function {
+    return api.patchMethod(target, name, (delegate: Function) => (self: any, args: any[]) => {
+      return delegate && delegate.apply(self, api.bindArguments(args, source));
+    });
+  }
   const {desktopCapturer, shell, CallbackRegistry} = require('electron');
   // patch api in renderer process directly
   // desktopCapturer
   if (desktopCapturer) {
-    api.patchArguments(desktopCapturer, 'getSources', 'electron.desktopCapturer.getSources');
+    patchArguments(desktopCapturer, 'getSources', 'electron.desktopCapturer.getSources');
   }
   // shell
   if (shell) {
-    api.patchArguments(shell, 'openExternal', 'electron.shell.openExternal');
+    patchArguments(shell, 'openExternal', 'electron.shell.openExternal');
   }
 
   // patch api in main process through CallbackRegistry
@@ -23,5 +27,5 @@ Zone.__load_patch('electron', (global: any, Zone: ZoneType, api: _ZonePrivate) =
     return;
   }
 
-  api.patchArguments(CallbackRegistry.prototype, 'add', 'CallbackRegistry.add');
+  patchArguments(CallbackRegistry.prototype, 'add', 'CallbackRegistry.add');
 });

--- a/lib/node/events.ts
+++ b/lib/node/events.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {globalSources, patchEventTarget, zoneSymbolEventNames} from '../common/events';
+import {ens, gs, patchEventTarget} from '../common/events';
 
-Zone.__load_patch('EventEmitter', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+(Zone as any).l('EventEmitter', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   const callAndReturnFirstParam = (fn: (self: any, args: any[]) => any) => {
     return (self: any, args: any[]) => {
       fn(self, args);
@@ -34,15 +34,15 @@ Zone.__load_patch('EventEmitter', (global: any, Zone: ZoneType, api: _ZonePrivat
 
   function patchEventEmitterMethods(obj: any) {
     const result = patchEventTarget(global, [obj], {
-      useGlobalCallback: false,
-      addEventListenerFnName: EE_ADD_LISTENER,
-      removeEventListenerFnName: EE_REMOVE_LISTENER,
-      prependEventListenerFnName: EE_PREPEND_LISTENER,
-      removeAllFnName: EE_REMOVE_ALL_LISTENER,
-      listenersFnName: EE_LISTENERS,
-      checkDuplicate: false,
-      returnTarget: true,
-      compareTaskCallbackVsDelegate: compareTaskCallbackVsDelegate
+      useG: false,
+      add: EE_ADD_LISTENER,
+      rm: EE_REMOVE_LISTENER,
+      prepend: EE_PREPEND_LISTENER,
+      rmAll: EE_REMOVE_ALL_LISTENER,
+      listeners: EE_LISTENERS,
+      chkDup: false,
+      rt: true,
+      diff: compareTaskCallbackVsDelegate
     });
     if (result && result[0]) {
       obj[EE_ON] = obj[EE_ADD_LISTENER];

--- a/lib/node/events.ts
+++ b/lib/node/events.ts
@@ -6,16 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ens, gs, patchEventTarget} from '../common/events';
+import {patchEventTarget} from '../common/events';
 
-(Zone as any).l('EventEmitter', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
-  const callAndReturnFirstParam = (fn: (self: any, args: any[]) => any) => {
-    return (self: any, args: any[]) => {
-      fn(self, args);
-      return self;
-    };
-  };
-
+Zone.__load_patch('EventEmitter', (global: any) => {
   // For EventEmitter
   const EE_ADD_LISTENER = 'addListener';
   const EE_PREPEND_LISTENER = 'prependListener';
@@ -25,11 +18,8 @@ import {ens, gs, patchEventTarget} from '../common/events';
   const EE_ON = 'on';
 
   const compareTaskCallbackVsDelegate = function(task: any, delegate: any) {
-    if (task.callback === delegate || task.callback.listener === delegate) {
-      // same callback, same capture, same event name, just return
-      return true;
-    }
-    return false;
+    // same callback, same capture, same event name, just return
+    return task.callback === delegate || task.callback.listener === delegate;
   };
 
   function patchEventEmitterMethods(obj: any) {

--- a/lib/node/fs.ts
+++ b/lib/node/fs.ts
@@ -8,7 +8,7 @@
 
 import {patchMacroTask} from '../common/utils';
 
-Zone.__load_patch('fs', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+(Zone as any).l('fs', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   let fs: any;
   try {
     fs = require('fs');
@@ -32,7 +32,7 @@ Zone.__load_patch('fs', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
             return {
               name: 'fs.' + name,
               args: args,
-              callbackIndex: args.length > 0 ? args.length - 1 : -1,
+              cbIdx: args.length > 0 ? args.length - 1 : -1,
               target: self
             };
           });

--- a/lib/node/fs.ts
+++ b/lib/node/fs.ts
@@ -8,7 +8,7 @@
 
 import {patchMacroTask} from '../common/utils';
 
-(Zone as any).l('fs', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+Zone.__load_patch('fs', () => {
   let fs: any;
   try {
     fs = require('fs');

--- a/lib/rxjs/rxjs.ts
+++ b/lib/rxjs/rxjs.ts
@@ -19,14 +19,11 @@ import {Subscriber} from 'rxjs/Subscriber';
 import {Subscription} from 'rxjs/Subscription';
 import {rxSubscriber} from 'rxjs/symbol/rxSubscriber';
 
-(Zone as any).__load_patch('rxjs', (global: any, Zone: ZoneType, api: any) => {
+(Zone as any).__load_patch('rxjs', (global: any, Zone: ZoneType) => {
   const symbol: (symbolString: string) => string = (Zone as any).__symbol__;
-  const subscribeSource = 'rxjs.subscribe';
   const nextSource = 'rxjs.Subscriber.next';
   const errorSource = 'rxjs.Subscriber.error';
   const completeSource = 'rxjs.Subscriber.complete';
-  const unsubscribeSource = 'rxjs.Subscriber.unsubscribe';
-  const teardownSource = 'rxjs.Subscriber.teardownLogic';
 
   const empty = {
     closed: true,
@@ -321,7 +318,6 @@ import {rxSubscriber} from 'rxjs/symbol/rxSubscriber';
     }
 
     const scheduleSymbol = symbol('scheduleSymbol');
-    const flushSymbol = symbol('flushSymbol');
     const zoneSymbol = symbol('zone');
     if (asap[scheduleSymbol]) {
       return;

--- a/lib/rxjs/rxjs.ts
+++ b/lib/rxjs/rxjs.ts
@@ -25,6 +25,8 @@ import {rxSubscriber} from 'rxjs/symbol/rxSubscriber';
   const errorSource = 'rxjs.Subscriber.error';
   const completeSource = 'rxjs.Subscriber.complete';
 
+  const ObjectDefineProperties = Object.defineProperties;
+
   const empty = {
     closed: true,
     next(value: any): void{},
@@ -58,7 +60,7 @@ import {rxSubscriber} from 'rxjs/symbol/rxSubscriber';
     const _subscribe = ObservablePrototype[_symbolSubscribe] = ObservablePrototype._subscribe;
     const subscribe = ObservablePrototype[symbolSubscribe] = ObservablePrototype.subscribe;
 
-    Object.defineProperties(Observable.prototype, {
+    ObjectDefineProperties(Observable.prototype, {
       _zone: {value: null, writable: true, configurable: true},
       _zoneSource: {value: null, writable: true, configurable: true},
       _zoneSubscribe: {value: null, writable: true, configurable: true},
@@ -109,7 +111,7 @@ import {rxSubscriber} from 'rxjs/symbol/rxSubscriber';
     const unsubscribeSymbol = symbol('unsubscribe');
     const unsubscribe = (Subscription.prototype as any)[unsubscribeSymbol] =
         Subscription.prototype.unsubscribe;
-    Object.defineProperties(Subscription.prototype, {
+    ObjectDefineProperties(Subscription.prototype, {
       _zone: {value: null, writable: true, configurable: true},
       _zoneUnsubscribe: {value: null, writable: true, configurable: true},
       _unsubscribe: {
@@ -341,7 +343,7 @@ import {rxSubscriber} from 'rxjs/symbol/rxSubscriber';
           return work.apply(this, arguments);
         }
       };
-      return schedule.apply(this, [patchedWork, delay, state]);
+      return schedule.call(this, patchedWork, delay, state);
     };
   };
 

--- a/lib/zone-spec/fake-async-test.ts
+++ b/lib/zone-spec/fake-async-test.ts
@@ -330,7 +330,7 @@
           // arguments
           let addtionalArgs: any[];
           if (args) {
-            let callbackIndex = (task.data as any).callbackIndex;
+            let callbackIndex = (task.data as any).cbIdx;
             if (typeof args.length === 'number' && args.length > callbackIndex + 1) {
               addtionalArgs = Array.prototype.slice.call(args, callbackIndex + 1);
             }

--- a/lib/zone-spec/fake-async-test.ts
+++ b/lib/zone-spec/fake-async-test.ts
@@ -182,7 +182,7 @@
         namePrefix: string, private trackPendingRequestAnimationFrame = false,
         private macroTaskOptions?: MacroTaskOptions[]) {
       this.name = 'fakeAsyncTestZone for ' + namePrefix;
-      // in case user can't access the construction of FakyAsyncTestSpec
+      // in case user can't access the construction of FakeAsyncTestSpec
       // user can also define macroTaskOptions by define a global variable.
       if (!this.macroTaskOptions) {
         this.macroTaskOptions = global[Zone.__symbol__('FakeAsyncTestMacroTask')];
@@ -328,16 +328,16 @@
           // should pass additional arguments to callback if have any
           // currently we know process.nextTick will have such additional
           // arguments
-          let addtionalArgs: any[];
+          let additionalArgs: any[];
           if (args) {
             let callbackIndex = (task.data as any).cbIdx;
             if (typeof args.length === 'number' && args.length > callbackIndex + 1) {
-              addtionalArgs = Array.prototype.slice.call(args, callbackIndex + 1);
+              additionalArgs = Array.prototype.slice.call(args, callbackIndex + 1);
             }
           }
           this._microtasks.push({
             func: task.invoke,
-            args: addtionalArgs,
+            args: additionalArgs,
             target: task.data && (task.data as any).target
           });
           break;
@@ -378,7 +378,7 @@
                   task.data['handleId'] = this._setInterval(task.invoke, delay, callbackArgs);
                   task.data.isPeriodic = true;
                 } else {
-                  // not periodic, use setTimout to simulate
+                  // not periodic, use setTimeout to simulate
                   task.data['handleId'] = this._setTimeout(task.invoke, delay, callbackArgs);
                 }
                 break;

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -656,7 +656,7 @@ const Zone: ZoneType = (function(global: any) {
     }
 
     static get root(): AmbientZone {
-      let zone = Zone.c;
+      let zone = Zone.current;
       while (zone.parent) {
         zone = zone.parent;
       }
@@ -664,10 +664,6 @@ const Zone: ZoneType = (function(global: any) {
     }
 
     static get current(): AmbientZone {
-      return _currentZoneFrame.zone;
-    }
-
-    static get c(): AmbientZone {
       return _currentZoneFrame.zone;
     }
 
@@ -1176,7 +1172,7 @@ const Zone: ZoneType = (function(global: any) {
         this.invoke = ZoneTask.invokeTask;
       } else {
         this.invoke = function() {
-          return ZoneTask.invokeTask.apply(global, [self, this, <any>arguments]);
+          return ZoneTask.invokeTask.call(global, self, this, <any>arguments);
         };
       }
     }
@@ -1292,7 +1288,6 @@ const Zone: ZoneType = (function(global: any) {
           }
         }
       }
-      const showError: boolean = !(Zone as any)[__symbol__('ignoreConsoleErrorUncaughtError')];
       _api.microtaskDrainDone();
       _isDrainingMicrotaskQueue = false;
     }
@@ -1344,30 +1339,5 @@ const Zone: ZoneType = (function(global: any) {
   }
 
   performanceMeasure('Zone', 'Zone');
-  const z: any = Zone.prototype;
-  /** shorter for Zone.prototype.wrap */
-  z.w = z.wrap;
-  /** shorter for Zone.prototype.fork */
-  z.f = z.fork;
-  /** shorter for Zone.prototype.run */
-  z.r = z.run;
-  /** shorter for Zone.prototype.runGuarded */
-  z.rg = z.runGuarded;
-  /** shorter for Zone.prototype.runTask */
-  z.rt = z.runTask;
-  /** shorter for Zone.prototype.scheduleTask */
-  z.st = z.scheduleTask;
-  /** shorter for Zone.prototype.scheduleMacroTask */
-  z.sc = z.scheduleMacroTask;
-  /** shorter for Zone.prototype.scheduleMicroTask */
-  z.si = z.scheduleMicroTask;
-  /** shorter for Zone.prototype.scheduleEventTask */
-  z.se = z.scheduleEventTask;
-  /** shorter for Zone.prototype.cancelTask */
-  z.ct = z.cancelTask;
-  /** shorter for Zone.__load_patch */
-  (Zone as any).l = Zone.__load_patch;
-  /** shorter for Zone.__symbol__ */
-  (Zone as any).s = Zone.__symbol__;
   return global['Zone'] = Zone;
 })(typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || global);

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1345,17 +1345,29 @@ const Zone: ZoneType = (function(global: any) {
 
   performanceMeasure('Zone', 'Zone');
   const z: any = Zone.prototype;
+  /** shorter for Zone.prototype.wrap */
   z.w = z.wrap;
+  /** shorter for Zone.prototype.fork */
   z.f = z.fork;
+  /** shorter for Zone.prototype.run */
   z.r = z.run;
+  /** shorter for Zone.prototype.runGuarded */
   z.rg = z.runGuarded;
+  /** shorter for Zone.prototype.runTask */
   z.rt = z.runTask;
+  /** shorter for Zone.prototype.scheduleTask */
   z.st = z.scheduleTask;
+  /** shorter for Zone.prototype.scheduleMacroTask */
   z.sc = z.scheduleMacroTask;
+  /** shorter for Zone.prototype.scheduleMicroTask */
   z.si = z.scheduleMicroTask;
+  /** shorter for Zone.prototype.scheduleEventTask */
   z.se = z.scheduleEventTask;
+  /** shorter for Zone.prototype.cancelTask */
   z.ct = z.cancelTask;
+  /** shorter for Zone.__load_patch */
   (Zone as any).l = Zone.__load_patch;
+  /** shorter for Zone.__symbol__ */
   (Zone as any).s = Zone.__symbol__;
   return global['Zone'] = Zone;
 })(typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || global);

--- a/test/browser-zone-setup.ts
+++ b/test/browser-zone-setup.ts
@@ -10,6 +10,7 @@ if (typeof window !== 'undefined') {
 }
 import '../lib/common/to-string';
 import '../lib/browser/browser';
+import '../lib/browser/webapis-user-media';
 import '../lib/zone-spec/async-test';
 import '../lib/zone-spec/fake-async-test';
 import '../lib/zone-spec/long-stack-trace';

--- a/test/browser/browser.spec.ts
+++ b/test/browser/browser.spec.ts
@@ -2504,7 +2504,6 @@ describe('Zone', function() {
                const zone = Zone.current.fork({name: 'media'});
                zone.run(() => {
                  const constraints = {audio: true, video: {width: 1280, height: 720}};
-
                  navigator.getUserMedia(
                      constraints,
                      () => {

--- a/test/browser_entry_point.ts
+++ b/test/browser_entry_point.ts
@@ -25,4 +25,3 @@ import './browser/Worker.spec';
 import './mocha-patch.spec';
 import './jasmine-patch.spec';
 import './extra/cordova.spec';
-import './rxjs/rxjs.spec';

--- a/test/closure/zone.closure.ts
+++ b/test/closure/zone.closure.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import '../../dist/zone-node';
-const shortKeys = ['w', 'f', 'r', 'rg', 'rt', 'st', 'sc', 'si', 'se', 'ct'];
 const testClosureFunction = () => {
   const logs: string[] = [];
   // call all Zone exposed functions
@@ -69,9 +68,7 @@ const testClosureFunction = () => {
       logs.push('get' + keyZone.get('key'));
       logs.push('root' + Zone.root.name);
       Object.keys((Zone as any).prototype).forEach(key => {
-        if (shortKeys.indexOf(key) === -1) {
-          logs.push(key);
-        }
+        logs.push(key);
       });
       Object.keys(testZoneSpec).forEach(key => {
         logs.push(key);

--- a/test/closure/zone.closure.ts
+++ b/test/closure/zone.closure.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import '../../dist/zone-node';
-
+const shortKeys = ['w', 'f', 'r', 'rg', 'rt', 'st', 'sc', 'si', 'se', 'ct'];
 const testClosureFunction = () => {
   const logs: string[] = [];
   // call all Zone exposed functions
@@ -69,7 +69,9 @@ const testClosureFunction = () => {
       logs.push('get' + keyZone.get('key'));
       logs.push('root' + Zone.root.name);
       Object.keys((Zone as any).prototype).forEach(key => {
-        logs.push(key);
+        if (shortKeys.indexOf(key) === -1) {
+          logs.push(key);
+        }
       });
       Object.keys(testZoneSpec).forEach(key => {
         logs.push(key);

--- a/test/common/util.spec.ts
+++ b/test/common/util.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {patchMethod, patchProperty, patchPrototype, wrapFunctionArgs, zoneSymbol} from '../../lib/common/utils';
+import {patchMethod, patchProperty, patchPrototype, zoneSymbol} from '../../lib/common/utils';
 
 describe('utils', function() {
 
@@ -327,32 +327,6 @@ describe('utils', function() {
         });
       });
       expect(log).toEqual(['property2<root>']);
-    });
-  });
-
-  describe('wrapFunctionArgs', () => {
-    it('wrapFunctionArgs should make function arguments in zone', () => {
-      const func = function(arg1: string, arg2: Function, arg3: Function) {
-        arg2(arg1);
-        arg3(arg1);
-      };
-
-      const zone = Zone.current.fork({name: 'wrap'});
-
-      wrapFunctionArgs(func);
-
-      zone.run(() => {
-        func(
-            'test',
-            function(arg: string) {
-              expect(arg).toEqual('test');
-              expect(Zone.current.name).toEqual(zone.name);
-            },
-            function(arg: string) {
-              expect(arg).toEqual('test');
-              expect(Zone.current.name).toEqual(zone.name);
-            });
-      });
     });
   });
 });

--- a/test/common_tests.ts
+++ b/test/common_tests.ts
@@ -21,6 +21,6 @@ import './zone-spec/sync-test.spec';
 import './zone-spec/fake-async-test.spec';
 import './zone-spec/proxy.spec';
 import './zone-spec/task-tracking.spec';
-// import './rxjs/rxjs.spec';
+import './rxjs/rxjs.spec';
 
 Error.stackTraceLimit = Number.POSITIVE_INFINITY;

--- a/test/common_tests.ts
+++ b/test/common_tests.ts
@@ -21,6 +21,6 @@ import './zone-spec/sync-test.spec';
 import './zone-spec/fake-async-test.spec';
 import './zone-spec/proxy.spec';
 import './zone-spec/task-tracking.spec';
-import './rxjs/rxjs.spec';
+// import './rxjs/rxjs.spec';
 
 Error.stackTraceLimit = Number.POSITIVE_INFINITY;

--- a/test/zone-spec/fake-async-test.spec.ts
+++ b/test/zone-spec/fake-async-test.spec.ts
@@ -732,7 +732,7 @@ describe('FakeAsyncTestZoneSpec', () => {
         patchMacroTask(
             TestClass.prototype, 'myTimeout',
             (self: any, args: any[]) =>
-                ({name: 'TestClass.myTimeout', target: self, callbackIndex: 0, args: args}));
+                ({name: 'TestClass.myTimeout', target: self, cbIdx: 0, args: args}));
 
         const testClass = new TestClass();
         testClass.myTimeout(function(callbackArgs: any) {
@@ -758,7 +758,7 @@ describe('FakeAsyncTestZoneSpec', () => {
         patchMacroTask(
             TestClass.prototype, 'myTimeout',
             (self: any, args: any[]) =>
-                ({name: 'TestClass.myTimeout', target: self, callbackIndex: 0, args: args}));
+                ({name: 'TestClass.myTimeout', target: self, cbIdx: 0, args: args}));
 
         const testClass = new TestClass();
         testClass.myTimeout(() => {
@@ -787,7 +787,7 @@ describe('FakeAsyncTestZoneSpec', () => {
         patchMacroTask(
             TestClass.prototype, 'myInterval',
             (self: any, args: any[]) =>
-                ({name: 'TestClass.myInterval', target: self, callbackIndex: 0, args: args}));
+                ({name: 'TestClass.myInterval', target: self, cbIdx: 0, args: args}));
 
         const testClass = new TestClass();
         const id = testClass.myInterval(() => {


### PR DESCRIPTION
fix #989.
1. remove unused code
2. move `getUserMedia` and `electron` related code to standalone files.
3. use `shorter` variable and function name to reduce bundle size.
now the size of `zone.min.js` will be `38510` or `38955` bytes. (the size will change when I rebuild)

4. add file size check logic in `travis` build.
5. change `func.apply` to `func.call` for better performance.

now I set a `limitation` of `zone.min.js` to `40000` bytes.

@mhevery , please review the idea is ok or not. thank you!
  
  