### PR TITLE
feat(bluebird): fix #921, #977, support bluebird

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ script:
   - node_modules/.bin/karma start karma-dist-sauce-selenium3-jasmine.conf.js --single-run
   - node_modules/.bin/karma start karma-build-sauce-selenium3-mocha.conf.js --single-run
   - node_modules/.bin/gulp test/node
+  - node_modules/.bin/gulp test/bluebird
   - node simple-server.js 2>&1> server.log&
   - node ./test/webdriver/test.sauce.js
   - yarn add jasmine@3.0.0 jasmine-core@3.0.0

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -391,11 +391,9 @@ gulp.task('build', [
   'build/closure.js'
 ]);
 
-gulp.task('test/node', ['compile-node'], function(cb) {
+function nodeTest(specFiles, cb) {
   var JasmineRunner = require('jasmine');
   var jrunner = new JasmineRunner();
-
-  var specFiles = ['build/test/node_entry_point.js'];
 
   jrunner.configureDefaultReporter({showColors: true});
 
@@ -417,6 +415,16 @@ gulp.task('test/node', ['compile-node'], function(cb) {
   jrunner.specDir = '';
   jrunner.addSpecFiles(specFiles);
   jrunner.execute();
+}
+
+gulp.task('test/node', ['compile-node'], function(cb) {
+  var specFiles = ['build/test/node_entry_point.js'];
+  nodeTest(specFiles, cb);
+});
+
+gulp.task('test/bluebird', ['compile-node'], function(cb) {
+  var specFiles = ['build/test/node_bluebird_entry_point.js'];
+  nodeTest(specFiles, cb);
 });
 
 // Check the coding standards and programming errors

--- a/lib/extra/bluebird.ts
+++ b/lib/extra/bluebird.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-Zone.__load_patch('bluebird', (global: any, Zone: ZoneType) => {
+Zone.__load_patch('bluebird', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   // TODO: @JiaLiPassion, we can automatically patch bluebird
   // if global.Promise = Bluebird, but sometimes in nodejs,
   // global.Promise is not Bluebird, and Bluebird is just be
@@ -13,8 +13,28 @@ Zone.__load_patch('bluebird', (global: any, Zone: ZoneType) => {
   // safe to just expose a method to patch Bluebird explicitly
   const BLUEBIRD = 'bluebird';
   (Zone as any)[Zone.__symbol__(BLUEBIRD)] = function patchBluebird(Bluebird: any) {
-    Bluebird.setScheduler((fn: Function) => {
-      Zone.current.scheduleMicroTask(BLUEBIRD, fn);
+    // patch method of Bluebird.prototype which not using `then` internally
+    const bluebirdApis: string[] = ['then', 'spread', 'finally'];
+    bluebirdApis.forEach(bapi => {
+      api.patchMethod(Bluebird.prototype, bapi, (delegate: Function) => (self: any, args: any[]) => {
+        const zone = Zone.current;
+        for (let i = 0; i < args.length; i ++) {
+          const func = args[i];
+          if (typeof func === 'function') {
+            args[i] = function() {
+              const argSelf: any = this;
+              const argArgs: any = arguments;
+              zone.scheduleMicroTask('Promise.then', () => {
+                return func.apply(argSelf, argArgs);
+              });
+            };
+          }
+        }
+        return delegate.apply(self, args);
+      });
     });
+
+    // override global promise
+    global[api.symbol('ZoneAwarePromise')] = Bluebird;
   };
 });

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:single": "npm run tsc && concurrently \"npm run ws-server\" \"npm run karma-jasmine:autoclose\"",
     "test-dist": "concurrently \"npm run tsc:w\" \"npm run ws-server\" \"karma start karma-dist-jasmine.conf.js\"",
     "test-node": "gulp test/node",
+    "test-bluebird": "gulp test/bluebird",
     "test-mocha": "npm run tsc && concurrently \"npm run tsc:w\" \"npm run ws-server\" \"karma start karma-build-mocha.conf.js\"",
     "serve": "python -m SimpleHTTPServer 8000"
   },
@@ -61,6 +62,7 @@
     "@types/node": "^6.0.96",
     "@types/systemjs": "^0.19.30",
     "assert": "^1.4.1",
+    "bluebird": "^3.5.1",
     "clang-format": "1.0.46",
     "concurrently": "^2.2.0",
     "conventional-changelog": "^1.1.7",

--- a/test/extra/bluebird.spec.ts
+++ b/test/extra/bluebird.spec.ts
@@ -47,8 +47,8 @@ describe('bluebird promise', () => {
       });
       p.then(() => {
         expect(Zone.current.name).toEqual('bluebird');
-        expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-        expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+        expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+        expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
         done();
       });
     });
@@ -62,8 +62,8 @@ describe('bluebird promise', () => {
         }, 0);
       });
       p.catch(() => {
-        expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-        expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+        expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+        expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
         expect(Zone.current.name).toEqual('bluebird');
         done();
       });
@@ -76,8 +76,8 @@ describe('bluebird promise', () => {
           .spread((r1: string, r2: string) => {
             expect(r1).toEqual('test1');
             expect(r2).toEqual('test2');
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
             expect(Zone.current.name).toEqual('bluebird');
             done();
           });
@@ -92,8 +92,8 @@ describe('bluebird promise', () => {
         }, 0);
       });
       p.finally(() => {
-        expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-        expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+        expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+        expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
         expect(Zone.current.name).toEqual('bluebird');
         done();
       });
@@ -112,8 +112,8 @@ describe('bluebird promise', () => {
               })
           .then(() => {
             expect(Zone.current.name).toEqual('bluebird');
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
             done();
           });
     });
@@ -126,8 +126,8 @@ describe('bluebird promise', () => {
             throw new Error('promise error');
           })
           .catch((err: Error) => {
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
             expect(Zone.current.name).toEqual('bluebird');
             expect(err.message).toEqual('promise error');
             done();
@@ -142,8 +142,8 @@ describe('bluebird promise', () => {
             return 'test';
           })()
           .then((result: string) => {
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
             expect(Zone.current.name).toEqual('bluebird');
             expect(result).toEqual('test');
             done();
@@ -154,8 +154,8 @@ describe('bluebird promise', () => {
   it('bluebird promise resolve method should be in zone', (done) => {
     zone.run(() => {
       BluebirdPromise.resolve('test').then((result: string) => {
-        expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-        expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+        expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+        expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
         expect(Zone.current.name).toEqual('bluebird');
         expect(result).toEqual('test');
         done();
@@ -166,8 +166,8 @@ describe('bluebird promise', () => {
   it('bluebird promise reject method should be in zone', (done) => {
     zone.run(() => {
       BluebirdPromise.reject('error').catch((error: Error) => {
-        expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-        expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+        expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+        expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
         expect(Zone.current.name).toEqual('bluebird');
         expect(error).toEqual('error');
         done();
@@ -181,8 +181,8 @@ describe('bluebird promise', () => {
           .then((r: string[]) => {
             expect(r[0]).toEqual('test1');
             expect(r[1]).toEqual('test2');
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
             expect(Zone.current.name).toEqual('bluebird');
             done();
           });
@@ -196,8 +196,8 @@ describe('bluebird promise', () => {
           .then((r: any) => {
             expect(r.test1).toEqual('test1');
             expect(r.test2).toEqual('test2');
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
             expect(Zone.current.name).toEqual('bluebird');
             done();
           });
@@ -209,8 +209,8 @@ describe('bluebird promise', () => {
       BluebirdPromise.any([BluebirdPromise.resolve('test1'), BluebirdPromise.resolve('test2')])
           .then((r: any) => {
             expect(r).toEqual('test1');
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
             expect(Zone.current.name).toEqual('bluebird');
             done();
           });
@@ -223,8 +223,8 @@ describe('bluebird promise', () => {
           .then((r: any) => {
             expect(r.length).toBe(1);
             expect(r[0]).toEqual('test1');
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
             expect(Zone.current.name).toEqual('bluebird');
             done();
           });
@@ -243,8 +243,8 @@ describe('bluebird promise', () => {
             expect(r.length).toBe(2);
             expect(r[0]).toEqual('test1');
             expect(r[1]).toEqual('test2');
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
             expect(Zone.current.name).toEqual('bluebird');
             done();
           });
@@ -261,9 +261,9 @@ describe('bluebird promise', () => {
               })
           .then((r: number) => {
             expect(r).toBe(3);
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length)
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length)
                 .toBeTruthy();
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length)
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length)
                 .toBeTruthy();
             expect(Zone.current.name).toEqual('bluebird');
             done();
@@ -282,8 +282,8 @@ describe('bluebird promise', () => {
               })
           .then((r: number[]) => {
             expect(r[0]).toBe(2);
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
             expect(Zone.current.name).toEqual('bluebird');
             done();
           });
@@ -297,9 +297,11 @@ describe('bluebird promise', () => {
           BluebirdPromise.map(arr, (item: number) => BluebirdPromise.resolve(item)),
           (r: number[], idx: number) => {
             expect(r[idx] === arr[idx]);
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length)
+            expect(Zone.current.name).toEqual('bluebird');
+          }).then((r: any) => {
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length)
                 .toBeTruthy();
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length)
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length)
                 .toBeTruthy();
             expect(Zone.current.name).toEqual('bluebird');
             done();
@@ -314,13 +316,15 @@ describe('bluebird promise', () => {
           BluebirdPromise.map(arr, (item: number) => BluebirdPromise.resolve(item)),
           (r: number[], idx: number) => {
             expect(r[idx] === arr[idx]);
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length)
+            expect(Zone.current.name).toEqual('bluebird');
+          }).then((r: any) => {
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length)
                 .toBeTruthy();
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length)
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length)
                 .toBeTruthy();
             expect(Zone.current.name).toEqual('bluebird');
             done();
-          });
+          });;
     });
   });
 
@@ -329,8 +333,8 @@ describe('bluebird promise', () => {
       BluebirdPromise.race([BluebirdPromise.resolve('test1'), BluebirdPromise.resolve('test2')])
           .then((r: string) => {
             expect(r).toEqual('test1');
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
             expect(Zone.current.name).toEqual('bluebird');
             done();
           });
@@ -358,8 +362,8 @@ describe('bluebird promise', () => {
             expect(Zone.current.name).toEqual('bluebird');
             expect(p.leakObj).toBe(null);
             // using will generate several promise inside bluebird
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBeTruthy();
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBeTruthy();
             done();
           });
     });
@@ -377,8 +381,8 @@ describe('bluebird promise', () => {
       promiseFunc().then((r: string) => {
         expect(Zone.current.name).toEqual('bluebird');
         expect(r).toBe('test');
-        expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-        expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+        expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+        expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
         done();
       });
     });
@@ -406,8 +410,8 @@ describe('bluebird promise', () => {
             expect(r[0]).toBe('test1');
             expect(r[1]).toBe('test2');
             // using will generate several promise inside
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(2);
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(2);
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
             done();
           });
     });
@@ -424,8 +428,8 @@ describe('bluebird promise', () => {
       BluebirdPromise.fromCallback(resolver).then((r: string) => {
         expect(Zone.current.name).toEqual('bluebird');
         expect(r).toBe('test');
-        expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-        expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+        expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+        expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
         done();
       });
     });
@@ -446,8 +450,8 @@ describe('bluebird promise', () => {
       BluebirdPromise.resolve('test').delay(10).then((r: string) => {
         expect(Zone.current.name).toEqual('bluebird');
         expect(r).toBe('test');
-        expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(2);
-        expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(2);
+        expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+        expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
         done();
       });
     });
@@ -464,8 +468,8 @@ describe('bluebird promise', () => {
           .then((r: string) => {
             expect(Zone.current.name).toEqual('bluebird');
             expect(r).toBe('test');
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
             done();
           });
     });
@@ -479,8 +483,10 @@ describe('bluebird promise', () => {
         }, 0);
       });
       p.tap(() => {
-        expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-        expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+        expect(Zone.current.name).toEqual('bluebird');
+      }).then(() => {
+        expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+        expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
         expect(Zone.current.name).toEqual('bluebird');
         done();
       });
@@ -502,8 +508,8 @@ describe('bluebird promise', () => {
               })
           .then((r: string) => {
             expect(r).toEqual('test1');
-            expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-            expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+            expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+            expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
             expect(Zone.current.name).toEqual('bluebird');
             done();
           });
@@ -514,8 +520,8 @@ describe('bluebird promise', () => {
     zone.run(() => {
       BluebirdPromise.resolve(['test1', 'test2']).get(-1).then((r: string) => {
         expect(r).toEqual('test2');
-        expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-        expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+        expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+        expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
         expect(Zone.current.name).toEqual('bluebird');
         done();
       });
@@ -526,8 +532,8 @@ describe('bluebird promise', () => {
     zone.run(() => {
       BluebirdPromise.resolve().return ('test1').then((r: string) => {
         expect(r).toEqual('test1');
-        expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-        expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+        expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+        expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
         expect(Zone.current.name).toEqual('bluebird');
         done();
       });
@@ -538,8 +544,8 @@ describe('bluebird promise', () => {
     zone.run(() => {
       BluebirdPromise.resolve().throw('test1').catch((r: string) => {
         expect(r).toEqual('test1');
-        expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-        expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+        expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+        expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
         expect(Zone.current.name).toEqual('bluebird');
         done();
       });
@@ -550,8 +556,8 @@ describe('bluebird promise', () => {
     zone.run(() => {
       BluebirdPromise.reject().catchReturn('test1').then((r: string) => {
         expect(r).toEqual('test1');
-        expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-        expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+        expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+        expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
         expect(Zone.current.name).toEqual('bluebird');
         done();
       });
@@ -562,8 +568,8 @@ describe('bluebird promise', () => {
     zone.run(() => {
       BluebirdPromise.reject().catchThrow('test1').catch((r: string) => {
         expect(r).toEqual('test1');
-        expect(log.filter(item => item === 'schedule bluebird task bluebird').length).toBe(1);
-        expect(log.filter(item => item === 'invoke bluebird task bluebird').length).toBe(1);
+        expect(log.filter(item => item === 'schedule bluebird task Promise.then').length).toBe(1);
+        expect(log.filter(item => item === 'invoke bluebird task Promise.then').length).toBe(1);
         expect(Zone.current.name).toEqual('bluebird');
         done();
       });
@@ -586,6 +592,31 @@ describe('bluebird promise', () => {
             }
             expect(Zone.current.name).toEqual('bluebird');
           });
+    });
+  });
+
+  it('bluebird should be able to run into different zone', (done: Function) => {
+    Zone.current.fork({
+      name: 'zone_A'
+    }).run(() => {
+      new BluebirdPromise((resolve: any, reject: any) => {
+        expect(Zone.current.name).toEqual('zone_A');
+        resolve(1);
+      }).then((r: any) => {
+        expect(Zone.current.name).toEqual('zone_A');
+      });
+    });
+    
+    Zone.current.fork({
+      name: 'zone_B'
+    }).run(() => {
+      new BluebirdPromise((resolve: any, reject: any) => {
+        expect(Zone.current.name).toEqual('zone_B');
+        resolve(2);
+      }).then((r: any) => {
+        expect(Zone.current.name).toEqual('zone_B');
+        done();
+      });
     });
   });
 });

--- a/test/node_bluebird_entry_point.ts
+++ b/test/node_bluebird_entry_point.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// Must be loaded before zone loads, so that zone can detect WTF.
+import './wtf_mock';
+import './test_fake_polyfill';
+
+// Setup tests for Zone without microtask support
+import '../lib/zone';
+import '../lib/common/promise';
+import '../lib/common/to-string';
+import '../lib/node/node';
+import '../lib/zone-spec/async-test';
+import '../lib/zone-spec/fake-async-test';
+import '../lib/zone-spec/long-stack-trace';
+import '../lib/zone-spec/proxy';
+import '../lib/zone-spec/sync-test';
+import '../lib/zone-spec/task-tracking';
+import '../lib/zone-spec/wtf';
+import '../lib/rxjs/rxjs';
+
+import '../lib/testing/promise-testing';
+// Setup test environment
+import './test-env-setup-jasmine';
+
+// List all tests here:
+import './extra/bluebird.spec';

--- a/test/node_tests.ts
+++ b/test/node_tests.ts
@@ -13,7 +13,3 @@ import './node/Error.spec';
 import './node/crypto.spec';
 import './node/http.spec';
 import './node/console.spec';
-
-// before test bluebird, must run npm install bluebird first.
-// then remove the comment below
-// import './extra/bluebird.spec';

--- a/yarn.lock
+++ b/yarn.lock
@@ -450,6 +450,10 @@ bluebird@^2.9.27, bluebird@^2.9.30:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
 
+bluebird@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+
 body-parser@^1.12.4:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454"


### PR DESCRIPTION
fix #921, #977 
Support `bluebird`.
1. Support use `Bluebird` to override `global Promise`.
2. Support `Bluebird` 's own API to be considered as `microTask`.
3. fix #921 bug that all promises are run into the same zone.  
