### PR TITLE
Fix the typo in timer module documentation

### DIFF
--- a/MODULE.md
+++ b/MODULE.md
@@ -32,7 +32,7 @@ Below is the full list of currently supported modules.
 |Module Name|Behavior with zone.js patch|How to disable|
 |--|--|--|
 |on_property|target.onProp will become zone aware target.addEventListener(prop)|__Zone_disable_on_property = true|
-|timers|setTimeout/setInterval/setImmediate will be patched as Zone MacroTask|__Zone_disable_timer = true|
+|timers|setTimeout/setInterval/setImmediate will be patched as Zone MacroTask|__Zone_disable_timers = true|
 |requestAnimationFrame|requestAnimationFrame will be patched as Zone MacroTask|__Zone_disable_requestAnimationFrame = true|
 |blocking|alert/prompt/confirm will be patched as Zone.run|__Zone_disable_blocking = true|
 |EventTarget|target.addEventListener will be patched as Zone aware EventTask|__Zone_disable_EventTarget = true|


### PR DESCRIPTION
The source code lib/browser.ts says that the correct property to disable timer patching name is **timers** not **timer**.