### PR TITLE
fix(bluebird): fix #1112, bluebird chained callback should return a Bluebird Promise

### DIFF
--- a/file-size-limit.json
+++ b/file-size-limit.json
@@ -3,7 +3,7 @@
     {
       "path": "dist/zone.min.js",
       "checkTarget": true,
-      "limit": 42000
+      "limit": 42050
     }
   ]
 }

--- a/lib/common/promise.ts
+++ b/lib/common/promise.ts
@@ -476,11 +476,6 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
 
   if (NativePromise) {
     patchThen(NativePromise);
-
-    /*let fetch = global['fetch'];
-    if (typeof fetch == 'function') {
-      global['fetch'] = zoneify(fetch);
-    }*/
   }
 
   // This is not part of public API, but it is useful for tests, so we expose it.


### PR DESCRIPTION
fix #1112.
The issue can be described as the following case.

```ts
new BluebirdPromise((resolve: any, reject: any) => {
      expect(Zone.current.name).toEqual('zone_A');
      resolve(1);
}).then((r: any) => {
      expect(r).toBe(1);
      expect(Zone.current.name).toEqual('zone_A');
      return Promise.resolve(2);
}).then((r: any) => {
      expect(r).toBe(2);
      expect(Zone.current.name).toEqual('zone_A');
});
```

So we should return a `new bluebird promise` in `then callback`.