### PR TITLE
fix(xhr): fix #1072, should set scheduled flag to target

### DIFF
--- a/file-size-limit.json
+++ b/file-size-limit.json
@@ -3,7 +3,7 @@
     {
       "path": "dist/zone.min.js",
       "checkTarget": true,
-      "limit": 41500
+      "limit": 41600
     }
   ]
 }


### PR DESCRIPTION
fix #1072.

- it is better to set `scheduled` flag to `target` than `XMLHttpRequest`.  set to `XMLHttpRequest` is not a bug, but is not a good way to set such kind of `flag` to global object.
- issue #530, when open an invalid request, current logic will leave a `scheduled macroTask` in `chrome`. we should `invoke` the task to make the `macroTask` finish.
```javascript
 var req = new XMLHttpRequest();
 req.open('get', 'file:///test', true);
 req.send();
``` 