### PR TITLE
fix(memory): reduce memory leaks in Jest JSDOM environment

### DIFF
--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -158,6 +158,11 @@ export function patchProperty(obj: any, prop: string, prototype?: any) {
     return;
   }
 
+  const onPropPatchedSymbol = zoneSymbol('on' + prop + 'patched');
+  if (obj.hasOwnProperty(onPropPatchedSymbol) && obj[onPropPatchedSymbol]) {
+    return;
+  }
+
   // A property descriptor cannot have getter/setter and be writable
   // deleting the writable and value properties avoids this error:
   //
@@ -240,6 +245,8 @@ export function patchProperty(obj: any, prop: string, prototype?: any) {
   };
 
   ObjectDefineProperty(obj, prop, desc);
+
+  obj[onPropPatchedSymbol] = true;
 }
 
 export function patchOnProperties(obj: any, properties: string[]|null, prototype?: any) {


### PR DESCRIPTION
This is related to https://github.com/angular/angular/issues/24048#issuecomment-395099543

As JSDOM shares prototypes we have a leak after directly patching them.
The proposed solution is to wrap global functions with delegators and also their prototypes same way.
This way zone.js will patch only delegators making originals untouched and no memory leak therefore will hapen.

In order to reproduce the issue please refer to https://github.com/FreeleX/jest-angular-memory-leak-example and for more info to the https://github.com/angular/angular/issues/24048