### PR TITLE
fix(core): don't update taskCounts of setInterval

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -846,8 +846,9 @@ const Zone: ZoneType = (function(global: any) {
         this._zoneDelegate.handleError(this, err);
         throw err;
       }
-      if ((task as any as ZoneTask<any>)._zoneDelegates === zoneDelegates) {
+      if ((task as any as ZoneTask<any>)._zoneDelegates === zoneDelegates && !(task.data && task.data.isPeriodic)) {
         // we have to check because internally the delegate can reschedule the task.
+        // and we don't need to updateTaskCount for periodic task such as setInterval
         this._updateTaskCount(task as any as ZoneTask<any>, 1);
       }
       if ((task as any as ZoneTask<any>).state == scheduling) {
@@ -891,7 +892,9 @@ const Zone: ZoneType = (function(global: any) {
         this._zoneDelegate.handleError(this, err);
         throw err;
       }
-      this._updateTaskCount(task as ZoneTask<any>, -1);
+      if (!(task.data && task.data.isPeriodic)) {
+        this._updateTaskCount(task as ZoneTask<any>, -1);
+      }
       (task as ZoneTask<any>)._transitionTo(notScheduled, canceling);
       task.runCount = 0;
       return task;

--- a/test/common/zone.spec.ts
+++ b/test/common/zone.spec.ts
@@ -183,14 +183,7 @@ describe('Zone', function() {
         zone.cancelTask(task);
       });
       expect(log).toEqual([
-        {microTask: false, macroTask: true, eventTask: false, change: 'macroTask', zone: 'parent'},
-        'macroTask', 'macroTask', {
-          microTask: false,
-          macroTask: false,
-          eventTask: false,
-          change: 'macroTask',
-          zone: 'parent'
-        }
+        'macroTask', 'macroTask'
       ]);
     });
 


### PR DESCRIPTION
fix https://github.com/angular/angular/issues/20970#issuecomment-360444160

don't update taskCount or trigger `hasTask` for `setInterval`.
otherwise the `zone` will always be `unstable`.

### update
now the CI failed because new version `jasmine` complains,  I have pinned the version of `jasmine` in #994.