### PR TITLE
feat(jasmine): support Date.now in fakeAsyncTest

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -276,6 +276,14 @@ gulp.task('build/rxjs.min.js', ['compile-esm'], function(cb) {
   return generateScript('./lib/rxjs/rxjs.ts', 'zone-patch-rxjs.min.js', true, cb);
 });
 
+gulp.task('build/rxjs-fake-async.js', ['compile-esm'], function(cb) {
+  return generateScript('./lib/rxjs/rxjs-fake-async.ts', 'zone-patch-rxjs-fake-async.js', false, cb);
+});
+
+gulp.task('build/rxjs-fake-async.min.js', ['compile-esm'], function(cb) {
+  return generateScript('./lib/rxjs/rxjs-fake-async.ts', 'zone-patch-rxjs-fake-async.min.js', true, cb);
+});
+
 gulp.task('build/closure.js', function() {
   return gulp.src('./lib/closure/zone_externs.js')
              .pipe(gulp.dest('./dist'));
@@ -327,6 +335,8 @@ gulp.task('build', [
   'build/sync-test.js',
   'build/rxjs.js',
   'build/rxjs.min.js',
+  'build/rxjs-fake-async.js',
+  'build/rxjs-fake-async.min.js',
   'build/closure.js'
 ]);
 

--- a/lib/rxjs/rxjs-fake-async.ts
+++ b/lib/rxjs/rxjs-fake-async.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Scheduler} from 'rxjs/Scheduler';
+import {async} from 'rxjs/scheduler/async';
+import {asap} from 'rxjs/scheduler/asap';
+
+Zone.__load_patch('rxjs.Scheduler.now', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  api.patchMethod(Scheduler, 'now', (delegate: Function) => (self: any, args: any[]) => {
+    return Date.now.apply(self, args);
+  });
+  api.patchMethod(async, 'now', (delegate: Function) => (self: any, args: any[]) => {
+    return Date.now.apply(self, args);
+  });
+  api.patchMethod(asap, 'now', (delegate: Function) => (self: any, args: any[]) => {
+    return Date.now.apply(self, args);
+  });
+});


### PR DESCRIPTION
fix https://github.com/angular/angular/issues/8678

support `Date.now` in `fakeAsyncTest`. there are `3` features in this PR.

- support auto patch `Date.now` and `new Date()` in `fakeAsync`.

```javascript
 fakeAsyncTestZone.run(() => {
        const start = Date.now();
        testZoneSpec.tick(100);
        const end = Date.now();
        expect(end - start).toBe(100);
  });

 fakeAsyncTestZone.run(() => {
        const start = new Date();
        testZoneSpec.tick(100);
        const end = new Date();
        expect(end.getTime() - start.getTime()).toBe(100);
  });
```

- automatically run a `fakeAsync` test when `jasmine.clock().install` is called.

```javascript
beforeEach(() => {
      jasmine.clock().install();
    });

    afterEach(() => {
      jasmine.clock().uninstall();
    });

    it('should get date diff correctly', () => {  // we don't need fakeAsync here.
      // automatically run into fake async zone, because jasmine.clock() is installed.
      const start = Date.now();
      jasmine.clock().tick(100);
      const end = Date.now();
      expect(end - start).toBe(100);
    });
```

- rxjs `Scheduler` support, need to import `zone.js/dist/zone-patch-rxjs-fake-async`.

```javascript
    import '../../lib/rxjs/rxjs-fake-async';
    it('should get date diff correctly', (done) => {
      fakeAsyncTestZone.run(() => {
        let result = null;
        const observable = new Observable((subscribe: any) => {
          subscribe.next('hello');
        });
        observable.delay(1000).subscribe(v => {
          result = v;
        });
        expect(result).toBeNull();
        testZoneSpec.tick(1000);
        expect(result).toBe('hello');
        done();
      });
    });
```

@mhevery , @vikerman , please review, thank you!