### PR TITLE
fix(test): fix mocha compatible issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ script:
   - node_modules/.bin/gulp test/node
   - node simple-server.js 2>&1> server.log&
   - node ./test/webdriver/test.sauce.js
-  - yarn add jasmine@3.0.0 jasmine-core@3.0.0
+  - yarn add jasmine@3.0.0 jasmine-core@3.0.0 mocha@5.0.1
   - yarn test:phantomjs-single
   - node_modules/.bin/karma start karma-dist-sauce-jasmine3.conf.js --single-run
+  - node_modules/.bin/karma start karma-build-sauce-selenium3-mocha.conf.js --single-run
   - node_modules/.bin/gulp test/node

--- a/karma-build-sauce-selenium3-mocha.conf.js
+++ b/karma-build-sauce-selenium3-mocha.conf.js
@@ -8,5 +8,5 @@
 
 module.exports = function (config) {
   require('./karma-dist-mocha.conf.js')(config);
-  require('./sauce-selenium3.conf')(config);
+  require('./sauce-selenium3.conf')(config, ['SL_IE9']);
 };

--- a/lib/mocha/mocha.ts
+++ b/lib/mocha/mocha.ts
@@ -158,9 +158,6 @@
 
     Mocha.Runner.prototype.run = function(fn: Function) {
       this.on('test', (e: any) => {
-        if (Zone.current !== rootZone) {
-          throw new Error('Unexpected zone: ' + Zone.current.name);
-        }
         testZone = rootZone.fork(new ProxyZoneSpec());
       });
 


### PR DESCRIPTION
fix https://github.com/angular/angular/issues/22150

in new version of mocha, the code like below 

```javascript
 beforeEach(async(() => {
    TestBed.configureTestingModule({
      declarations: [
        AppComponent
      ],
    }).compileComponents();
  }));

  it(`should have as title 'app'`, async(() => {
    console.log('title app test');
    const fixture = TestBed.createComponent(AppComponent);
    const app = fixture.debugElement.componentInstance;
    expect(app.title).to.equal('app');
  }));
```

will in the same `Mocha.Runner.prototype.run`.
so `Mocha.Runner.prototype.run` will run into `ProxyZone` instead of `rootZone`, we need to remove the `root zone` check, otherwise all mocha test will not begin.

also update `mocha` to 5.0.1