### PR TITLE
fix(core): use then directly when promise is not patchable

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1272,7 +1272,13 @@ const Zone: ZoneType = (function(global: any) {
         }
       }
       if (nativeMicroTaskQueuePromise) {
-        nativeMicroTaskQueuePromise[symbolThen](drainMicroTaskQueue);
+        let nativeThen = nativeMicroTaskQueuePromise[symbolThen];
+        if (!nativeThen) {
+          // native Promise is not patchable, we need to use `then` directly
+          // issue 1078
+          nativeThen = nativeMicroTaskQueuePromise['then'];
+        }
+        nativeThen.call(nativeMicroTaskQueuePromise, drainMicroTaskQueue);
       } else {
         global[symbolSetTimeout](drainMicroTaskQueue, 0);
       }


### PR DESCRIPTION
fix #1078 
In some old browser or other environment, `Promise.prototype.then` may not configurable, so we should use `promise.then` instead of `promise['__zone_symbol__then']`.