### PR TITLE
feat(test): can handle non zone aware task in promise within AsyncTestZoneSpec

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -200,6 +200,14 @@ gulp.task('build/zone-patch-socket-io.min.js', ['compile-esm'], function(cb) {
   return generateScript('./lib/extra/socket-io.ts', 'zone-patch-socket-io.min.js', true, cb);
 });
 
+gulp.task('build/zone-patch-promise-testing.js', ['compile-esm'], function(cb) {
+  return generateScript('./lib/testing/promise-testing.ts', 'zone-patch-promise-test.js', false, cb);
+});
+
+gulp.task('build/zone-patch-promise-testing.min.js', ['compile-esm'], function(cb) {
+  return generateScript('./lib/testing/promise-testing.ts', 'zone-patch-promise-test.min.js', true, cb);
+});
+
 gulp.task('build/bluebird.js', ['compile-esm'], function(cb) {
     return generateScript('./lib/extra/bluebird.ts', 'zone-bluebird.js', false, cb);
 });
@@ -307,6 +315,8 @@ gulp.task('build', [
   'build/zone-patch-user-media.min.js',
   'build/zone-patch-socket-io.js',
   'build/zone-patch-socket-io.min.js',
+  'build/zone-patch-promise-testing.js',
+  'build/zone-patch-promise-testing.min.js',
   'build/zone-mix.js',
   'build/bluebird.js',
   'build/bluebird.min.js',

--- a/karma-dist.conf.js
+++ b/karma-dist.conf.js
@@ -20,5 +20,6 @@ module.exports = function (config) {
   config.files.push('dist/sync-test.js');
   config.files.push('dist/task-tracking.js');
   config.files.push('dist/wtf.js');
+  config.files.push('dist/zone-patch-promise-test.js');
   config.files.push('build/test/main.js');
 };

--- a/lib/common/promise.ts
+++ b/lib/common/promise.ts
@@ -241,7 +241,7 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
       } catch (error) {
         resolvePromise(chainPromise, false, error);
       }
-    });
+    }, chainPromise as TaskData);
   }
 
   const ZONE_AWARE_PROMISE_TO_STRING = 'function ZoneAwarePromise() { [native code] }';

--- a/lib/testing/promise-testing.ts
+++ b/lib/testing/promise-testing.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+ /**
+  * Promise for async/fakeAsync zoneSpec test
+  * can support async operation which not supported by zone.js
+  * such as
+  * it ('test jsonp in AsyncZone', async() => {
+  *   new Promise(res => {
+  *     jsonp(url, (data) => {
+  *       // success callback  
+  *       res(data); 
+  *     });
+  *   }).then((jsonpResult) => {
+  *     // get jsonp result. 
+  *
+  *     // user will expect AsyncZoneSpec wait for
+  *     // then, but because jsonp is not zone aware
+  *     // AsyncZone will finish before then is called.
+  *   });
+  * });
+  */
+Zone.__load_patch('promisefortest', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  const symbolState: string = api.symbol('state');
+  const UNRESOLVED: null = null;
+  const symbolParentUnresolved = api.symbol('parentUnresolved');
+  
+  // patch Promise.prototype.then to keep an internal
+  // number for tracking unresolved chained promise
+  // we will decrease this number when the parent promise
+  // being resolved/rejected and chained promise was
+  // scheduled as a microTask.
+  // so we can know such kind of chained promise still
+  // not resolved in AsyncTestZone
+  (Promise as any)[api.symbol('patchPromiseForTest')] = function patchPromiseForTest() {
+    let oriThen = (Promise as any)[Zone.__symbol__('ZonePromiseThen')];
+    if (oriThen) {
+      return;
+    }
+    oriThen = (Promise as any)[Zone.__symbol__('ZonePromiseThen')] = Promise.prototype.then;
+    Promise.prototype.then = function() {
+      const chained = oriThen.apply(this, arguments); 
+      if (this[symbolState] === UNRESOLVED) {
+        // parent promise is unresolved.
+        const asyncTestZoneSpec = Zone.current.get('AsyncTestZoneSpec');
+        if (asyncTestZoneSpec) {
+          asyncTestZoneSpec.unresolvedChainedPromiseCount ++;
+          chained[symbolParentUnresolved] = true;
+        }
+      } 
+      return chained;
+    };
+  };
+
+  (Promise as any)[api.symbol('unPatchPromiseForTest')] = function unpatchPromiseForTest() {
+    // restore origin then
+    const oriThen = (Promise as any)[Zone.__symbol__('ZonePromiseThen')];
+    if (oriThen) {
+      Promise.prototype.then = oriThen;
+      (Promise as any)[Zone.__symbol__('ZonePromiseThen')] = undefined;
+    }
+  };
+});

--- a/lib/testing/zone-testing.ts
+++ b/lib/testing/zone-testing.ts
@@ -13,3 +13,4 @@ import '../zone-spec/sync-test';
 import '../jasmine/jasmine';
 import '../zone-spec/async-test';
 import '../zone-spec/fake-async-test';
+import './promise-testing';

--- a/lib/zone-spec/async-test.ts
+++ b/lib/zone-spec/async-test.ts
@@ -7,21 +7,27 @@
  */
 
 class AsyncTestZoneSpec implements ZoneSpec {
+  static symbolParentUnresolved = Zone.__symbol__('parentUnresolved');
+
   _finishCallback: Function;
   _failCallback: Function;
   _pendingMicroTasks: boolean = false;
   _pendingMacroTasks: boolean = false;
   _alreadyErrored: boolean = false;
   runZone = Zone.current;
+  unresolvedChainedPromiseCount = 0;
 
   constructor(finishCallback: Function, failCallback: Function, namePrefix: string) {
     this._finishCallback = finishCallback;
     this._failCallback = failCallback;
     this.name = 'asyncTestZone for ' + namePrefix;
+    this.properties = {
+      'AsyncTestZoneSpec': this 
+    };
   }
 
   _finishCallbackIfDone() {
-    if (!(this._pendingMicroTasks || this._pendingMacroTasks)) {
+    if (!(this._pendingMicroTasks || this._pendingMacroTasks || this.unresolvedChainedPromiseCount !== 0)) {
       // We do this because we would like to catch unhandled rejected promises.
       this.runZone.run(() => {
         setTimeout(() => {
@@ -33,9 +39,36 @@ class AsyncTestZoneSpec implements ZoneSpec {
     }
   }
 
+  patchPromiseForTest() {
+    const patchPromiseForTest = (Promise as any)[Zone.__symbol__('patchPromiseForTest')];
+    if (patchPromiseForTest) {
+      patchPromiseForTest();
+    }
+  }
+
+  unPatchPromiseForTest() {
+    const unPatchPromiseForTest = (Promise as any)[Zone.__symbol__('unPatchPromiseForTest')];
+    if (unPatchPromiseForTest) {
+      unPatchPromiseForTest();
+    }
+  }
+
   // ZoneSpec implementation below.
 
   name: string;
+
+  properties: {[key: string]: any};
+
+  onScheduleTask(delegate: ZoneDelegate, current: Zone, target: Zone, task: Task): Task {
+    if (task.type === 'microTask' && task.data && task.data instanceof Promise) {
+      // check whether the promise is a chained promise 
+      if ((task.data as any)[AsyncTestZoneSpec.symbolParentUnresolved] === true) {
+        // chained promise is being scheduled
+        this.unresolvedChainedPromiseCount --;
+      }
+    } 
+    return delegate.scheduleTask(target, task);
+  }
 
   // Note - we need to use onInvoke at the moment to call finish when a test is
   // fully synchronous. TODO(juliemr): remove this when the logic for
@@ -44,8 +77,10 @@ class AsyncTestZoneSpec implements ZoneSpec {
       parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, delegate: Function,
       applyThis: any, applyArgs: any[], source: string): any {
     try {
+      this.patchPromiseForTest();
       return parentZoneDelegate.invoke(targetZone, delegate, applyThis, applyArgs, source);
     } finally {
+      this.unPatchPromiseForTest();
       this._finishCallbackIfDone();
     }
   }

--- a/test/browser-zone-setup.ts
+++ b/test/browser-zone-setup.ts
@@ -19,3 +19,4 @@ import '../lib/zone-spec/sync-test';
 import '../lib/zone-spec/task-tracking';
 import '../lib/zone-spec/wtf';
 import '../lib/extra/cordova';
+import '../lib/testing/promise-testing';

--- a/test/node_entry_point.ts
+++ b/test/node_entry_point.ts
@@ -24,6 +24,7 @@ import '../lib/zone-spec/task-tracking';
 import '../lib/zone-spec/wtf';
 import '../lib/rxjs/rxjs';
 
+import '../lib/testing/promise-testing';
 // Setup test environment
 import './test-env-setup-jasmine';
 

--- a/test/zone-spec/async-test.spec.ts
+++ b/test/zone-spec/async-test.spec.ts
@@ -316,4 +316,31 @@ describe('AsyncTestZoneSpec', function() {
     });
 
   });
+
+  describe('non zone aware async task in promise should be detected', () => {
+    it('should be able to detect non zone aware async task in promise', (done) => {
+      let finished = false;
+
+      const testZoneSpec = new AsyncTestZoneSpec(
+          () => {
+            expect(finished).toBe(true);
+            done();
+          },
+          () => {
+            done.fail('async zone called failCallback unexpectedly');
+          },
+          'name');
+
+      const atz = Zone.current.fork(testZoneSpec);
+
+      atz.run(() => {
+        new Promise((res, rej) => {
+          const g: any = typeof window === 'undefined' ? global : window;
+          g[Zone.__symbol__('setTimeout')](res, 100);
+        }).then(() => {
+          finished = true;
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
fix #1013.
currently if there are some `async` task which is not `zone aware`, `AsyncTestZoneSpec` will not handle it. such as, 

```javascript
it('test jsonp', () => {
 let finished = false; 
  const asyncTestZoneSpec = new AsyncTestZoneSpec(() => {
     expect(finished).toBe(true);
   }, () => {}, 'async');
   asyncTestZone.run(() => {
     jsonp(url, () =>{
        // success callback
        finished = true;
     });
   });
}); 
 
```

this case will fail because `jsonp` is not a `zone aware` async operation, so finished will be still be false, when `AsyncTestZone` think all `microTasks` and `macroTasks` have been done (but jsonp is still running).

We can't handle all `non zone aware` async task, so when such kind of issue occurs, we can help user use `Zone.prototype.scheduleMicroTask` or `Zone.prototype.scheduleMacroTask` to handle them.

But some case is much more confusing the user with `promise`, such as, 


```javascript
it('test jsonp', () => {
 let finished = false; 
  const asyncTestZoneSpec = new AsyncTestZoneSpec(() => {
     expect(finished).toBe(true);
   }, () => {}, 'async');
   asyncTestZone.run(() => {
     new Promise((res, rej) => {
       jsonp(url, () =>{
        // success callback and resolve the promise
        res();
       });
     }).then(() => {
        finished = true;
     });
   });
}); 
 
```

now even with the `promise` and `promise.then`, the case still failed. Because 
- `jsonp` is not `zone aware`.
- so `new Promise((res, rej) => jsonp(...))` will not trigger any `async` operation (promise itself it not `async`).
- `promise.then` is also not `async`  until the `promise` is resolved.

But the asyncTestZone will think all `async` finished (in this case, no async happened) before `promise.then` is invoked and schedule a microTask. So the test case will still fail.

We can still handle this issue by make those `non zone aware` task to `zone aware`, but it will cost time, and in most case, user call `promise.then`, they believe promise will be resolved or rejected, so I think `zone.js` may handle it more friendly.

in this PR, if there is such case.

- promise is chained (means promise.then is called)
- parent promise is unresolved.

I will increase a chainedPromise number in AsyncTestZoneSpec. And when the chainedPromise's parent resolved and `schedule` a microTask, I will decrease the number, and when `AsyncTestZoneSpec` check whether should call `finish or not` not only check `hasPendingMicroTask/MacoTask` but also check is there any `promise.then` waiting for `non zone aware` promise.

```javascript
it('test jsonp', () => {
 let finished = false; 
  const asyncTestZoneSpec = new AsyncTestZoneSpec(() => {
     expect(finished).toBe(true);
   }, () => {}, 'async');
   asyncTestZone.run(() => {
     new Promise((res, rej) => {
       jsonp(url, () =>{
        // success callback and resolve the promise
        res();  // 2. here, when parent promise resolved, and a microTask is scheduled, decrease the chainedPromise number.
       });
     }).then(() => {  // 1. here, when promise.then is called, increase the chainedPromise number
        finished = true; 
     });
   });
}); 
```

@mhevery , could you take a look about this idea is ok or not? thank you!