### PR TITLE
fix(eventListener): use the correct WTF issue array to iterate on

### DIFF
--- a/lib/browser/event-target.ts
+++ b/lib/browser/event-target.ts
@@ -55,7 +55,7 @@ export function eventTargetPatch(_global: any, api: _ZonePrivate) {
   }
 
   //  predefine all task.source string
-  for (let i = 0; i < WTF_ISSUE_555.length; i++) {
+  for (let i = 0; i < WTF_ISSUE_555_ARRAY.length; i++) {
     const target: any = WTF_ISSUE_555_ARRAY[i];
     const targets: any = globalSources[target] = {};
     for (let j = 0; j < eventNames.length; j++) {


### PR DESCRIPTION
It seems that zone.js iterates on the wrong array while considering WTF issue. This results in a lot of unnecessary iterations and object creations. Although it seems that the main functionality is not affected.