### PR TITLE
fix(test): add async/fakeAsync into zone-testing bundle

### DIFF
--- a/lib/testing/zone-testing.ts
+++ b/lib/testing/zone-testing.ts
@@ -11,6 +11,6 @@ import '../zone-spec/long-stack-trace';
 import '../zone-spec/proxy';
 import '../zone-spec/sync-test';
 import '../jasmine/jasmine';
-import '../zone-spec/async-test';
-import '../zone-spec/fake-async-test';
+import './async-testing';
+import './fake-async';
 import './promise-testing';


### PR DESCRIPTION
sorry I forget to put the `async-test` and `fakeAsync` into bundles.
@mhevery , please review.