### PR TITLE
fix(event): in IE, fix #1128, #589, pointer event will be transformed in IE

### DIFF
--- a/test/browser/browser.spec.ts
+++ b/test/browser/browser.spec.ts
@@ -2662,5 +2662,44 @@ describe('Zone', function() {
                });
              }));
     });
+
+    describe(
+        'pointer event in IE',
+        ifEnvSupports(
+            () => {
+              return getIEVersion() === 10;
+            },
+            () => {
+              const pointerEventsMap: {[key: string]: string} = {
+                'pointercancel': 'MSPointerCancel',
+                'pointerdown': 'MSPointerDown',
+                'pointerenter': 'MSPointerEnter',
+                'pointerhover': 'MSPointerHover',
+                'pointerleave': 'MSPointerLeave',
+                'pointermove': 'MSPointerMove',
+                'pointerout': 'MSPointerOut',
+                'pointerover': 'MSPointerOver',
+                'pointerup': 'MSPointerUp'
+              };
+              let div: HTMLDivElement;
+              beforeEach(() => {
+                div = document.createElement('div');
+                document.body.appendChild(div);
+              });
+              afterEach(() => {
+                document.body.removeChild(div);
+              });
+              Object.keys(pointerEventsMap).forEach(key => {
+                it(`${key} should be registered as ${pointerEventsMap[key]}`, (done: DoneFn) => {
+                  div.addEventListener(key, (event: any) => {
+                    expect(event.type).toEqual(pointerEventsMap[key]);
+                    done();
+                  });
+                  const evt = document.createEvent('Event');
+                  evt.initEvent(key, true, true);
+                  div.dispatchEvent(evt);
+                });
+              });
+            }));
   });
 });

--- a/test/browser/browser.spec.ts
+++ b/test/browser/browser.spec.ts
@@ -2699,6 +2699,38 @@ describe('Zone', function() {
                   evt.initEvent(key, true, true);
                   div.dispatchEvent(evt);
                 });
+
+                it(`${key} and ${pointerEventsMap[key]} should both be triggered`,
+                   (done: DoneFn) => {
+                     const logs: string[] = [];
+                     div.addEventListener(key, (event: any) => {
+                       expect(event.type).toEqual(pointerEventsMap[key]);
+                       logs.push(`${key} triggered`);
+                     });
+                     div.addEventListener(pointerEventsMap[key], (event: any) => {
+                       expect(event.type).toEqual(pointerEventsMap[key]);
+                       logs.push(`${pointerEventsMap[key]} triggered`);
+                     });
+                     const evt1 = document.createEvent('Event');
+                     evt1.initEvent(key, true, true);
+                     div.dispatchEvent(evt1);
+
+                     setTimeout(() => {
+                       expect(logs).toEqual(
+                           [`${key} triggered`, `${pointerEventsMap[key]} triggered`]);
+                     });
+
+                     const evt2 = document.createEvent('Event');
+                     evt2.initEvent(pointerEventsMap[key], true, true);
+                     div.dispatchEvent(evt2);
+
+                     setTimeout(() => {
+                       expect(logs).toEqual(
+                           [`${key} triggered`, `${pointerEventsMap[key]} triggered`]);
+                     });
+
+                     setTimeout(done);
+                   });
               });
             }));
   });


### PR DESCRIPTION
fix #589. #1128.

In `IE`, the `pointer` event will use the `MS` version, such as `pointerup` will become `MSPointerUp`. So we need to do the `mapping` to handle this case.