### PR TITLE
env: change BLACK_LISTED_EVENTS to DISABLE_EVENTS

### DIFF
--- a/lib/browser/api-util.ts
+++ b/lib/browser/api-util.ts
@@ -13,4 +13,19 @@ Zone.__load_patch('util', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   api.patchMethod = patchMethod;
   api.bindArguments = bindArguments;
   api.patchMacroTask = patchMacroTask;
+  // In earlier version of zone.js (<0.9.0), we use env name `__zone_symbol__BLACK_LISTED_EVENTS` to
+  // define which events will not be patched by `Zone.js`.
+  // In newer version (>=0.9.0), we change the env name to `__zone_symbol__UNPATCHED_EVENTS` to keep
+  // the name consistent with angular repo.
+  // The  `__zone_symbol__BLACK_LISTED_EVENTS` is deprecated, but it is still be supported for
+  // backwards compatibility.
+  const SYMBOL_BLACK_LISTED_EVENTS = Zone.__symbol__('BLACK_LISTED_EVENTS');
+  const SYMBOL_UNPATCHED_EVENTS = Zone.__symbol__('UNPATCHED_EVENTS');
+  if (global[SYMBOL_UNPATCHED_EVENTS]) {
+    global[SYMBOL_BLACK_LISTED_EVENTS] = global[SYMBOL_UNPATCHED_EVENTS];
+  }
+  if (global[SYMBOL_BLACK_LISTED_EVENTS]) {
+    (Zone as any)[SYMBOL_BLACK_LISTED_EVENTS] = (Zone as any)[SYMBOL_UNPATCHED_EVENTS] =
+        global[SYMBOL_BLACK_LISTED_EVENTS];
+  }
 });

--- a/lib/browser/browser-legacy.ts
+++ b/lib/browser/browser-legacy.ts
@@ -19,10 +19,6 @@ Zone.__load_patch('registerElement', (global: any, Zone: ZoneType, api: _ZonePri
 });
 
 Zone.__load_patch('EventTargetLegacy', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
-  const SYMBOL_BLACK_LISTED_EVENTS = Zone.__symbol__('BLACK_LISTED_EVENTS');
-  if (global[SYMBOL_BLACK_LISTED_EVENTS]) {
-    (Zone as any)[SYMBOL_BLACK_LISTED_EVENTS] = global[SYMBOL_BLACK_LISTED_EVENTS];
-  }
   eventTargetLegacyPatch(global, api);
   propertyDescriptorLegacyPatch(api, global);
 });

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -47,12 +47,6 @@ Zone.__load_patch('blocking', (global: any, Zone: ZoneType) => {
 });
 
 Zone.__load_patch('EventTarget', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
-  // load blackListEvents from global
-  const SYMBOL_BLACK_LISTED_EVENTS = Zone.__symbol__('BLACK_LISTED_EVENTS');
-  if (global[SYMBOL_BLACK_LISTED_EVENTS]) {
-    (Zone as any)[SYMBOL_BLACK_LISTED_EVENTS] = global[SYMBOL_BLACK_LISTED_EVENTS];
-  }
-
   patchEvent(global, api);
   eventTargetPatch(global, api);
   // patch XMLHttpRequestEventTarget's addEventListener/removeEventListener

--- a/test/test_fake_polyfill.ts
+++ b/test/test_fake_polyfill.ts
@@ -75,5 +75,5 @@ Object.defineProperties(TestTarget.prototype, {
 global['__Zone_ignore_on_properties'] =
     [{target: TestTarget.prototype, ignoreProperties: ['prop1']}];
 global['__zone_symbol__FakeAsyncTestMacroTask'] = [{source: 'TestClass.myTimeout'}];
-global['__zone_symbol__BLACK_LISTED_EVENTS'] = ['scroll'];
+global['__zone_symbol__UNPATCHED_EVENTS'] = ['scroll'];
 })(typeof window === 'object' && window || typeof self === 'object' && self || global);


### PR DESCRIPTION
based on this change in Angular repo, https://github.com/angular/angular/pull/28529
change env name from `__zone_symbol__BLACK_LISTED_EVENTS` to `__zone_symbol__DISABLE_EVENTS`.
And for `backward compatibility`, we still support `__zone_symbol__BLACK_LISTED_EVENTS`