### PR TITLE
fix(testing): fix #1032, fakeAsync should pass parameters correctly

### DIFF
--- a/lib/zone-spec/fake-async-test.ts
+++ b/lib/zone-spec/fake-async-test.ts
@@ -294,7 +294,7 @@
       this._scheduler.removeScheduledFunctionWithId(id);
     }
 
-    private _setInterval(fn: Function, interval: number, ...args: any[]): number {
+    private _setInterval(fn: Function, interval: number, args: any[]): number {
       let id = this._scheduler.nextId;
       let completers = {onSuccess: null as Function, onError: this._dequeuePeriodicTimer(id)};
       let cb = this._fnAndFlush(fn, completers);
@@ -410,11 +410,11 @@
           switch (task.source) {
             case 'setTimeout':
               task.data['handleId'] =
-                  this._setTimeout(task.invoke, task.data['delay'], (task.data as any)['args']);
+                  this._setTimeout(task.invoke, task.data['delay'], Array.prototype.slice.call((task.data as any)['args'], 2));
               break;
             case 'setInterval':
               task.data['handleId'] =
-                  this._setInterval(task.invoke, task.data['delay'], (task.data as any)['args']);
+                  this._setInterval(task.invoke, task.data['delay'], Array.prototype.slice.call((task.data as any)['args'], 2));
               break;
             case 'XMLHttpRequest.send':
               throw new Error(

--- a/test/zone-spec/fake-async-test.spec.ts
+++ b/test/zone-spec/fake-async-test.spec.ts
@@ -206,6 +206,18 @@ describe('FakeAsyncTestZoneSpec', () => {
       });
     });
 
+    it('should pass arguments to times', () => {
+      fakeAsyncTestZone.run(() => {
+        let value = 'genuine value';
+        let id = setTimeout((arg1, arg2) => {
+          value = arg1 + arg2;
+        }, 0, 'expected', ' value');
+    
+        testZoneSpec.tick();
+        expect(value).toEqual('expected value');
+      });
+    });
+
     it('should run periodic timers', () => {
       fakeAsyncTestZone.run(() => {
         let cycles = 0;
@@ -224,6 +236,18 @@ describe('FakeAsyncTestZoneSpec', () => {
 
         testZoneSpec.tick(30);
         expect(cycles).toEqual(6);
+      });
+    });
+
+    it('should pass arguments to periodic timers', () => {
+      fakeAsyncTestZone.run(() => {
+        let value = 'genuine value';
+        let id = setInterval((arg1, arg2) => {
+          value = arg1 + arg2;
+        }, 10, 'expected', ' value');
+    
+        testZoneSpec.tick(10);
+        expect(value).toEqual('expected value');
       });
     });
 


### PR DESCRIPTION
fix #1032 

Thanks @e-hein find this issue and provide the fix and spec.
`fakeAsyncTest` should pass `parameters` correctly.