### PR TITLE
fix(node): node patched method should copy original delegate's symbol properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 dist: trusty
 cache: yarn
 node_js:
-  - 6
+  - 8
 env:
   global:
     - BROWSER_PROVIDER_READY_FILE=/tmp/sauce-connect-ready

--- a/lib/node/node.ts
+++ b/lib/node/node.ts
@@ -6,21 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import './node_util';
 import './events';
 import './fs';
 
 import {findEventTasks} from '../common/events';
 import {patchTimer} from '../common/timers';
-import {ArraySlice, bindArguments, isMix, patchMacroTask, patchMethod, patchMicroTask, patchOnProperties} from '../common/utils';
+import {ArraySlice, isMix, patchMacroTask, patchMicroTask} from '../common/utils';
 
 const set = 'set';
 const clear = 'clear';
-
-Zone.__load_patch('node_util', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
-  api.patchOnProperties = patchOnProperties;
-  api.patchMethod = patchMethod;
-  api.bindArguments = bindArguments;
-});
 
 Zone.__load_patch('node_timers', (global: any, Zone: ZoneType) => {
   // Timers

--- a/lib/node/node_util.ts
+++ b/lib/node/node_util.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {setShouldCopySymbolProperties, patchOnProperties, patchMethod, bindArguments} from '../common/utils';
+
+Zone.__load_patch('node_util', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+  api.patchOnProperties = patchOnProperties;
+  api.patchMethod = patchMethod;
+  api.bindArguments = bindArguments;
+  setShouldCopySymbolProperties(true);
+});

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {},
   "devDependencies": {
     "@types/jasmine": "2.2.33",
-    "@types/node": "^6.0.96",
+    "@types/node": "^8.10.17",
     "@types/systemjs": "^0.19.30",
     "assert": "^1.4.1",
     "bluebird": "^3.5.1",

--- a/test/node/timer.spec.ts
+++ b/test/node/timer.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { promisify } from 'util';
+
+describe('node timer', () => {
+  it('util.promisify should work with setTimeout', (done: DoneFn) => {
+    const setTimeoutPromise = promisify(setTimeout);
+    setTimeoutPromise(50, 'value').then(value => {
+      expect(value).toEqual('value');
+      done();
+    }, error => {
+      fail(`should not be here with error: ${error}.`);
+    });
+  });
+
+  it('util.promisify should work with setImmediate', (done: DoneFn) => {
+    const setImmediatePromise = promisify(setImmediate);
+    setImmediatePromise('value').then(value => {
+      expect(value).toEqual('value');
+      done();
+    }, error => {
+      fail(`should not be here with error: ${error}.`);
+    });
+  });
+});

--- a/test/node_tests.ts
+++ b/test/node_tests.ts
@@ -13,3 +13,4 @@ import './node/Error.spec';
 import './node/crypto.spec';
 import './node/http.spec';
 import './node/console.spec';
+import './node/timer.spec';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,9 @@
   version "2.2.33"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.2.33.tgz#4715cfd2ca7fbd632fc7f1784f13e637bed028c5"
 
-"@types/node@^6.0.96":
-  version "6.0.101"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.101.tgz#0c5911cfb434af4a51c0a499931fe6423207d921"
+"@types/node@^8.10.17":
+  version "8.10.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.17.tgz#d48cf10f0dc6dcf59f827f5a3fc7a4a6004318d3"
 
 "@types/systemjs@^0.19.30":
   version "0.19.33"


### PR DESCRIPTION
fix #1094 

the error can be described as this,

```javascript
    import * as util from 'util';
    const promisifyExists = util.promisify(exists);
    promisifyExists(__filename).then(r => {
      expect(r).toBe(true);
      done();
    }, err => {
      fail(`should not be here with error: ${err}`);
    });
```

Before this PR, after `promisify`, the promise will be `rejected` as error.
The reason is in `nodejs promisify` implementation, by default, it will handle the nodejs style callback `(err, ...values)` to promise, but some of the nodejs API is not in this style, such as `fs.exists`, the callback is `(exists) => {}`, without the 1st `err` parameter. 

So `nodejs` provide a mechanism to let those special API provide their own `promisify` implementation by add a `symbol property Symbol(custom)` in the method, for example, `fs.exists` provide a custom implementation here, https://github.com/nodejs/node/blob/master/lib/fs.js#L213

```javascript
Object.defineProperty(exists, internalUtil.promisify.custom, {
  value: (path) => {
    const { createPromise, promiseResolve } = process.binding('util');
    const promise = createPromise();
    fs.exists(path, (exists) => promiseResolve(promise, exists));
    return promise;
  }
});
```
And this property is defined on the function, so when `zone.js` patched this `function`, the `symbol property` got lost, so we need to copy this symbol property.

