### PR TITLE
doc(module): fix the name of the "disable browser timers" variable

### DIFF
--- a/MODULE.md
+++ b/MODULE.md
@@ -32,7 +32,7 @@ Below is the full list of currently supported modules.
 |Module Name|Behavior with zone.js patch|How to disable|
 |--|--|--|
 |on_property|target.onProp will become zone aware target.addEventListener(prop)|__Zone_disable_on_property = true|
-|timers|setTimeout/setInterval/setImmediate will be patched as Zone MacroTask|__Zone_disable_timer = true|
+|timers|setTimeout/setInterval/setImmediate will be patched as Zone MacroTask|__Zone_disable_timers = true|
 |requestAnimationFrame|requestAnimationFrame will be patched as Zone MacroTask|__Zone_disable_requestAnimationFrame = true|
 |blocking|alert/prompt/confirm will be patched as Zone.run|__Zone_disable_blocking = true|
 |EventTarget|target.addEventListener will be patched as Zone aware EventTask|__Zone_disable_EventTarget = true|


### PR DESCRIPTION
The documentation uses the singular `timer`, but it looks like the [code](https://github.com/angular/zone.js/blob/427705f2a6468fc74fdd1e8dc15b70ecb11d32c9/lib/browser/browser.ts#L28) checks for the plural `timers`.