### PR TITLE
fix(fakeAsync): fix #1056, fakeAsync timerId should not be zero

### DIFF
--- a/lib/zone-spec/fake-async-test.ts
+++ b/lib/zone-spec/fake-async-test.ts
@@ -56,7 +56,7 @@
 
   class Scheduler {
     // Next scheduler id.
-    public nextId: number = 0;
+    public nextId: number = 1;
 
     // Scheduler queue with the tuple of end time and callback function - sorted by end time.
     private _schedulerQueue: ScheduledFunction[] = [];
@@ -409,12 +409,14 @@
         case 'macroTask':
           switch (task.source) {
             case 'setTimeout':
-              task.data['handleId'] =
-                  this._setTimeout(task.invoke, task.data['delay'], Array.prototype.slice.call((task.data as any)['args'], 2));
+              task.data['handleId'] = this._setTimeout(
+                  task.invoke, task.data['delay'],
+                  Array.prototype.slice.call((task.data as any)['args'], 2));
               break;
             case 'setInterval':
-              task.data['handleId'] =
-                  this._setInterval(task.invoke, task.data['delay'], Array.prototype.slice.call((task.data as any)['args'], 2));
+              task.data['handleId'] = this._setInterval(
+                  task.invoke, task.data['delay'],
+                  Array.prototype.slice.call((task.data as any)['args'], 2));
               break;
             case 'XMLHttpRequest.send':
               throw new Error(
@@ -480,7 +482,9 @@
       }
     }
 
-    onInvoke(delegate: ZoneDelegate, current: Zone, target: Zone, callback: Function, applyThis: any, applyArgs: any[], source: string): any {
+    onInvoke(
+        delegate: ZoneDelegate, current: Zone, target: Zone, callback: Function, applyThis: any,
+        applyArgs: any[], source: string): any {
       try {
         FakeAsyncTestZoneSpec.patchDate();
         return delegate.invoke(target, callback, applyThis, applyArgs, source);

--- a/test/test-env-setup-mocha.ts
+++ b/test/test-env-setup-mocha.ts
@@ -76,6 +76,11 @@ declare const global: any;
           throw new Error(`Expected ${expected} to be ${actual}`);
         }
       },
+      toBeGreaterThan: function(actual: number) {
+        if (expected <= actual) {
+          throw new Error(`Expected ${expected} to be greater than ${actual}`);
+        }
+      },
       toBeDefined: function() {
         if (!expected) {
           throw new Error(`Expected ${expected} to be defined`);

--- a/test/zone-spec/fake-async-test.spec.ts
+++ b/test/zone-spec/fake-async-test.spec.ts
@@ -226,6 +226,8 @@ describe('FakeAsyncTestZoneSpec', () => {
           cycles++;
         }, 10);
 
+        expect(id).toBeGreaterThan(0);
+
         testZoneSpec.tick(10);
         expect(cycles).toEqual(1);
 


### PR DESCRIPTION
fix #1056 
FakeAsyncTestSpec scheduler should not return a `zero` timerId, it will break `rxjs6` or some library which will depends on the `timerId`.