### PR TITLE
feat(async): support native async/await

### DIFF
--- a/lib/common/promise.ts
+++ b/lib/common/promise.ts
@@ -207,6 +207,9 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
             api.scheduleMicroTask();  // to make sure that it is running
           }
         }
+        if ((promise as any)['__zone_symbol__isAsync'] === true) {
+          Zone.setAsyncFrame();
+        }
       }
     }
     // Resolving an already resolved promise is a noop.
@@ -450,9 +453,16 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
     proto[symbolThen] = originalThen;
 
     Ctor.prototype.then = function(onResolve: any, onReject: any) {
+      let isNativePromise = false;
+      if (this && !(this instanceof ZoneAwarePromise)) {
+        isNativePromise = true;
+      }
       const wrapped = new ZoneAwarePromise((resolve, reject) => {
         originalThen.call(this, resolve, reject);
       });
+      if (isNativePromise) {
+        (wrapped as any)['__zone_symbol__isAsync'] = true;
+      }
       return wrapped.then(onResolve, onReject);
     };
     (Ctor as any)[symbolThenPatched] = true;

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -307,6 +307,9 @@ interface ZoneType {
 
   /** @internal */
   __symbol__(name: string): string;
+
+  /** @internal */
+  setAsyncFrame(): void;
 }
 
 /** @internal */
@@ -661,6 +664,9 @@ const Zone: ZoneType = (function(global: any) {
     }
   }
 
+  const detectAsyncFunction = async function() {};
+  const AsyncFunction = detectAsyncFunction.constructor;
+
   class Zone implements AmbientZone {
     static __symbol__: (name: string) => string = __symbol__;
 
@@ -689,6 +695,10 @@ const Zone: ZoneType = (function(global: any) {
 
     static get currentTask(): Task|null {
       return _currentTask;
+    }
+
+    static setAsyncFrame() {
+      _currentZoneFrame = _asyncZoneFrame!;
     }
 
     static __load_patch(name: string, fn: _PatchFn): void {
@@ -761,9 +771,26 @@ const Zone: ZoneType = (function(global: any) {
         callback: (...args: any[]) => T, applyThis?: any, applyArgs?: any[], source?: string): T {
       _currentZoneFrame = {parent: _currentZoneFrame, zone: this};
       try {
+        if (callback && callback.constructor === AsyncFunction) {
+          const r = this._zoneDelegate.invoke(this, callback, applyThis, applyArgs, source);
+          if (r && typeof r.then === 'function') {
+            _asyncZoneFrame = _currentZoneFrame;
+            return r.then((result: any) => {
+              _currentZoneFrame = _asyncZoneFrame!.parent!;
+              _isAsyncSet = true;
+              _asyncZoneFrame = null;
+              return result;
+            });
+          }
+          return r;
+        }
         return this._zoneDelegate.invoke(this, callback, applyThis, applyArgs, source);
       } finally {
-        _currentZoneFrame = _currentZoneFrame.parent!;
+        if (!_isAsyncSet) {
+          _currentZoneFrame = _currentZoneFrame.parent!;
+        } else {
+          _isAsyncSet = false;
+        }
       }
     }
 
@@ -1353,6 +1380,8 @@ const Zone: ZoneType = (function(global: any) {
     },
   };
   let _currentZoneFrame: _ZoneFrame = {parent: null, zone: new Zone(null, null)};
+  let _asyncZoneFrame: _ZoneFrame|null = null;
+  let _isAsyncSet = false;
   let _currentTask: Task|null = null;
   let _numberOfNestedTaskFrames = 0;
 


### PR DESCRIPTION
I think I may find a way to resolve `native async/await` issue.
The test code below works well.
```ts
  async function test() {
            console.log('test');
            return 1;
        }

        async function test1() {
            console.log('before await test', Zone.current.name);
            const result = await test();
            // should keep zone context test
            console.log('after await test', result, Zone.current.name);
        }

        async function test2() {
            console.log('before await test1', Zone.current.name);
            const result = await test1();
            // should keep zone context test
            console.log('after await test1', result, Zone.current.name);
        }
        console.log('begin test');
        Zone.current.fork({name: 'test'}).run(test1);
        // here should be <root> zone.
        console.log('outside test', Zone.current.name);
        Zone.current.fork({name: 'test1'}).run(() => {
            // should be test1 zone.
            console.log('another test', Zone.current.name);
        });
```

@mhevery, I will continue to add test cases, hope it can work.