### PR TITLE
fix(test): fix #1155, try/catch modify error.message

### DIFF
--- a/lib/jasmine/jasmine.ts
+++ b/lib/jasmine/jasmine.ts
@@ -224,7 +224,11 @@
           const proxyZoneSpec: any = this && this.testProxyZoneSpec;
           if (proxyZoneSpec) {
             const pendingTasksInfo = proxyZoneSpec.getAndClearPendingTasksInfo();
-            error.message += pendingTasksInfo;
+            try {
+              // try catch here in case error.message is not writable
+              error.message += pendingTasksInfo;
+            } catch (err) {
+            }
           }
         }
         if (onException) {

--- a/lib/mocha/mocha.ts
+++ b/lib/mocha/mocha.ts
@@ -164,7 +164,11 @@
       this.on('fail', (test: any, err: any) => {
         const proxyZoneSpec = testZone && testZone.get('ProxyZoneSpec');
         if (proxyZoneSpec && err) {
-          err.message += proxyZoneSpec.getAndClearPendingTasksInfo();
+          try {
+            // try catch here in case err.message is not writable
+            err.message += proxyZoneSpec.getAndClearPendingTasksInfo();
+          } catch (error) {
+          }
         }
       });
 


### PR DESCRIPTION
fix #1155.

In some test cases, the user may throw an error with an unconfigurable or readonly `message` property, so we should try/catch when we want to add some additional information to the message there.