### PR TITLE
fix(core): fix interval will still run after cancelled error

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -796,7 +796,7 @@ const Zone: ZoneType = (function(global: any) {
       // will run in notScheduled(canceled) state, we should not try to
       // run such kind of task but just return
 
-      if (task.state === notScheduled && task.type === eventTask) {
+      if (task.state === notScheduled && (task.type === eventTask || task.type === macroTask)) {
         return;
       }
 


### PR DESCRIPTION
This issue is posted by @vsavkin from slack, in one project using `angularjs 1.X ngUpgrade with Angular5`,  in `Edge`, the `setInterval` will still call `runTask` after `cancelInterval`, cannot reproduce with a simple project. There is the similar error before in #778, so in this PR, we will add some code to prevent such kind of error.

@mhevery, please review.