### PR TITLE
fix(element): Fix native_shim.js not implement adoptedCallback error.

### DIFF
--- a/lib/browser/register-element.ts
+++ b/lib/browser/register-element.ts
@@ -26,7 +26,7 @@ function patchCallbacks(target: any, targetName: string, method: string, callbac
           if (descriptor && descriptor.value) {
             descriptor.value = wrapWithCurrentZone(descriptor.value, source);
             _redefineProperty(opts.prototype, callback, descriptor);
-          } else {
+          } else if (prototype[callback]) {
             prototype[callback] = wrapWithCurrentZone(prototype[callback], source);
           }
         } else if (prototype[callback]) {


### PR DESCRIPTION
To pass test in `angular`, we need to handle some of `callbacks` are not implemented by some `polyfilles`. `@webcomponent/native_shim.js` doesn't implement `adopdatedCallback`, `zone.js` will throw error, so we need to check this case.