### PR TITLE
build: bump version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="0.9.0"></a>
+# [0.9.0](https://github.com/angular/zone.js/compare/v0.8.29...0.9.0) (2019-02-24)
+
+
+### Build 
+
+* **core:** separate evergreen vs legacy support ([ac3851e](https://github.com/angular/zone.js/commit/ac3851e))
+
 <a name="0.8.29"></a>
 ## [0.8.29](https://github.com/angular/zone.js/compare/v0.8.28...0.8.29) (2019-01-22)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zone.js",
-  "version": "0.8.29",
+  "version": "0.9.0",
   "description": "Zones for JavaScript",
   "main": "dist/zone-node.js",
   "browser": "dist/zone.js",

--- a/sauce-evergreen.conf.js
+++ b/sauce-evergreen.conf.js
@@ -7,7 +7,6 @@ module.exports = function(config, ignoredLaunchers) {
   var basicLaunchers = {
     'SL_CHROME': {base: 'SauceLabs', browserName: 'chrome', version: '72'},
     'SL_CHROME_60': {base: 'SauceLabs', browserName: 'chrome', version: '60'},
-    'SL_FIREFOX_59': {base: 'SauceLabs', browserName: 'firefox', platform: 'Windows 10', version: '65'},
     'SL_SAFARI':
       {base: 'SauceLabs', browserName: 'safari', platform: 'macOS 10.13', version: '11.1'},
     'SL_ANDROID8.0': {


### PR DESCRIPTION
We need to bump the version from `0.8` to `0.9` because we have some `minor API changes` in https://github.com/angular/zone.js/pull/1044, and we also add support for `evergreen` browsers.