### PR TITLE
fix(bluebird): fix #1124, if zone handle error return false, don't fire unhandledRejection

### DIFF
--- a/lib/extra/bluebird.ts
+++ b/lib/extra/bluebird.ts
@@ -41,12 +41,40 @@ Zone.__load_patch('bluebird', (global: any, Zone: ZoneType, api: _ZonePrivate) =
           });
     });
 
+    if (typeof window !== 'undefined') {
+      window.addEventListener('unhandledrejection', function(event: any) {
+        const error = event.detail && event.detail.reason;
+        if (error && error.isHandledByZone) {
+          event.preventDefault();
+          if (typeof event.stopImmediatePropagation === 'function') {
+            event.stopImmediatePropagation();
+          }
+        }
+      });
+    } else if (typeof process !== 'undefined') {
+      process.on('unhandledRejection', (reason: any, p: any) => {
+        if (reason && reason.isHandledByZone) {
+          const listeners = process.listeners('unhandledRejection');
+          if (listeners) {
+            // remove unhandledRejection listeners so the callback
+            // will not be triggered.
+            process.removeAllListeners('unhandledRejection');
+            process.nextTick(() => {
+              listeners.forEach(listener => process.on('unhandledRejection', listener));
+            });
+          }
+        }
+      });
+    }
+
     Bluebird.onPossiblyUnhandledRejection(function(e: any, promise: any) {
       try {
         Zone.current.runGuarded(() => {
+          e.isHandledByZone = true;
           throw e;
         });
       } catch (err) {
+        err.isHandledByZone = false;
         api.onUnhandledError(err);
       }
     });


### PR DESCRIPTION
fix #1124.
In the following case, if `zone.onHandleError` return `false`, we should not let `Bluebird` trigger `unhandledrejection`. So the behavior is consistent with `ZoneAwarePromise`.

```ts
  var Bluebird = window.P;
        Zone[Zone["__symbol__"]("bluebird")](Bluebird);
        window.addEventListener("unhandledrejection",
            (e) => {
       // should not get here.
       console.log("unhandled rejection (only called with Bluebird patch)", e.detail.reason.message); });
        Zone.current.fork({
            name: "test zone", onHandleError(a, b, c, err) {
                console.log("Zone handled err", err.message);
                return false;
            }
        }).run(() => { return Promise.reject(new Error("error in promise rejection")); })
```