### PR TITLE
fix(test): karma-dist should test bundle under dist

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,7 +43,9 @@ function generateScript(inFile, outFile, minify, callback) {
               'rxjs/Observable': 'Rx',
               'rxjs/Subscriber': 'Rx',
               'rxjs/Subscription': 'Rx',
+              'rxjs/Scheduler': 'Rx.Scheduler',
               'rxjs/scheduler/asap': 'Rx.Scheduler',
+              'rxjs/scheduler/async': 'Rx.Scheduler',
               'rxjs/symbol/rxSubscriber': 'Rx.Symbol'
             }
           },
@@ -404,9 +406,9 @@ function nodeTest(specFiles, cb) {
   require('./build/lib/node/rollup-main');
   var args = process.argv;
   if (args.length > 3) {
-    require('./build/test/test-env-setup-jasmine' + args[3]); 
+    require('./build/test/test-env-setup-jasmine' + args[3]);
   }
-  var JasmineRunner = require('jasmine');	
+  var JasmineRunner = require('jasmine');
   var JasmineRunner = require('jasmine');
   var jrunner = new JasmineRunner();
 

--- a/karma-base.conf.js
+++ b/karma-base.conf.js
@@ -6,45 +6,39 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-module.exports = function (config) {
+module.exports = function(config) {
   config.set({
     basePath: '',
     files: [
-      'node_modules/systemjs/dist/system-polyfills.js',
-      'node_modules/systemjs/dist/system.src.js',
+      'node_modules/systemjs/dist/system-polyfills.js', 'node_modules/systemjs/dist/system.src.js',
       'node_modules/whatwg-fetch/fetch.js',
-      {pattern: 'node_modules/rxjs/**/**/*.js', included: false, watched: false },
-      {pattern: 'node_modules/rxjs/**/**/*.js.map', included: false, watched: false },
-      {pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false },
-      {pattern: 'node_modules/es6-promise/**/*.js', included: false, watched: false },
-      {pattern: 'node_modules/rxjs/**/*.js.map', included: false, watched: false },
+      {pattern: 'node_modules/rxjs/**/**/*.js', included: false, watched: false},
+      {pattern: 'node_modules/rxjs/**/**/*.js.map', included: false, watched: false},
+      {pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false},
+      {pattern: 'node_modules/es6-promise/**/*.js', included: false, watched: false},
+      {pattern: 'node_modules/rxjs/**/*.js.map', included: false, watched: false},
       {pattern: 'test/assets/**/*.*', watched: true, served: true, included: false},
       {pattern: 'build/**/*.js.map', watched: true, served: true, included: false},
       {pattern: 'build/**/*.js', watched: true, served: true, included: false}
     ],
 
     plugins: [
-      require('karma-chrome-launcher'),
-      require('karma-firefox-launcher'),
+      require('karma-chrome-launcher'), require('karma-firefox-launcher'),
       require('karma-sourcemap-loader')
     ],
 
-    preprocessors: {
-      '**/*.js': ['sourcemap']
-    },
+    preprocessors: {'**/*.js': ['sourcemap']},
 
-    exclude: [
-      'test/microtasks.spec.ts'
-    ],
+    exclude: ['test/microtasks.spec.ts'],
 
     reporters: ['progress'],
 
-    //port: 9876,
+    // port: 9876,
     colors: true,
 
     logLevel: config.LOG_INFO,
 
-    browsers: ['Firefox'],
+    browsers: ['Chrome'],
 
     captureTimeout: 60000,
 

--- a/karma-dist-mocha.conf.js
+++ b/karma-dist-mocha.conf.js
@@ -1,10 +1,23 @@
 
-module.exports = function (config) {
+module.exports = function(config) {
   require('./karma-dist.conf.js')(config);
 
+  for (let i = 0; i < config.files.length; i++) {
+    if (config.files[i] === 'dist/zone-testing.js') {
+      config.files.splice(i, 1);
+      break;
+    }
+  }
+  config.files.push('dist/long-stack-trace-zone.js');
+  config.files.push('dist/proxy.js');
+  config.files.push('dist/sync-test.js');
+  config.files.push('dist/async-test.js');
+  config.files.push('dist/fake-async-test.js');
+  config.files.push('dist/zone-patch-promise-test.js');
   config.plugins.push(require('karma-mocha'));
   config.frameworks.push('mocha');
   config.client.mocha = {
-    timeout: 5000 // copied timeout for Jasmine in WebSocket.spec (otherwise Mochas default timeout at 2 sec is to low for the tests)
+    timeout: 5000  // copied timeout for Jasmine in WebSocket.spec (otherwise Mochas default timeout
+                   // at 2 sec is to low for the tests)
   };
 };

--- a/karma-dist.conf.js
+++ b/karma-dist.conf.js
@@ -12,15 +12,12 @@ module.exports = function(config) {
   config.files.push('build/test/test_fake_polyfill.js');
   config.files.push('build/test/custom_error.js');
   config.files.push('dist/zone.js');
+  config.files.push('dist/webapis-media-query.js');
+  config.files.push('dist/webapis-notification.js');
   config.files.push('dist/zone-patch-user-media.js');
   config.files.push('dist/zone-patch-resize-observer.js');
-  config.files.push('dist/long-stack-trace-zone.js');
-  config.files.push('dist/proxy.js');
-  config.files.push('dist/sync-test.js');
-  config.files.push('dist/async-test.js');
-  config.files.push('dist/fake-async-test.js');
   config.files.push('dist/task-tracking.js');
-  config.files.push('dist/zone-patch-promise-test.js');
   config.files.push('dist/wtf.js');
+  config.files.push('dist/zone-testing.js');
   config.files.push('build/test/main.js');
 };

--- a/sauce-selenium3.conf.js
+++ b/sauce-selenium3.conf.js
@@ -1,16 +1,14 @@
 // Sauce configuration with Welenium drivers 3+
 
-module.exports = function (config) {
+module.exports = function(config) {
   // The WS server is not available with Sauce
   config.files.unshift('test/saucelabs.js');
 
   var customLaunchers = {
-    'SL_CHROME60': {
-      base: 'SauceLabs',
-      browserName: 'Chrome',
-      platform: 'Windows 10',
-      version: '60.0'
-    }
+    'SL_CHROME60':
+        {base: 'SauceLabs', browserName: 'Chrome', platform: 'Windows 10', version: '60.0'},
+    'SL_SAFARI11':
+        {base: 'SauceLabs', browserName: 'safari', platform: 'macOS 10.13', version: '11.0'},
   };
 
   config.set({
@@ -22,11 +20,11 @@ module.exports = function (config) {
       startConnect: false,
       recordVideo: false,
       recordScreenshots: false,
-      options:  {
-          'selenium-version': '3.5.0',
-          'command-timeout': 600,
-          'idle-timeout': 600,
-          'max-duration': 5400
+      options: {
+        'selenium-version': '3.5.0',
+        'command-timeout': 600,
+        'idle-timeout': 600,
+        'max-duration': 5400
       }
     },
 
@@ -38,13 +36,12 @@ module.exports = function (config) {
 
     singleRun: true,
 
-    plugins: [
-      'karma-*'
-    ]
+    plugins: ['karma-*']
   });
 
   if (process.env.TRAVIS) {
-    config.sauceLabs.build = 'TRAVIS #' + process.env.TRAVIS_BUILD_NUMBER + ' (' + process.env.TRAVIS_BUILD_ID + ')';
+    config.sauceLabs.build =
+        'TRAVIS #' + process.env.TRAVIS_BUILD_NUMBER + ' (' + process.env.TRAVIS_BUILD_ID + ')';
     config.sauceLabs.tunnelIdentifier = process.env.TRAVIS_JOB_NUMBER;
 
     process.env.SAUCE_ACCESS_KEY = process.env.SAUCE_ACCESS_KEY.split('').reverse().join('');

--- a/sauce.conf.js
+++ b/sauce.conf.js
@@ -6,9 +6,9 @@ module.exports = function(config, ignoredLaunchers) {
 
   var basicLaunchers = {
     'SL_CHROME': {base: 'SauceLabs', browserName: 'chrome', version: '48'},
-    'SL_CHROME_60': {base: 'SauceLabs', browserName: 'chrome', version: '60'},
+    'SL_CHROME_65': {base: 'SauceLabs', browserName: 'chrome', version: '60'},
     'SL_FIREFOX': {base: 'SauceLabs', browserName: 'firefox', version: '52'},
-    'SL_FIREFOX_54': {base: 'SauceLabs', browserName: 'firefox', version: '54'},
+    'SL_FIREFOX_59': {base: 'SauceLabs', browserName: 'firefox', version: '54'},
     /*'SL_SAFARI7': {
       base: 'SauceLabs',
         browserName: 'safari',

--- a/test/browser-zone-setup.ts
+++ b/test/browser-zone-setup.ts
@@ -12,6 +12,7 @@ if (typeof window !== 'undefined') {
 import '../lib/common/to-string';
 import '../lib/browser/browser';
 import '../lib/browser/webapis-user-media';
+import '../lib/browser/webapis-media-query';
 import '../lib/testing/zone-testing';
 import '../lib/zone-spec/task-tracking';
 import '../lib/zone-spec/wtf';
@@ -20,3 +21,4 @@ import '../lib/testing/promise-testing';
 import '../lib/testing/async-testing';
 import '../lib/testing/fake-async';
 import '../lib/browser/webapis-resize-observer';
+import '../lib/rxjs/rxjs-fake-async';

--- a/test/browser/MediaQuery.spec.ts
+++ b/test/browser/MediaQuery.spec.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import '../../lib/browser/webapis-media-query';
-
 import {zoneSymbol} from '../../lib/common/utils';
 import {ifEnvSupports} from '../test-util';
 declare const global: any;

--- a/test/browser/Notification.spec.ts
+++ b/test/browser/Notification.spec.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import '../../lib/browser/webapis-notification';
-
 import {zoneSymbol} from '../../lib/common/utils';
 import {ifEnvSupports} from '../test-util';
 declare const window: any;

--- a/test/main.ts
+++ b/test/main.ts
@@ -28,7 +28,12 @@ if ((window as any)[(Zone as any).__symbol__('setTimeout')]) {
 } else {
   // this means that Zone has not patched the browser yet, which means we must be running in
   // build mode and need to load the browser patch.
-  browserPatchedPromise = System.import('/base/build/test/browser-zone-setup');
+  browserPatchedPromise = System.import('/base/build/test/browser-zone-setup').then(() => {
+    let testFrameworkPatch = typeof(window as any).Mocha !== 'undefined' ?
+        '/base/build/lib/mocha/mocha' :
+        '/base/build/lib/jasmine/jasmine';
+    return System.import(testFrameworkPatch);
+  });
 }
 
 browserPatchedPromise.then(() => {

--- a/test/node_entry_point.ts
+++ b/test/node_entry_point.ts
@@ -19,11 +19,9 @@ import '../lib/testing/zone-testing';
 import '../lib/zone-spec/task-tracking';
 import '../lib/zone-spec/wtf';
 import '../lib/rxjs/rxjs';
-
-import '../lib/testing/promise-testing';
-import '../lib/testing/async-testing';
-import '../lib/testing/fake-async';
+import '../lib/rxjs/rxjs-fake-async';
 // Setup test environment
+import '../lib/jasmine/jasmine';
 import './test-env-setup-jasmine';
 
 // List all tests here:

--- a/test/test-env-setup-jasmine.ts
+++ b/test/test-env-setup-jasmine.ts
@@ -7,4 +7,3 @@
  */
 
 (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = 5000;
-import '../lib/jasmine/jasmine';

--- a/test/test-env-setup-mocha.ts
+++ b/test/test-env-setup-mocha.ts
@@ -10,7 +10,7 @@ import '../lib/mocha/mocha';
 declare const global: any;
 
 ((context: any) => {
-  context['jasmine'] = global['jasmine'] || {};
+  context['jasmine'] = context['jasmine'] || {};
   context['jasmine'].createSpy = function(spyName: string) {
     let spy: any = function(...params: any[]) {
       spy.countCall++;
@@ -183,4 +183,4 @@ declare const global: any;
       }
     };
   };
-})(window);
+})(typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || global);

--- a/test/webdriver/test.sauce.js
+++ b/test/webdriver/test.sauce.js
@@ -8,83 +8,50 @@
 
 const webdriverio = require('webdriverio');
 const desiredCapabilities = {
-    firefox52Win7: {
-        browserName: 'firefox',
-        platform: 'Windows 7',
-        version: '52'
-    },
-    firefox53Win7: {
-        browserName: 'firefox',
-        platform: 'Windows 7',
-        version: '53'
-    },
-    edge14: {
-        browserName: 'MicrosoftEdge',
-        platform: 'Windows 10',
-        version: '14.14393' 
-    },
-    /*edge15: {
-        browserName: 'Edge',
-        platform: 'Windows 10',
-        version: '15.15063' 
-    },*/
-    chrome48: {
-      browserName: 'chrome',
-      version: '48'
-    },
-    safari8: {
-      browserName: 'safari',
-      platform: 'OS X 10.10',
-      version: '8.0'
-    },
-    safari9: {
-      browserName: 'safari',
-      platform: 'OS X 10.11',
-      version: '9.0'
-    },
-    /*
-    ios84: {
-      browserName: 'iphone',
-      platform: 'OS X 10.10',
-      version: '8.4'
-    },*/
-    ios93: {
-      browserName: 'iphone',
-      platform: 'OS X 10.10',
-      version: '9.3'
-    },
-    ios10: {
-      browserName: 'iphone',
-      platform: 'OS X 10.10',
-      version: '10.2'
-    },
-    /*
-    ie9: {
-      browserName: 'internet explorer',
-      platform: 'Windows 2008',
-      version: '9'
-    },*/
-    /*
-    ie10: {
-      browserName: 'internet explorer',
-      platform: 'Windows 2012',
-      version: '10'
-    },*/
-    ie11: {
-      browserName: 'internet explorer',
-      platform: 'Windows 10',
-      version: '11'
-    },
-    andriod44: {
-      browserName: 'android',
-      platform: 'Linux',
-      version: '4.4'
-    },
-    android51: {
-      browserName: 'android',
-      platform: 'Linux',
-      version: '5.1'
-    }
+  firefox52Win7: {browserName: 'firefox', platform: 'Windows 7', version: '52'},
+  firefox53Win7: {browserName: 'firefox', platform: 'Windows 7', version: '53'},
+  edge14: {browserName: 'MicrosoftEdge', platform: 'Windows 10', version: '14.14393'},
+  edge15: {browserName: 'MicrosoftEdge', platform: 'Windows 10', version: '15.15063'},
+  chrome48: {browserName: 'chrome', version: '48'},
+  safari8: {browserName: 'safari', platform: 'OS X 10.10', version: '8.0'},
+  safari9: {browserName: 'safari', platform: 'OS X 10.11', version: '9.0'},
+  safari10: {browserName: 'safari', platform: 'OS X 10.11', version: '10.0'},
+  safari11: {browserName: 'safari', platform: 'macOS 10.13', version: '11.0'},
+  /*ios84: {browserName: 'iphone', platform: 'OS X 10.10', version: '8.4'},*/
+  ios93: {browserName: 'iphone', platform: 'OS X 10.10', version: '9.3'},
+  ios10: {browserName: 'iphone', platform: 'OS X 10.10', version: '10.2'},
+  ios11: {browserName: 'iphone', platform: 'OS X 10.12', version: '11.2'},
+  /*
+  ie9: {
+    browserName: 'internet explorer',
+    platform: 'Windows 2008',
+    version: '9'
+  },*/
+  /*
+  ie10: {
+    browserName: 'internet explorer',
+    platform: 'Windows 2012',
+    version: '10'
+  },*/
+  ie11: {browserName: 'internet explorer', platform: 'Windows 10', version: '11'},
+  andriod44: {browserName: 'android', platform: 'Linux', version: '4.4'},
+  android51: {browserName: 'android', platform: 'Linux', version: '5.1'},
+  android60: {
+    deviceName: 'Android GoogleAPI Emulator',
+    browserName: 'Chrome',
+    platformName: 'Android',
+    platformVersion: '6.0',
+    deviceOrientation: 'portrait',
+    appiumVersion: '1.7.2'
+  },
+  android71: {
+    deviceName: 'Android GoogleAPI Emulator',
+    browserName: 'Chrome',
+    platformName: 'Android',
+    platformVersion: '7.1',
+    deviceOrientation: 'portrait',
+    appiumVersion: '1.7.2'
+  }
 };
 
 const errors = [];
@@ -104,64 +71,67 @@ Object.keys(desiredCapabilities).forEach(key => {
     key: process.env.SAUCE_ACCESS_KEY,
     host: 'localhost',
     port: 4445,
-    desiredCapabilities: desiredCapabilities[key] 
+    desiredCapabilities: desiredCapabilities[key]
   });
 
-  const p = client
-    .init()
-    .timeouts('script', 60000)
-    .url('http://localhost:8080/test/webdriver/test.html')
-    .executeAsync(function(done) { window.setTimeout(done,1000) })
-    .execute(function() 
-      {
-        const elem = document.getElementById('thetext');
-        const zone = window['Zone'] ? Zone.current.fork({name: 'webdriver'}) : null;
-        if (zone) {
-            zone.run(function() {
-              elem.addEventListener('click', function(e) {
-                e.target.innerText = 'clicked' + Zone.current.name;
-              });
-            });
-        } else {
-          elem.addEventListener('click', function(e) {
-             e.target.innerText = 'clicked';
-          });
-        }
-    })
-    .click('#thetext')
-    .getText('#thetext')
-    .then((text => {
-      if (text !== 'clickedwebdriver') {
-        errors.push(`Env: ${key}, expected clickedwebdriver, get ${text}`);
-      }}), (error) => {
-        errors.push(`Env: ${key}, error occurs: ${error}`);
-      })
-    .end();
-    tasks.push(p);
+  const p = client.init()
+                .timeouts('script', 60000)
+                .url('http://localhost:8080/test/webdriver/test.html')
+                .executeAsync(function(done) {
+                  window.setTimeout(done, 1000)
+                })
+                .execute(function() {
+                  const elem = document.getElementById('thetext');
+                  const zone = window['Zone'] ? Zone.current.fork({name: 'webdriver'}) : null;
+                  if (zone) {
+                    zone.run(function() {
+                      elem.addEventListener('click', function(e) {
+                        e.target.innerText = 'clicked' + Zone.current.name;
+                      });
+                    });
+                  } else {
+                    elem.addEventListener('click', function(e) {
+                      e.target.innerText = 'clicked';
+                    });
+                  }
+                })
+                .click('#thetext')
+                .getText('#thetext')
+                .then(
+                    (text => {
+                      if (text !== 'clickedwebdriver') {
+                        errors.push(`Env: ${key}, expected clickedwebdriver, get ${text}`);
+                      }
+                    }),
+                    (error) => {
+                      errors.push(`Env: ${key}, error occurs: ${error}`);
+                    })
+                .end();
+  tasks.push(p);
 });
 
 function exit(exitCode) {
-    const http = require('http');
-    http.get('http://localhost:8080/close', () => {
-      process.exit(exitCode);
-    });
+  const http = require('http');
+  http.get('http://localhost:8080/close', () => {
+    process.exit(exitCode);
+  });
 }
 
 Promise.all(tasks).then(() => {
-    if (errors.length > 0) {
-        let nonTimeoutError = false;
-        errors.forEach(error => {
-          console.log(error);
-          if (error.toString().lastIndexOf('timeout') === -1) {
-            nonTimeoutError = true;
-          }
-        });
-        if (nonTimeoutError) {
-          exit(1);
-        } else {
-          exit(0);
-        }
+  if (errors.length > 0) {
+    let nonTimeoutError = false;
+    errors.forEach(error => {
+      console.log(error);
+      if (error.toString().lastIndexOf('timeout') === -1) {
+        nonTimeoutError = true;
+      }
+    });
+    if (nonTimeoutError) {
+      exit(1);
     } else {
-        exit(0);
+      exit(0);
     }
+  } else {
+    exit(0);
+  }
 });


### PR DESCRIPTION
### update karma-dist.conf.js

current `karma-dist.conf.js` will load bundles under `dist` and the purpose is to test those built bundles instead of the dev version which under `build` folder.
so in `karma-dist.conf.js`, we will load 

```javascript
 config.files.push('dist/zone.js');
 config.files.push('dist/async-test.js');
...
``` 

But in current test cases will load some of the lib directly from `build` folder, for example in `async-test.spec.ts`, in current version, it will load 

```javascript
import '../../lib/zone-spec/async-test';
```
so the test case in fact will not test the bundle under `dist` but `build`.

-------------

in this PR, I load all needed bundles in `karma-dist.conf.js` and remove all directly import from test specs. And also modify the test entry classes to make sure currently test cases will be ok for both `build` test and `dist` test.

- in dev mode, test bundles under `build`.
- in dist mode, test bundles under `dist`.

### Also disable ios 8.4 test because saucelabs seems not stable

### change default karma browser to Chrome.

### change rollup globals.

### add ios 11, edge 15, android 7.1 to ci test.