### PR TITLE
fix(core): fix #1000, check target is null or not when patchOnProperty

### DIFF
--- a/lib/browser/property-descriptor.ts
+++ b/lib/browser/property-descriptor.ts
@@ -256,6 +256,11 @@ function filterProperties(
 
 export function patchFilteredProperties(
     target: any, onProperties: string[], ignoreProperties: IgnoreProperty[], prototype?: any) {
+  // check whether target is available, sometimes target will be undefined
+  // because different browser or some 3rd party plugin.
+  if (!target) {
+    return;
+  }
   const filteredProperties: string[] = filterProperties(target, onProperties, ignoreProperties);
   patchOnProperties(target, filteredProperties, prototype);
 }


### PR DESCRIPTION
fix #1000.

check target prototype is available or not, in some browser with some extensions or 3rd party library installed, global object's prototype maybe modified.