### PR TITLE
fix(event): fix #1110, nodejs EventEmitter should support Symbol eventName

### DIFF
--- a/file-size-limit.json
+++ b/file-size-limit.json
@@ -3,7 +3,7 @@
     {
       "path": "dist/zone.min.js",
       "checkTarget": true,
-      "limit": 42500
+      "limit": 43000
     }
   ]
 }

--- a/lib/node/events.ts
+++ b/lib/node/events.ts
@@ -22,6 +22,16 @@ Zone.__load_patch('EventEmitter', (global: any) => {
     return task.callback === delegate || task.callback.listener === delegate;
   };
 
+  const eventNameToString = function(eventName: string|Symbol) {
+    if (typeof eventName === 'string') {
+      return eventName as string;
+    }
+    if (!eventName) {
+      return '';
+    }
+    return eventName.toString().replace('(', '_').replace(')', '_');
+  };
+
   function patchEventEmitterMethods(obj: any) {
     const result = patchEventTarget(global, [obj], {
       useG: false,
@@ -32,7 +42,8 @@ Zone.__load_patch('EventEmitter', (global: any) => {
       listeners: EE_LISTENERS,
       chkDup: false,
       rt: true,
-      diff: compareTaskCallbackVsDelegate
+      diff: compareTaskCallbackVsDelegate,
+      eventNameToString: eventNameToString
     });
     if (result && result[0]) {
       obj[EE_ON] = obj[EE_ADD_LISTENER];

--- a/test/node/events.spec.ts
+++ b/test/node/events.spec.ts
@@ -189,4 +189,16 @@ describe('nodejs EventEmitter', () => {
       process.on('uncaughtException', function() {});
     });
   });
+  it('should be able to addEventListener with symbol eventName', () => {
+    zoneA.run(() => {
+      const testSymbol = Symbol('test');
+      const test1Symbol = Symbol('test1');
+      emitter.on(testSymbol, expectZoneA);
+      emitter.on(test1Symbol, shouldNotRun);
+      emitter.removeListener(test1Symbol, shouldNotRun);
+      expect(emitter.listeners(testSymbol).length).toBe(1);
+      expect(emitter.listeners(test1Symbol).length).toBe(0);
+      emitter.emit(testSymbol, 'test value');
+    });
+  });
 });

--- a/tsconfig-esm-node.json
+++ b/tsconfig-esm-node.json
@@ -18,7 +18,8 @@
     "lib": [
       "es5",
       "dom",
-      "es2015.promise"
+      "es2015.promise",
+      "es2015.symbol"
     ]
   },
   "exclude": [

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -26,6 +26,13 @@
     "build",
     "build-esm",
     "dist",
-    "lib/closure"
+    "lib/closure",
+    "lib/node/**",
+    "lib/mix/**",
+    "test/node/**",
+    "test/node_bluebird_entry_point.ts",
+    "test/node_entry_point.ts",
+    "test/node_error_entry_point.ts",
+    "test/node_tests.ts"
   ]
 }

--- a/tsconfig-node.json
+++ b/tsconfig-node.json
@@ -16,7 +16,8 @@
     "lib": [
       "es5",
       "dom",
-      "es2015.promise"
+      "es2015.promise",
+      "es2015.symbol"
     ]
   },
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,13 @@
     "build",
     "build-esm",
     "dist",
-    "lib/closure"
+    "lib/closure",
+    "lib/node/**",
+    "lib/mix/**",
+    "test/node/**",
+    "test/node_bluebird_entry_point.ts",
+    "test/node_entry_point.ts",
+    "test/node_error_entry_point.ts",
+    "test/node_tests.ts"
   ]
 }


### PR DESCRIPTION
fix #1110.

In nodejs, `EventEmitter` should support `Symbol` as `eventName`.

```ts
const symbolA = Symbol('A');
emitter.addListener(symbolA, listener);
emitter.removeListener(symbolA, listener);
```