### PR TITLE
feat(core): upgrade to typescript 3.0.3

### DIFF
--- a/lib/browser/property-descriptor.ts
+++ b/lib/browser/property-descriptor.ts
@@ -113,10 +113,10 @@ const globalEventHandlersEventNames = [
   'wheel'
 ];
 const documentEventNames = [
-  'afterscriptexecute', 'beforescriptexecute', 'DOMContentLoaded', 'fullscreenchange',
+  'afterscriptexecute', 'beforescriptexecute', 'DOMContentLoaded', 'freeze', 'fullscreenchange',
   'mozfullscreenchange', 'webkitfullscreenchange', 'msfullscreenchange', 'fullscreenerror',
   'mozfullscreenerror', 'webkitfullscreenerror', 'msfullscreenerror', 'readystatechange',
-  'visibilitychange'
+  'visibilitychange', 'resume'
 ];
 const windowEventNames = [
   'absolutedeviceorientation',

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ts-loader": "^0.6.0",
     "tslint": "^4.1.1",
     "tslint-eslint-rules": "^3.1.0",
-    "typescript": "2.9.2",
+    "typescript": "^3.0.3",
     "vrsource-tslint-rules": "^4.0.0",
     "webdriver-manager": "^12.0.6",
     "webdriverio": "^4.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5511,9 +5511,9 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+typescript@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
 
 uglify-js@2.6.4:
   version "2.6.4"


### PR DESCRIPTION
1. Upgrade to typescript 3.0.3
2. Add `resume`, `freeze` onProperty patch for `document` in `chrome 66`.

@mhevery, please review. thanks!