### PR TITLE
test(promise): add test cases for Promise.all with sync then operations

### DIFF
--- a/test/common/Promise.spec.ts
+++ b/test/common/Promise.spec.ts
@@ -463,6 +463,26 @@ describe(
             });
           });
 
+          it('should resolve with the sync then operation', () => {
+            queueZone.run(() => {
+              let value = null;
+              const p1 = {
+                then: function(thenCallback: Function) {
+                  return thenCallback('p1');
+                }
+              };
+              const p2 = {
+                then: function(thenCallback: Function) {
+                  return thenCallback('p2');
+                }
+              };
+              Promise.all([p1, 'v1', p2]).then((v: any) => value = v);
+              // expect(Zone.current.get('queue').length).toEqual(2);
+              flushMicrotasks();
+              expect(value).toEqual(['p1', 'v1', 'p2']);
+            });
+          });
+
           it('should resolve generators',
              ifEnvSupports(
                  () => {


### PR DESCRIPTION
add test cases for #1150, `Promise.all` should handle `sync thenable` operations.