### PR TITLE
feat(error): fix #975, can config how to load blacklist zone stack frames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,13 @@ script:
   - node_modules/.bin/karma start karma-build-sauce-mocha.conf.js --single-run
   - node_modules/.bin/karma start karma-dist-sauce-selenium3-jasmine.conf.js --single-run
   - node_modules/.bin/karma start karma-build-sauce-selenium3-mocha.conf.js --single-run
+  - node_modules/.bin/karma start karma-dist-sauce-jasmine3.conf.js --single-run --errorpolicy=disable
+  - node_modules/.bin/karma start karma-dist-sauce-jasmine3.conf.js --single-run --errorpolicy=lazy
   - node_modules/.bin/gulp test/node
   - node_modules/.bin/gulp test/node -no-patch-clock
   - node_modules/.bin/gulp test/bluebird
+  - node_modules/.bin/gulp test/node/disableerror
+  - node_modules/.bin/gulp test/node/lazyerror
   - node simple-server.js 2>&1> server.log&
   - node ./test/webdriver/test.sauce.js
   - yarn add jasmine@3.0.0 jasmine-core@3.0.0 mocha@5.0.1

--- a/file-size-limit.json
+++ b/file-size-limit.json
@@ -3,7 +3,7 @@
     {
       "path": "dist/zone.min.js",
       "checkTarget": true,
-      "limit": 40000
+      "limit": 40144
     }
   ]
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -444,6 +444,18 @@ gulp.task('test/bluebird', ['compile-node'], function(cb) {
   nodeTest(specFiles, cb);
 });
 
+gulp.task('test/node/disableerror', ['compile-node'], function(cb) {
+  process.env.errorpolicy = 'disable';
+  var specFiles = ['build/test/node_error_entry_point.js'];
+  nodeTest(specFiles, cb);
+});
+
+gulp.task('test/node/lazyerror', ['compile-node'], function(cb) {
+  process.env.errorpolicy = 'lazy';
+  var specFiles = ['build/test/node_error_entry_point.js'];
+  nodeTest(specFiles, cb);
+});
+
 // Check the coding standards and programming errors
 gulp.task('lint', () => {
   const tslint = require('gulp-tslint');

--- a/karma-base.conf.js
+++ b/karma-base.conf.js
@@ -9,6 +9,7 @@
 module.exports = function(config) {
   config.set({
     basePath: '',
+    client: {errorpolicy: config.errorpolicy},
     files: [
       'node_modules/systemjs/dist/system-polyfills.js', 'node_modules/systemjs/dist/system.src.js',
       'node_modules/whatwg-fetch/fetch.js',
@@ -41,6 +42,7 @@ module.exports = function(config) {
     browsers: ['Chrome'],
 
     captureTimeout: 60000,
+    retryLimit: 4,
 
     autoWatch: true,
     singleRun: false

--- a/karma-build.conf.js
+++ b/karma-build.conf.js
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-module.exports = function (config) {
+module.exports = function(config) {
   require('./karma-base.conf.js')(config);
   config.files.push('build/test/wtf_mock.js');
   config.files.push('build/test/test_fake_polyfill.js');
   config.files.push('build/lib/zone.js');
   config.files.push('build/lib/common/promise.js');
-  config.files.push('build/lib/common/error-rewrite.js');
   config.files.push('build/test/main.js');
 };

--- a/lib/browser/define-property.ts
+++ b/lib/browser/define-property.ts
@@ -19,7 +19,7 @@ const _create = Object.create;
 const unconfigurablesKey = zoneSymbol('unconfigurables');
 
 export function propertyPatch() {
-  Object.defineProperty = function(obj, prop, desc) {
+  Object.defineProperty = function(obj: any, prop: string, desc: any) {
     if (isUnconfigurable(obj, prop)) {
       throw new TypeError('Cannot assign to read only property \'' + prop + '\' of ' + obj);
     }

--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -342,10 +342,10 @@ export function copySymbolProperties(src: any, dest: any) {
   symbols.forEach((symbol: any) => {
     const desc = Object.getOwnPropertyDescriptor(src, symbol);
     Object.defineProperty(dest, symbol, {
-      get: function () {
+      get: function() {
         return src[symbol];
       },
-      set: function (value: any) {
+      set: function(value: any) {
         if (desc && (!desc.writable || typeof desc.set !== 'function')) {
           // if src[symbol] is not writable or not have a setter, just return
           return;

--- a/lib/node/node_util.ts
+++ b/lib/node/node_util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {setShouldCopySymbolProperties, patchOnProperties, patchMethod, bindArguments} from '../common/utils';
+import {bindArguments, patchMethod, patchOnProperties, setShouldCopySymbolProperties} from '../common/utils';
 
 Zone.__load_patch('node_util', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   api.patchOnProperties = patchOnProperties;

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {},
   "devDependencies": {
     "@types/jasmine": "2.2.33",
-    "@types/node": "^8.10.17",
+    "@types/node": "^9.x",
     "@types/systemjs": "^0.19.30",
     "assert": "^1.4.1",
     "bluebird": "^3.5.1",

--- a/sauce-selenium3.conf.js
+++ b/sauce-selenium3.conf.js
@@ -8,7 +8,7 @@ module.exports = function(config) {
     'SL_CHROME60':
         {base: 'SauceLabs', browserName: 'Chrome', platform: 'Windows 10', version: '60.0'},
     'SL_SAFARI11':
-        {base: 'SauceLabs', browserName: 'safari', platform: 'macOS 10.13', version: '11.0'},
+        {base: 'SauceLabs', browserName: 'safari', platform: 'macOS 10.13', version: '11.1'},
   };
 
   config.set({

--- a/sauce.conf.js
+++ b/sauce.conf.js
@@ -36,7 +36,7 @@ module.exports = function(config, ignoredLaunchers) {
       version: '8.4'
     },*/
     'SL_IOS9': {base: 'SauceLabs', browserName: 'iphone', platform: 'OS X 10.10', version: '9.3'},
-    'SL_IOS10': {base: 'SauceLabs', browserName: 'iphone', platform: 'OS X 10.10', version: '10.2'},
+    'SL_IOS10': {base: 'SauceLabs', browserName: 'iphone', platform: 'OS X 10.10', version: '10.3'},
     'SL_IE9': {
       base: 'SauceLabs',
       browserName: 'internet explorer',

--- a/test/browser/WebSocket.spec.ts
+++ b/test/browser/WebSocket.spec.ts
@@ -47,7 +47,7 @@ if (!window['saucelabs']) {
                  expect(e.data).toBe('pass');
                  done();
                };
-             });
+             }, 10000);
 
              it('should work with addEventListener', function(done) {
                testZone.run(function() {

--- a/test/main.ts
+++ b/test/main.ts
@@ -13,6 +13,14 @@ declare const __karma__: {
 };
 
 __karma__.loaded = function() {};
+
+if (typeof __karma__ !== 'undefined') {
+  (window as any)['__Zone_Error_BlacklistedStackFrames_policy'] =
+      (__karma__ as any).config.errorpolicy;
+} else if (typeof process !== 'undefined') {
+  (window as any)['__Zone_Error_BlacklistedStackFrames_policy'] = process.env.errorpolicy;
+}
+
 (window as any).global = window;
 System.config({
   defaultJSExtensions: true,
@@ -29,7 +37,7 @@ if ((window as any)[(Zone as any).__symbol__('setTimeout')]) {
   // this means that Zone has not patched the browser yet, which means we must be running in
   // build mode and need to load the browser patch.
   browserPatchedPromise = System.import('/base/build/test/browser-zone-setup').then(() => {
-    let testFrameworkPatch = typeof(window as any).Mocha !== 'undefined' ?
+    let testFrameworkPatch = typeof (window as any).Mocha !== 'undefined' ?
         '/base/build/lib/mocha/mocha' :
         '/base/build/lib/jasmine/jasmine';
     return System.import(testFrameworkPatch);
@@ -42,13 +50,15 @@ browserPatchedPromise.then(() => {
       '/base/build/test/test-env-setup-jasmine';
   // Setup test environment
   System.import(testFrameworkPatch).then(() => {
-    System.import('/base/build/test/browser_entry_point')
-        .then(
-            () => {
-              __karma__.start();
-            },
-            (error) => {
-              console.error(error.stack || error);
-            });
+    System.import('/base/build/lib/common/error-rewrite').then(() => {
+      System.import('/base/build/test/browser_entry_point')
+          .then(
+              () => {
+                __karma__.start();
+              },
+              (error) => {
+                console.error(error.stack || error);
+              });
+    });
   });
 });

--- a/test/node/fs.spec.ts
+++ b/test/node/fs.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {exists, read, unlink, unwatchFile, watch, write, watchFile, writeFile, openSync, fstatSync, closeSync, unlinkSync} from 'fs';
+import {closeSync, exists, fstatSync, openSync, read, unlink, unlinkSync, unwatchFile, watch, watchFile, write, writeFile} from 'fs';
 import * as util from 'util';
 
 describe('nodejs file system', () => {
@@ -94,12 +94,15 @@ describe('nodejs file system', () => {
 describe('util.promisify', () => {
   it('fs.exists should work with util.promisify', (done: DoneFn) => {
     const promisifyExists = util.promisify(exists);
-    promisifyExists(__filename).then(r => {
-      expect(r).toBe(true);
-      done();
-    }, err => {
-      fail(`should not be here with error: ${err}`);
-    });
+    promisifyExists(__filename)
+        .then(
+            r => {
+              expect(r).toBe(true);
+              done();
+            },
+            err => {
+              fail(`should not be here with error: ${err}`);
+            });
   });
 
   it('fs.read should work with util.promisify', (done: DoneFn) => {
@@ -111,15 +114,17 @@ describe('util.promisify', () => {
     const buffer = new Buffer(bufferSize);
     let bytesRead = 0;
     // fd, buffer, offset, length, position, callback
-    promisifyRead(fd, buffer, bytesRead, chunkSize, bytesRead).then(
-      (value) => {
-        expect(value.bytesRead).toBe(chunkSize);
-        closeSync(fd);
-        done();
-      }, err => {
-        closeSync(fd);
-        fail(`should not be here with error: ${error}.`);
-      });
+    promisifyRead(fd, buffer, bytesRead, chunkSize, bytesRead)
+        .then(
+            (value) => {
+              expect(value.bytesRead).toBe(chunkSize);
+              closeSync(fd);
+              done();
+            },
+            err => {
+              closeSync(fd);
+              fail(`should not be here with error: ${error}.`);
+            });
   });
 
   it('fs.write should work with util.promisify', (done: DoneFn) => {
@@ -133,16 +138,18 @@ describe('util.promisify', () => {
       buffer[i] = 0;
     }
     // fd, buffer, offset, length, position, callback
-    promisifyWrite(fd, buffer, 0, chunkSize, 0).then(
-      (value) => {
-        expect(value.bytesWritten).toBe(chunkSize);
-        closeSync(fd);
-        unlinkSync(dest);
-        done();
-      }, err => {
-        closeSync(fd);
-        unlinkSync(dest);
-        fail(`should not be here with error: ${error}.`);
-      });
+    promisifyWrite(fd, buffer, 0, chunkSize, 0)
+        .then(
+            (value) => {
+              expect(value.bytesWritten).toBe(chunkSize);
+              closeSync(fd);
+              unlinkSync(dest);
+              done();
+            },
+            err => {
+              closeSync(fd);
+              unlinkSync(dest);
+              fail(`should not be here with error: ${error}.`);
+            });
   });
 });

--- a/test/node/timer.spec.ts
+++ b/test/node/timer.spec.ts
@@ -5,26 +5,31 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { promisify } from 'util';
+import {promisify} from 'util';
 
 describe('node timer', () => {
   it('util.promisify should work with setTimeout', (done: DoneFn) => {
     const setTimeoutPromise = promisify(setTimeout);
-    setTimeoutPromise(50, 'value').then(value => {
-      expect(value).toEqual('value');
-      done();
-    }, error => {
-      fail(`should not be here with error: ${error}.`);
-    });
+    setTimeoutPromise(50, 'value')
+        .then(
+            value => {
+              expect(value).toEqual('value');
+              done();
+            },
+            error => {
+              fail(`should not be here with error: ${error}.`);
+            });
   });
 
   it('util.promisify should work with setImmediate', (done: DoneFn) => {
     const setImmediatePromise = promisify(setImmediate);
-    setImmediatePromise('value').then(value => {
-      expect(value).toEqual('value');
-      done();
-    }, error => {
-      fail(`should not be here with error: ${error}.`);
-    });
+    setImmediatePromise('value').then(
+        value => {
+          expect(value).toEqual('value');
+          done();
+        },
+        error => {
+          fail(`should not be here with error: ${error}.`);
+        });
   });
 });

--- a/test/node_entry_point.ts
+++ b/test/node_entry_point.ts
@@ -20,6 +20,7 @@ import '../lib/zone-spec/task-tracking';
 import '../lib/zone-spec/wtf';
 import '../lib/rxjs/rxjs';
 import '../lib/rxjs/rxjs-fake-async';
+
 // Setup test environment
 import '../lib/jasmine/jasmine';
 import './test-env-setup-jasmine';

--- a/test/node_error_entry_point.ts
+++ b/test/node_error_entry_point.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// Must be loaded before zone loads, so that zone can detect WTF.
+import './wtf_mock';
+import './test_fake_polyfill';
+
+// Setup tests for Zone without microtask support
+import '../lib/zone';
+import '../lib/common/promise';
+import '../lib/common/to-string';
+
+if (typeof __karma__ !== 'undefined') {
+  (global as any)['__Zone_Error_BlacklistedStackFrames_policy'] =
+      (__karma__ as any).config.errorpolicy;
+} else if (typeof process !== 'undefined') {
+  (global as any)['__Zone_Error_BlacklistedStackFrames_policy'] = process.env.errorpolicy;
+}
+
+import '../lib/common/error-rewrite';
+import '../lib/node/node';
+import '../lib/zone-spec/async-test';
+import '../lib/zone-spec/fake-async-test';
+import '../lib/zone-spec/long-stack-trace';
+import '../lib/zone-spec/proxy';
+import '../lib/zone-spec/sync-test';
+import '../lib/zone-spec/task-tracking';
+import '../lib/zone-spec/wtf';
+import '../lib/rxjs/rxjs';
+
+import '../lib/testing/promise-testing';
+// Setup test environment
+import './test-env-setup-jasmine';
+
+// List all tests here:
+import './common/Error.spec';

--- a/test/webdriver/test.sauce.js
+++ b/test/webdriver/test.sauce.js
@@ -16,10 +16,10 @@ const desiredCapabilities = {
   safari8: {browserName: 'safari', platform: 'OS X 10.10', version: '8.0'},
   safari9: {browserName: 'safari', platform: 'OS X 10.11', version: '9.0'},
   safari10: {browserName: 'safari', platform: 'OS X 10.11', version: '10.0'},
-  safari11: {browserName: 'safari', platform: 'macOS 10.13', version: '11.0'},
+  safari11: {browserName: 'safari', platform: 'macOS 10.13', version: '11.1'},
   /*ios84: {browserName: 'iphone', platform: 'OS X 10.10', version: '8.4'},*/
   ios93: {browserName: 'iphone', platform: 'OS X 10.10', version: '9.3'},
-  ios10: {browserName: 'iphone', platform: 'OS X 10.10', version: '10.2'},
+  ios10: {browserName: 'iphone', platform: 'OS X 10.10', version: '10.3'},
   ios11: {browserName: 'iphone', platform: 'OS X 10.12', version: '11.2'},
   /*
   ie9: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,9 @@
   version "2.2.33"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.2.33.tgz#4715cfd2ca7fbd632fc7f1784f13e637bed028c5"
 
-"@types/node@^8.10.17":
-  version "8.10.17"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.17.tgz#d48cf10f0dc6dcf59f827f5a3fc7a4a6004318d3"
+"@types/node@^9.x":
+  version "9.6.22"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.22.tgz#05b55093faaadedea7a4b3f76e9a61346a6dd209"
 
 "@types/systemjs@^0.19.30":
   version "0.19.33"


### PR DESCRIPTION
fix #975.

current `zone-error` provide several functionality.

1. handle `class MyError extends Error`, `new MyError() instanceof Error` will report `false` issue. 

2. remove `zone.js internal stack trace frames`.

3. add `zone` information to each `zone frame`.

The No2 and No3. feature  will slow down the ` new Error()` performance, 
So the motivation of this PR is to provide a flag to let user be able to disable No2 and No3.

 The flag is `__Zone_Error_BlacklistedStackFrames_policy`. And the available options is:

1. default: this is the default one, if you load `zone.js/dist/zone-error` without
 setting the flag, `default` will be used, and `BlackListStackFrames` will be available 
 when `new Error()`, you can get a `error.stack`  which is `zone stack free`. But this 
 will slow down `new Error()` a little bit.

2. disable: this will disable `BlackListZoneStackFrame` feature, and if you load
 `zone.js/dist/zone-error`, you will only get a `wrapped Error` which can handle
  `Error inherit` issue.

3. lazy: this is a feature to let you be able to get `BlackListZoneStackFrame` feature,
 but not impact performance. But as a trade off, you can't get the `zone free stack 
 frames` by access `error.stack`. You can only get it by access `error.zoneAwareStack`.