### PR TITLE
feat(jsonp): provide a help method to patch jsonp

### DIFF
--- a/NON-STANDARD-APIS.md
+++ b/NON-STANDARD-APIS.md
@@ -198,3 +198,22 @@ user need to patch `io` themselves just like following code.
 please reference the sample repo [zone-socketio](https://github.com/JiaLiPassion/zone-socketio) about 
 detail usage.
 
+* jsonp
+
+## Usage.
+
+provide a helper method to patch jsonp. Because jsonp has a lot of implementation, so
+user need to provide the information to let json `send` and `callback` in zone.
+
+there is a sampel repo [zone-jsonp](https://github.com/JiaLiPassion/test-zone-js-with-jsonp) here,
+sample usage is:
+
+```javascript
+import 'zone.js/dist/zone-patch-jsonp';
+Zone['__zone_symbol__jsonp']({
+  jsonp: getJSONP,
+  sendFuncName: 'send',
+  successFuncName: 'jsonpSuccessCallback', 
+  failedFuncName: 'jsonpFailedCallback'
+});
+```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -208,6 +208,14 @@ gulp.task('build/bluebird.min.js', ['compile-esm'], function(cb) {
     return generateScript('./lib/extra/bluebird.ts', 'zone-bluebird.min.js', true, cb);
 });
 
+gulp.task('build/zone-patch-jsonp.js', ['compile-esm'], function(cb) {
+    return generateScript('./lib/extra/jsonp.ts', 'zone-patch-jsonp.js', false, cb);
+});
+
+gulp.task('build/zone-patch-jsonp.min.js', ['compile-esm'], function(cb) {
+    return generateScript('./lib/extra/jsonp.ts', 'zone-patch-jsonp.min.js', true, cb);
+});
+
 gulp.task('build/jasmine-patch.js', ['compile-esm'], function(cb) {
   return generateScript('./lib/jasmine/jasmine.ts', 'jasmine-patch.js', false, cb);
 });
@@ -310,6 +318,8 @@ gulp.task('build', [
   'build/zone-mix.js',
   'build/bluebird.js',
   'build/bluebird.min.js',
+  'build/zone-patch-jsonp.js',
+  'build/zone-patch-jsonp.min.js',
   'build/jasmine-patch.js',
   'build/jasmine-patch.min.js',
   'build/mocha-patch.js',

--- a/lib/extra/jsonp.ts
+++ b/lib/extra/jsonp.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+Zone.__load_patch('jsonp', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  const noop = function() {};
+  // because jsonp is not a standard api, there are a lot of
+  // implementations, so zone.js just provide a helper util to
+  // patch the jsonp send and onSuccess/onError callback
+  // the options is an object which contains
+  // - jsonp, the jsonp object which hold the send function
+  // - sendFuncName, the name of the send function
+  // - successFuncName, success func name
+  // - failedFuncName, failed func name
+  (Zone as any)[Zone.__symbol__('jsonp')] = function patchJsonp(options: any) {
+    if (!options || !options.jsonp || !options.sendFuncName) {
+      return;
+    }
+    const noop = function() {};
+
+    [options.successFuncName, options.failedFuncName].forEach(methodName => {
+      if (!methodName) {
+        return;
+      }
+
+      const oriFunc = global[methodName];
+      if (oriFunc) {
+        api.patchMethod(global, methodName, (delegate: Function) => (self: any, args: any[]) => {
+          const task = global[api.symbol('jsonTask')];
+          if (task) {
+            task.callback = delegate;
+            return task.invoke.apply(self, args);
+          } else {
+            return delegate.apply(self, args);
+          }
+        });
+      } else {
+        Object.defineProperty(global, methodName, {
+          configurable: true,
+          enumerable: true,
+          get: function() {
+            return function() {
+              const task = global[api.symbol('jsonpTask')];
+              const target = this ? this : global;
+              const delegate = global[api.symbol(`jsonp${methodName}callback`)];
+
+              if (task) {
+                if (delegate) {
+                  task.callback = delegate;
+                }
+                global[api.symbol('jsonpTask')] = undefined;
+                return task.invoke.apply(this, arguments);
+              } else {
+                if (delegate) {
+                  return delegate.apply(this, arguments);
+                }
+              }
+              return null;
+            };
+          },
+          set: function(callback: Function) {
+            this[api.symbol(`jsonp${methodName}callback`)] = callback;
+          }
+        });
+      }
+    });
+
+    api.patchMethod(options.jsonp, options.sendFuncName, (delegate: Function) => (self: any, args: any[]) => {
+      global[api.symbol('jsonpTask')] = Zone.current.scheduleMacroTask('jsonp', noop, {}, (task: Task) => {
+        return delegate.apply(self, args);
+      }, noop);
+    });
+  };
+});


### PR DESCRIPTION
fix https://github.com/angular/angular/issues/7792
provide a helper method to patch `jsonp`.

 Because jsonp has a lot of implementation, so
user need to provide the information to let json `send` and `callback` in zone.

sample usage is:

```javascript
import 'zone.js/dist/zone-patch-jsonp';
Zone['__zone_symbol__jsonp']({
  jsonp: getJSONP,
  sendFuncName: 'send',
 onSuccessFuncName: 'onSuccess',
 onFailedFuncName: 'onFailed'
});
```

### update
now the CI failed because new version `jasmine` complains,  I have pinned the version of `jasmine` in #994.