### PR TITLE
add OriginalDelegate prop to Function::toString

### DIFF
--- a/lib/common/to-string.ts
+++ b/lib/common/to-string.ts
@@ -9,15 +9,14 @@ import {zoneSymbol} from './utils';
 
 // override Function.prototype.toString to make zone.js patched function
 // look like native function
-Zone.__load_patch('toString', (global: any, Zone: ZoneType) => {
+Zone.__load_patch('toString', (global: any) => {
   // patch Func.prototype.toString to let them look like native
-  const originalFunctionToString = (Zone as any)['__zone_symbol__originalToString'] =
-      Function.prototype.toString;
+  const originalFunctionToString = Function.prototype.toString;
 
   const ORIGINAL_DELEGATE_SYMBOL = zoneSymbol('OriginalDelegate');
   const PROMISE_SYMBOL = zoneSymbol('Promise');
   const ERROR_SYMBOL = zoneSymbol('Error');
-  Function.prototype.toString = function() {
+  const newFunctionToString = function toString() {
     if (typeof this === 'function') {
       const originalDelegate = this[ORIGINAL_DELEGATE_SYMBOL];
       if (originalDelegate) {
@@ -42,6 +41,8 @@ Zone.__load_patch('toString', (global: any, Zone: ZoneType) => {
     }
     return originalFunctionToString.apply(this, arguments);
   };
+  (newFunctionToString as any)[ORIGINAL_DELEGATE_SYMBOL] = originalFunctionToString;
+  Function.prototype.toString = newFunctionToString;
 
 
   // patch Object.prototype.toString to let them look like native

--- a/test/common/toString.spec.ts
+++ b/test/common/toString.spec.ts
@@ -36,6 +36,10 @@ describe('global function patch', () => {
       expect(Function.prototype.toString.call(Error)).toContain('[native code]');
     });
 
+    it('Function toString should look like native', () => {
+      expect(Function.prototype.toString.call(Function.prototype.toString)).toContain('[native code]');
+    });
+
     it('EventTarget addEventListener should look like native', ifEnvSupports('HTMLElement', () => {
          expect(Function.prototype.toString.call(HTMLElement.prototype.addEventListener))
              .toContain('[native code]');


### PR DESCRIPTION
This PR complements PR #686 , making `Function.prototype.toString.toString()` also returns `"function toString() { [native code] }"`, which should be a little safer.

Update: `Function.prototype.toString.call(Function.prototype.toString)` will return `[native code]`, too.