### PR TITLE
fix(test): fix #1069, FakeDate should handle constructor parameter

### DIFF
--- a/test/test-env-setup-mocha.ts
+++ b/test/test-env-setup-mocha.ts
@@ -81,6 +81,11 @@ declare const global: any;
           throw new Error(`Expected ${expected} to be greater than ${actual}`);
         }
       },
+      toBeLessThan: function(actual: number) {
+        if (expected >= actual) {
+          throw new Error(`Expected ${expected} to be lesser than ${actual}`);
+        }
+      },
       toBeDefined: function() {
         if (!expected) {
           throw new Error(`Expected ${expected} to be defined`);
@@ -107,6 +112,11 @@ declare const global: any;
       toBeTruthy: function() {
         if (!expected) {
           throw new Error(`Expected ${expected} to be truthy`);
+        }
+      },
+      toBeFalsy: function(actual: any) {
+        if (!!actual) {
+          throw new Error(`Expected ${actual} to be falsy`);
         }
       },
       toContain: function(actual: any) {
@@ -159,7 +169,11 @@ declare const global: any;
           if (expected > actual) {
             throw new Error(`Expected ${expected} not to be greater than ${actual}`);
           }
-
+        },
+        toBeLessThan: function(actual: number) {
+          if (expected < actual) {
+            throw new Error(`Expected ${expected} not to be lesser than ${actual}`);
+          }
         },
         toHaveBeenCalledWith: function(params: any[]) {
           if (!eq(expected.callArgs, params)) {


### PR DESCRIPTION
fix #1069.
fix #1071.

- in `fakeAsync`, now `Date` is monkey-patched with `FakeDate`, `FakeDate` should handle parameters in constructor correctly, such as `new Date(1995, 1)`, `new Date(0)`.

- should handle `Date.UTC()` in `fakeAsync` correctly

- should handle `Date.parse()` in `fakeAsync` correctly

@mhevery , sorry this is a regression bug, please review and please check should we cut a new release or not.