### PR TITLE
build: upgrade to pass jasmine 3.3 test

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "gulp-tslint": "^7.0.1",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.7",
-    "jasmine": "^2.9.1",
+    "jasmine": "^3.3.1",
     "jasmine-core": "^2.9.1",
     "karma": "^0.13.14",
     "karma-chrome-launcher": "^0.2.1",

--- a/test/node_bluebird_entry_point.ts
+++ b/test/node_bluebird_entry_point.ts
@@ -28,5 +28,28 @@ import '../lib/testing/promise-testing';
 // Setup test environment
 import './test-env-setup-jasmine';
 
+const globalErrors = (jasmine as any).GlobalErrors;
+const symbol = Zone.__symbol__;
+if (globalErrors && !(jasmine as any)[symbol('GlobalErrors')]) {
+  (jasmine as any)[symbol('GlobalErrors')] = globalErrors;
+  (jasmine as any).GlobalErrors = function() {
+    const instance = new globalErrors();
+    const originalInstall = instance.install;
+    if (originalInstall && !instance[symbol('install')]) {
+      instance[symbol('install')] = originalInstall;
+      instance.install = function() {
+        const originalHandlers = process.listeners('unhandledRejection');
+        const r = originalInstall.apply(this, arguments);
+        process.removeAllListeners('unhandledRejection');
+        if (originalHandlers) {
+          originalHandlers.forEach(h => process.on('unhandledRejection', h));
+        }
+        return r;
+      };
+    }
+    return instance;
+  };
+}
+
 // List all tests here:
 import './extra/bluebird.spec';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1856,11 +1856,6 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-exit@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
-  integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
-
 expand-braces@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/expand-braces/-/expand-braces-0.1.2.tgz#488b1d1d2451cb3d3a6b192cfc030f44c5855fea"
@@ -2587,7 +2582,7 @@ graceful-fs@^3.0.0:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-3.0.11.tgz#7613c778a1afea62f25c630a086d7f3acbbdd818"
   integrity sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=
   dependencies:
-    natives "^1.1.3"
+    natives "^1.1.0"
 
 graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
@@ -3559,19 +3554,23 @@ jade@0.26.3:
     commander "0.6.1"
     mkdirp "0.3.0"
 
-jasmine-core@^2.9.1, jasmine-core@~2.99.0:
+jasmine-core@^2.9.1:
   version "2.99.1"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.99.1.tgz#e6400df1e6b56e130b61c4bcd093daa7f6e8ca15"
   integrity sha1-5kAN8ea1bhMLYcS80JPap/boyhU=
 
-jasmine@^2.9.1:
-  version "2.99.0"
-  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-2.99.0.tgz#8ca72d102e639b867c6489856e0e18a9c7aa42b7"
-  integrity sha1-jKctEC5jm4Z8ZImFbg4YqceqQrc=
+jasmine-core@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.3.0.tgz#dea1cdc634bc93c7e0d4ad27185df30fa971b10e"
+  integrity sha512-3/xSmG/d35hf80BEN66Y6g9Ca5l/Isdeg/j6zvbTYlTzeKinzmaTM4p9am5kYqOmE05D7s1t8FGjzdSnbUbceA==
+
+jasmine@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-3.3.1.tgz#d61bb1dd8888859bd11ea83074a78ee13d949905"
+  integrity sha512-/vU3/H7U56XsxIXHwgEuWpCgQ0bRi2iiZeUpx7Nqo8n1TpoDHfZhkPIc7CO8I4pnMzYsi3XaSZEiy8cnTfujng==
   dependencies:
-    exit "^0.1.2"
     glob "^7.0.6"
-    jasmine-core "~2.99.0"
+    jasmine-core "~3.3.0"
 
 js-tokens@^3.0.2:
   version "3.0.2"
@@ -4421,7 +4420,7 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-natives@^1.1.3:
+natives@^1.1.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
   integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==


### PR DESCRIPTION
jasmine 3.3 will ignore `process.unhandledRejection eventListeners`, so some of our `Promise test` will fail, in this PR, I restore the `process.unhandledRejection` to make our test pass.