### PR TITLE
Ensure FakeAsyncTestZoneSpec tick always doTick

### DIFF
--- a/lib/zone-spec/fake-async-test.ts
+++ b/lib/zone-spec/fake-async-test.ts
@@ -150,7 +150,11 @@ class Scheduler {
         }
       }
     }
+    lastCurrentTime = this._currentTime;
     this._currentTime = finalTime;
+    if (doTick) {
+      doTick(this._currentTime - lastCurrentTime);
+    }
   }
 
   flush(limit = 20, flushPeriodic = false, doTick?: (elapsed: number) => void): number {

--- a/test/zone-spec/fake-async-test.spec.ts
+++ b/test/zone-spec/fake-async-test.spec.ts
@@ -172,6 +172,25 @@ describe('FakeAsyncTestZoneSpec', () => {
       });
     });
 
+    it('should run doTick callback even if no work ran', () => {
+      fakeAsyncTestZone.run(() => {
+        let totalElapsed = 0;
+        function doTick(elapsed: number) {
+          totalElapsed += elapsed;
+        }
+        setTimeout(() => {}, 10);
+
+        testZoneSpec.tick(6, doTick);
+        expect(totalElapsed).toEqual(6);
+
+        testZoneSpec.tick(6, doTick);
+        expect(totalElapsed).toEqual(12);
+
+        testZoneSpec.tick(6, doTick);
+        expect(totalElapsed).toEqual(18);
+      });
+    });
+
     it('should run queued timer created by timer callback', () => {
       fakeAsyncTestZone.run(() => {
         let counter = 0;


### PR DESCRIPTION
In the case where there is pending work in the scheduler queue, but the duration
of the tick did not causes it to run the doTick callback would not be called (or
would not be called with intervals summing to the total time ellapsed).