### PR TITLE
fix(event): fix #1021, removeListener/removeAllListeners should return eventEmitter

### DIFF
--- a/lib/common/events.ts
+++ b/lib/common/events.ts
@@ -497,6 +497,9 @@ export function patchEventTarget(
               target[symbolEventName] = null;
             }
             existingTask.zone.cancelTask(existingTask);
+            if (returnTarget) {
+              return target;
+            }
             return;
           }
         }
@@ -570,6 +573,10 @@ export function patchEventTarget(
             }
           }
         }
+      }
+
+      if (returnTarget) {
+        return this;
       }
     };
 

--- a/test/node/events.spec.ts
+++ b/test/node/events.spec.ts
@@ -66,6 +66,13 @@ describe('nodejs EventEmitter', () => {
       emitter.emit('test2', 'test value');
     });
   });
+  it('remove listener should return event emitter', () => {
+    zoneA.run(() => {
+      emitter.on('test', shouldNotRun);
+      expect(emitter.removeListener('test', shouldNotRun)).toEqual(emitter);
+      emitter.emit('test', 'test value');
+    });
+  });
   it('should return all listeners for an event', () => {
     zoneA.run(() => {
       emitter.on('test', expectZoneA);
@@ -103,6 +110,14 @@ describe('nodejs EventEmitter', () => {
       emitter.on('test', expectZoneA);
       emitter.on('test', expectZoneA);
       emitter.removeAllListeners('test');
+      expect(emitter.listeners('test').length).toEqual(0);
+    });
+  });
+  it('remove All listeners should return event emitter', () => {
+    zoneA.run(() => {
+      emitter.on('test', expectZoneA);
+      emitter.on('test', expectZoneA);
+      expect(emitter.removeAllListeners('test')).toEqual(emitter);
       expect(emitter.listeners('test').length).toEqual(0);
     });
   });


### PR DESCRIPTION
fix #1021.

`EventEmitter.prototype.removeListener` and `EventEmitter.prototype.removeAllListeners`  should return `EventEmitter` itself to allow `chaining`.