### PR TITLE
build: make legacy standalone bundle

### DIFF
--- a/file-size-limit.json
+++ b/file-size-limit.json
@@ -1,9 +1,14 @@
 {
   "targets": [
     {
-      "path": "dist/zone.min.js",
+      "path": "dist/zone-evergreen.min.js",
       "checkTarget": true,
       "limit": 43000
+    },
+    {
+      "path": "dist/zone.min.js",
+      "checkTarget": true,
+      "limit": 44000
     }
   ]
 }

--- a/lib/browser/api-util.ts
+++ b/lib/browser/api-util.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {bindArguments, patchMacroTask, patchMethod, patchOnProperties} from '../common/utils';
+import {globalSources, patchEventPrototype, patchEventTarget, zoneSymbolEventNames} from '../common/events';
+import {ADD_EVENT_LISTENER_STR, ArraySlice, attachOriginToPatched, bindArguments, FALSE_STR, isBrowser, isIEOrEdge, isMix, isNode, ObjectCreate, ObjectDefineProperty, ObjectGetOwnPropertyDescriptor, patchClass, patchMacroTask, patchMethod, patchOnProperties, REMOVE_EVENT_LISTENER_STR, TRUE_STR, wrapWithCurrentZone, ZONE_SYMBOL_PREFIX} from '../common/utils';
+
+import {patchCallbacks} from './browser-util';
+import {_redefineProperty} from './define-property';
+import {eventNames, filterProperties} from './property-descriptor';
 
 Zone.__load_patch('util', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   api.patchOnProperties = patchOnProperties;
@@ -28,4 +33,30 @@ Zone.__load_patch('util', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
     (Zone as any)[SYMBOL_BLACK_LISTED_EVENTS] = (Zone as any)[SYMBOL_UNPATCHED_EVENTS] =
         global[SYMBOL_BLACK_LISTED_EVENTS];
   }
+  api.patchEventPrototype = patchEventPrototype;
+  api.patchEventTarget = patchEventTarget;
+  api.isIEOrEdge = isIEOrEdge;
+  api.ObjectDefineProperty = ObjectDefineProperty;
+  api.ObjectGetOwnPropertyDescriptor = ObjectGetOwnPropertyDescriptor;
+  api.ObjectCreate = ObjectCreate;
+  api.ArraySlice = ArraySlice;
+  api.patchClass = patchClass;
+  api.wrapWithCurrentZone = wrapWithCurrentZone;
+  api.filterProperties = filterProperties;
+  api.attachOriginToPatched = attachOriginToPatched;
+  api._redefineProperty = _redefineProperty;
+  api.patchCallbacks = patchCallbacks;
+  api.getGlobalObjects = () => ({
+    globalSources,
+    zoneSymbolEventNames,
+    eventNames,
+    isBrowser,
+    isMix,
+    isNode,
+    TRUE_STR,
+    FALSE_STR,
+    ZONE_SYMBOL_PREFIX,
+    ADD_EVENT_LISTENER_STR,
+    REMOVE_EVENT_LISTENER_STR
+  });
 });

--- a/lib/browser/browser-legacy.ts
+++ b/lib/browser/browser-legacy.ts
@@ -14,11 +14,16 @@ import {eventTargetLegacyPatch} from './event-target-legacy';
 import {propertyDescriptorLegacyPatch} from './property-descriptor-legacy';
 import {registerElementPatch} from './register-element';
 
-Zone.__load_patch('registerElement', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
-  registerElementPatch(global);
-});
+(function(_global: any) {
+_global['__zone_symbol__legacyPatch'] = function() {
+  const Zone = _global['Zone'];
+  Zone.__load_patch('registerElement', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+    registerElementPatch(global, api);
+  });
 
-Zone.__load_patch('EventTargetLegacy', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
-  eventTargetLegacyPatch(global, api);
-  propertyDescriptorLegacyPatch(api, global);
-});
+  Zone.__load_patch('EventTargetLegacy', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
+    eventTargetLegacyPatch(global, api);
+    propertyDescriptorLegacyPatch(api, global);
+  });
+};
+})(typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || global);

--- a/lib/browser/browser-util.ts
+++ b/lib/browser/browser-util.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export function patchCallbacks(
+    api: _ZonePrivate, target: any, targetName: string, method: string, callbacks: string[]) {
+  const symbol = Zone.__symbol__(method);
+  if (target[symbol]) {
+    return;
+  }
+  const nativeDelegate = target[symbol] = target[method];
+  target[method] = function(name: any, opts: any, options?: any) {
+    if (opts && opts.prototype) {
+      callbacks.forEach(function(callback) {
+        const source = `${targetName}.${method}::` + callback;
+        const prototype = opts.prototype;
+        if (prototype.hasOwnProperty(callback)) {
+          const descriptor = api.ObjectGetOwnPropertyDescriptor(prototype, callback);
+          if (descriptor && descriptor.value) {
+            descriptor.value = api.wrapWithCurrentZone(descriptor.value, source);
+            api._redefineProperty(opts.prototype, callback, descriptor);
+          } else if (prototype[callback]) {
+            prototype[callback] = api.wrapWithCurrentZone(prototype[callback], source);
+          }
+        } else if (prototype[callback]) {
+          prototype[callback] = api.wrapWithCurrentZone(prototype[callback], source);
+        }
+      });
+    }
+
+    return nativeDelegate.call(target, name, opts, options);
+  };
+
+  api.attachOriginToPatched(target[method], nativeDelegate);
+}

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -18,7 +18,13 @@ import {patchCustomElements} from './custom-elements';
 import {propertyPatch} from './define-property';
 import {eventTargetPatch, patchEvent} from './event-target';
 import {propertyDescriptorPatch} from './property-descriptor';
-import {registerElementPatch} from './register-element';
+
+Zone.__load_patch('legacy', (global: any) => {
+  const legacyPatch = global[Zone.__symbol__('legacyPatch')];
+  if (legacyPatch) {
+    legacyPatch();
+  }
+});
 
 Zone.__load_patch('timers', (global: any) => {
   const set = 'set';
@@ -66,7 +72,7 @@ Zone.__load_patch('on_property', (global: any, Zone: ZoneType, api: _ZonePrivate
 });
 
 Zone.__load_patch('customElements', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
-  patchCustomElements(global);
+  patchCustomElements(global, api);
 });
 
 Zone.__load_patch('XHR', (global: any, Zone: ZoneType) => {

--- a/lib/browser/define-property.ts
+++ b/lib/browser/define-property.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {zoneSymbol} from '../common/utils';
 /*
  * This is necessary for Chrome and Chrome mobile, to enable
  * things like redefining `createdCallback` on an element.
  */
 
+const zoneSymbol = Zone.__symbol__;
 const _defineProperty = (Object as any)[zoneSymbol('defineProperty')] = Object.defineProperty;
 const _getOwnPropertyDescriptor = (Object as any)[zoneSymbol('getOwnPropertyDescriptor')] =
     Object.getOwnPropertyDescriptor;

--- a/lib/browser/event-target-legacy.ts
+++ b/lib/browser/event-target-legacy.ts
@@ -6,12 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {globalSources, patchEventPrototype, patchEventTarget, zoneSymbolEventNames} from '../common/events';
-import {FALSE_STR, isIEOrEdge, TRUE_STR, ZONE_SYMBOL_PREFIX} from '../common/utils';
-
-import {eventNames} from './property-descriptor';
-
 export function eventTargetLegacyPatch(_global: any, api: _ZonePrivate) {
+  const {eventNames, globalSources, zoneSymbolEventNames, TRUE_STR, FALSE_STR, ZONE_SYMBOL_PREFIX} =
+      api.getGlobalObjects()!;
   const WTF_ISSUE_555 =
       'Anchor,Area,Audio,BR,Base,BaseFont,Body,Button,Canvas,Content,DList,Directory,Div,Embed,FieldSet,Font,Form,Frame,FrameSet,HR,Head,Heading,Html,IFrame,Image,Input,Keygen,LI,Label,Legend,Link,Map,Marquee,Media,Menu,Meta,Meter,Mod,OList,Object,OptGroup,Option,Output,Paragraph,Pre,Progress,Quote,Script,Select,Source,Span,Style,TableCaption,TableCell,TableCol,Table,TableRow,TableSection,TextArea,Title,Track,UList,Unknown,Video';
   const NO_EVENT_TARGET =
@@ -36,7 +33,7 @@ export function eventTargetLegacyPatch(_global: any, api: _ZonePrivate) {
 
   const isDisableIECheck = _global['__Zone_disable_IE_check'] || false;
   const isEnableCrossContextCheck = _global['__Zone_enable_cross_context_check'] || false;
-  const ieOrEdge = isIEOrEdge();
+  const ieOrEdge = api.isIEOrEdge();
 
   const ADD_EVENT_LISTENER_SOURCE = '.addEventListener:';
   const FUNCTION_WRAPPER = '[object FunctionWrapper]';
@@ -103,11 +100,11 @@ export function eventTargetLegacyPatch(_global: any, api: _ZonePrivate) {
   }
   // vh is validateHandler to check event handler
   // is valid or not(for security check)
-  patchEventTarget(_global, apiTypes, {vh: checkIEAndCrossContext});
+  api.patchEventTarget(_global, apiTypes, {vh: checkIEAndCrossContext});
 
   return true;
 }
 
 export function patchEvent(global: any, api: _ZonePrivate) {
-  patchEventPrototype(global, api);
+  api.patchEventPrototype(global, api);
 }

--- a/lib/browser/event-target.ts
+++ b/lib/browser/event-target.ts
@@ -6,12 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {globalSources, patchEventPrototype, patchEventTarget, zoneSymbolEventNames} from '../common/events';
-import {FALSE_STR, TRUE_STR, ZONE_SYMBOL_PREFIX} from '../common/utils';
-
-import {eventNames} from './property-descriptor';
-
 export function eventTargetPatch(_global: any, api: _ZonePrivate) {
+  const {eventNames, zoneSymbolEventNames, TRUE_STR, FALSE_STR, ZONE_SYMBOL_PREFIX} =
+      api.getGlobalObjects()!;
   //  predefine all __zone_symbol__ + eventName + true/false string
   for (let i = 0; i < eventNames.length; i++) {
     const eventName = eventNames[i];
@@ -28,12 +25,11 @@ export function eventTargetPatch(_global: any, api: _ZonePrivate) {
   if (!EVENT_TARGET || !EVENT_TARGET.prototype) {
     return;
   }
-  patchEventTarget(_global, [EVENT_TARGET && EVENT_TARGET.prototype]);
-  api.patchEventTarget = patchEventTarget;
+  api.patchEventTarget(_global, [EVENT_TARGET && EVENT_TARGET.prototype]);
 
   return true;
 }
 
 export function patchEvent(global: any, api: _ZonePrivate) {
-  patchEventPrototype(global, api);
+  api.patchEventPrototype(global, api);
 }

--- a/lib/browser/property-descriptor-legacy.ts
+++ b/lib/browser/property-descriptor-legacy.ts
@@ -10,32 +10,19 @@
  * @suppress {globalThis}
  */
 
-import {isBrowser, isMix, isNode, ObjectDefineProperty, ObjectGetOwnPropertyDescriptor, patchClass, patchOnProperties, wrapWithCurrentZone, zoneSymbol} from '../common/utils';
-
-import {eventNames, filterProperties, IgnoreProperty} from './property-descriptor';
 import * as webSocketPatch from './websocket';
 
-export function patchFilteredProperties(
-    target: any, onProperties: string[], ignoreProperties: IgnoreProperty[], prototype?: any) {
-  // check whether target is available, sometimes target will be undefined
-  // because different browser or some 3rd party plugin.
-  if (!target) {
-    return;
-  }
-  const filteredProperties: string[] = filterProperties(target, onProperties, ignoreProperties);
-  patchOnProperties(target, filteredProperties, prototype);
-}
-
 export function propertyDescriptorLegacyPatch(api: _ZonePrivate, _global: any) {
+  const {isNode, isMix} = api.getGlobalObjects()!;
   if (isNode && !isMix) {
     return;
   }
 
   const supportsWebSocket = typeof WebSocket !== 'undefined';
-  if (!canPatchViaPropertyDescriptor()) {
+  if (!canPatchViaPropertyDescriptor(api)) {
     // Safari, Android browsers (Jelly Bean)
-    patchViaCapturingAllTheEvents();
-    patchClass('XMLHttpRequest');
+    patchViaCapturingAllTheEvents(api);
+    api.patchClass('XMLHttpRequest');
     if (supportsWebSocket) {
       webSocketPatch.apply(api, _global);
     }
@@ -43,19 +30,22 @@ export function propertyDescriptorLegacyPatch(api: _ZonePrivate, _global: any) {
   }
 }
 
-function canPatchViaPropertyDescriptor() {
-  if ((isBrowser || isMix) && !ObjectGetOwnPropertyDescriptor(HTMLElement.prototype, 'onclick') &&
+function canPatchViaPropertyDescriptor(api: _ZonePrivate) {
+  const {isBrowser, isMix} = api.getGlobalObjects()!;
+  if ((isBrowser || isMix) &&
+      !api.ObjectGetOwnPropertyDescriptor(HTMLElement.prototype, 'onclick') &&
       typeof Element !== 'undefined') {
     // WebKit https://bugs.webkit.org/show_bug.cgi?id=134364
     // IDL interface attributes are not configurable
-    const desc = ObjectGetOwnPropertyDescriptor(Element.prototype, 'onclick');
+    const desc = api.ObjectGetOwnPropertyDescriptor(Element.prototype, 'onclick');
     if (desc && !desc.configurable) return false;
   }
 
   const ON_READY_STATE_CHANGE = 'onreadystatechange';
   const XMLHttpRequestPrototype = XMLHttpRequest.prototype;
 
-  const xhrDesc = ObjectGetOwnPropertyDescriptor(XMLHttpRequestPrototype, ON_READY_STATE_CHANGE);
+  const xhrDesc =
+      api.ObjectGetOwnPropertyDescriptor(XMLHttpRequestPrototype, ON_READY_STATE_CHANGE);
 
   // add enumerable and configurable here because in opera
   // by default XMLHttpRequest.prototype.onreadystatechange is undefined
@@ -64,7 +54,7 @@ function canPatchViaPropertyDescriptor() {
   // and if XMLHttpRequest.prototype.onreadystatechange is undefined,
   // we should set a real desc instead a fake one
   if (xhrDesc) {
-    ObjectDefineProperty(XMLHttpRequestPrototype, ON_READY_STATE_CHANGE, {
+    api.ObjectDefineProperty(XMLHttpRequestPrototype, ON_READY_STATE_CHANGE, {
       enumerable: true,
       configurable: true,
       get: function() {
@@ -74,11 +64,11 @@ function canPatchViaPropertyDescriptor() {
     const req = new XMLHttpRequest();
     const result = !!req.onreadystatechange;
     // restore original desc
-    ObjectDefineProperty(XMLHttpRequestPrototype, ON_READY_STATE_CHANGE, xhrDesc || {});
+    api.ObjectDefineProperty(XMLHttpRequestPrototype, ON_READY_STATE_CHANGE, xhrDesc || {});
     return result;
   } else {
-    const SYMBOL_FAKE_ONREADYSTATECHANGE = zoneSymbol('fake');
-    ObjectDefineProperty(XMLHttpRequestPrototype, ON_READY_STATE_CHANGE, {
+    const SYMBOL_FAKE_ONREADYSTATECHANGE = api.symbol('fake');
+    api.ObjectDefineProperty(XMLHttpRequestPrototype, ON_READY_STATE_CHANGE, {
       enumerable: true,
       configurable: true,
       get: function() {
@@ -97,12 +87,12 @@ function canPatchViaPropertyDescriptor() {
   }
 }
 
-const unboundKey = zoneSymbol('unbound');
-
 // Whenever any eventListener fires, we check the eventListener target and all parents
 // for `onwhatever` properties and replace them with zone-bound functions
 // - Chrome (for now)
-function patchViaCapturingAllTheEvents() {
+function patchViaCapturingAllTheEvents(api: _ZonePrivate) {
+  const {eventNames} = api.getGlobalObjects()!;
+  const unboundKey = api.symbol('unbound');
   for (let i = 0; i < eventNames.length; i++) {
     const property = eventNames[i];
     const onproperty = 'on' + property;
@@ -115,7 +105,7 @@ function patchViaCapturingAllTheEvents() {
       }
       while (elt) {
         if (elt[onproperty] && !elt[onproperty][unboundKey]) {
-          bound = wrapWithCurrentZone(elt[onproperty], source);
+          bound = api.wrapWithCurrentZone(elt[onproperty], source);
           bound[unboundKey] = elt[onproperty];
           elt[onproperty] = bound;
         }

--- a/lib/browser/property-descriptor.ts
+++ b/lib/browser/property-descriptor.ts
@@ -10,9 +10,7 @@
  * @suppress {globalThis}
  */
 
-import {isBrowser, isIE, isMix, isNode, ObjectDefineProperty, ObjectGetOwnPropertyDescriptor, ObjectGetPrototypeOf, patchClass, patchOnProperties, wrapWithCurrentZone, zoneSymbol} from '../common/utils';
-
-import * as webSocketPatch from './websocket';
+import {isBrowser, isIE, isMix, isNode, ObjectGetPrototypeOf, patchOnProperties} from '../common/utils';
 
 const globalEventHandlersEventNames = [
   'abort',
@@ -273,7 +271,6 @@ export function propertyDescriptorPatch(api: _ZonePrivate, _global: any) {
     // events are already been patched by legacy patch.
     return;
   }
-
   const supportsWebSocket = typeof WebSocket !== 'undefined';
   const ignoreProperties: IgnoreProperty[] = _global['__Zone_ignore_on_properties'];
   // for browsers that we can patch the descriptor:  Chrome & Firefox

--- a/lib/browser/register-element.ts
+++ b/lib/browser/register-element.ts
@@ -6,10 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {isBrowser, isMix} from '../common/utils';
-import {patchCallbacks} from './custom-elements';
-
-export function registerElementPatch(_global: any) {
+export function registerElementPatch(_global: any, api: _ZonePrivate) {
+  const {isBrowser, isMix} = api.getGlobalObjects()!;
   if ((!isBrowser && !isMix) || !('registerElement' in (<any>_global).document)) {
     return;
   }
@@ -17,5 +15,5 @@ export function registerElementPatch(_global: any) {
   const callbacks =
       ['createdCallback', 'attachedCallback', 'detachedCallback', 'attributeChangedCallback'];
 
-  patchCallbacks(document, 'Document', 'registerElement', callbacks);
+  api.patchCallbacks(api, document, 'Document', 'registerElement', callbacks);
 }

--- a/lib/browser/websocket.ts
+++ b/lib/browser/websocket.ts
@@ -6,16 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {patchEventTarget} from '../common/events';
-import {ADD_EVENT_LISTENER_STR, ArraySlice, ObjectCreate, ObjectGetOwnPropertyDescriptor, patchOnProperties, REMOVE_EVENT_LISTENER_STR} from '../common/utils';
-
 // we have to patch the instance since the proto is non-configurable
 export function apply(api: _ZonePrivate, _global: any) {
+  const {ADD_EVENT_LISTENER_STR, REMOVE_EVENT_LISTENER_STR} = api.getGlobalObjects()!;
   const WS = (<any>_global).WebSocket;
   // On Safari window.EventTarget doesn't exist so need to patch WS add/removeEventListener
   // On older Chrome, no need since EventTarget was already patched
   if (!(<any>_global).EventTarget) {
-    patchEventTarget(_global, [WS.prototype]);
+    api.patchEventTarget(_global, [WS.prototype]);
   }
   (<any>_global).WebSocket = function(x: any, y: any) {
     const socket = arguments.length > 1 ? new WS(x, y) : new WS(x);
@@ -24,9 +22,9 @@ export function apply(api: _ZonePrivate, _global: any) {
     let proxySocketProto: any;
 
     // Safari 7.0 has non-configurable own 'onmessage' and friends properties on the socket instance
-    const onmessageDesc = ObjectGetOwnPropertyDescriptor(socket, 'onmessage');
+    const onmessageDesc = api.ObjectGetOwnPropertyDescriptor(socket, 'onmessage');
     if (onmessageDesc && onmessageDesc.configurable === false) {
-      proxySocket = ObjectCreate(socket);
+      proxySocket = api.ObjectCreate(socket);
       // socket have own property descriptor 'onopen', 'onmessage', 'onclose', 'onerror'
       // but proxySocket not, so we will keep socket as prototype and pass it to
       // patchOnProperties method
@@ -34,7 +32,7 @@ export function apply(api: _ZonePrivate, _global: any) {
       [ADD_EVENT_LISTENER_STR, REMOVE_EVENT_LISTENER_STR, 'send', 'close'].forEach(function(
           propName) {
         proxySocket[propName] = function() {
-          const args = ArraySlice.call(arguments);
+          const args = api.ArraySlice.call(arguments);
           if (propName === ADD_EVENT_LISTENER_STR || propName === REMOVE_EVENT_LISTENER_STR) {
             const eventName = args.length > 0 ? args[0] : undefined;
             if (eventName) {
@@ -50,7 +48,7 @@ export function apply(api: _ZonePrivate, _global: any) {
       proxySocket = socket;
     }
 
-    patchOnProperties(proxySocket, ['close', 'error', 'message', 'open'], proxySocketProto);
+    api.patchOnProperties(proxySocket, ['close', 'error', 'message', 'open'], proxySocketProto);
     return proxySocket;
   };
 

--- a/lib/common/utils.ts
+++ b/lib/common/utils.ts
@@ -12,7 +12,6 @@
  */
 
 // issue #989, to reduce bundle size, use short name
-
 /** Object.getOwnPropertyDescriptor */
 export const ObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 /** Object.defineProperty */
@@ -513,7 +512,7 @@ export function isIEOrEdge() {
     if (ua.indexOf('MSIE ') !== -1 || ua.indexOf('Trident/') !== -1 || ua.indexOf('Edge/') !== -1) {
       ieOrEdge = true;
     }
-    return ieOrEdge;
   } catch (error) {
   }
+  return ieOrEdge;
 }

--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -321,7 +321,7 @@ interface _ZonePrivate {
   microtaskDrainDone: () => void;
   showUncaughtError: () => boolean;
   patchEventTarget: (global: any, apis: any[], options?: any) => boolean[];
-  patchOnProperties: (obj: any, properties: string[]|null) => void;
+  patchOnProperties: (obj: any, properties: string[]|null, prototype?: any) => void;
   patchThen: (ctro: Function) => void;
   setNativePromise: (nativePromise: any) => void;
   patchMethod:
@@ -331,6 +331,27 @@ interface _ZonePrivate {
   bindArguments: (args: any[], source: string) => any[];
   patchMacroTask:
       (obj: any, funcName: string, metaCreator: (self: any, args: any[]) => any) => void;
+  patchEventPrototype: (_global: any, api: _ZonePrivate) => void;
+  isIEOrEdge: () => boolean;
+  ObjectDefineProperty:
+      (o: any, p: PropertyKey, attributes: PropertyDescriptor&ThisType<any>) => any;
+  ObjectGetOwnPropertyDescriptor: (o: any, p: PropertyKey) => PropertyDescriptor | undefined;
+  ObjectCreate(o: object|null, properties?: PropertyDescriptorMap&ThisType<any>): any;
+  ArraySlice(start?: number, end?: number): any[];
+  patchClass: (className: string) => void;
+  wrapWithCurrentZone: (callback: any, source: string) => any;
+  filterProperties: (target: any, onProperties: string[], ignoreProperties: any[]) => string[];
+  attachOriginToPatched: (target: any, origin: any) => void;
+  _redefineProperty: (target: any, callback: string, desc: any) => void;
+  patchCallbacks:
+      (api: _ZonePrivate, target: any, targetName: string, method: string,
+       callbacks: string[]) => void;
+  getGlobalObjects: () => {
+    globalSources: any, zoneSymbolEventNames: any, eventNames: string[], isBrowser: boolean,
+        isMix: boolean, isNode: boolean, TRUE_STR: string, FALSE_STR: string,
+        ZONE_SYMBOL_PREFIX: string, ADD_EVENT_LISTENER_STR: string,
+        REMOVE_EVENT_LISTENER_STR: string
+  } | undefined;
 }
 
 /** @internal */
@@ -1356,6 +1377,19 @@ const Zone: ZoneType = (function(global: any) {
         nativeMicroTaskQueuePromise = NativePromise.resolve(0);
       }
     },
+    patchEventPrototype: () => noop,
+    isIEOrEdge: () => false,
+    getGlobalObjects: () => undefined,
+    ObjectDefineProperty: () => noop,
+    ObjectGetOwnPropertyDescriptor: () => undefined,
+    ObjectCreate: () => undefined,
+    ArraySlice: () => [],
+    patchClass: () => noop,
+    wrapWithCurrentZone: () => noop,
+    filterProperties: () => [],
+    attachOriginToPatched: () => noop,
+    _redefineProperty: () => noop,
+    patchCallbacks: () => noop
   };
   let _currentZoneFrame: _ZoneFrame = {parent: null, zone: new Zone(null, null)};
   let _currentTask: Task|null = null;

--- a/test/browser/WebSocket.spec.ts
+++ b/test/browser/WebSocket.spec.ts
@@ -44,6 +44,10 @@ if (!window['saucelabs']) {
              it('should be patched in a Web Worker', done => {
                const worker = new Worker('/base/build/test/ws-webworker-context.js');
                worker.onmessage = (e: MessageEvent) => {
+                 if (e.data !== 'pass' && e.data !== 'fail') {
+                   fail(`web worker ${e.data}`);
+                   return;
+                 }
                  expect(e.data).toBe('pass');
                  done();
                };

--- a/test/zone_worker_entry_point.ts
+++ b/test/zone_worker_entry_point.ts
@@ -8,21 +8,24 @@
 
 // Setup tests for Zone without microtask support
 System.config({defaultJSExtensions: true});
-System.import('../lib/browser/browser-legacy').then(() => {
-  System.import('../lib/browser/browser').then(() => {
-    Zone.current.fork({name: 'webworker'}).run(() => {
-      const websocket = new WebSocket('ws://localhost:8001');
-      websocket.addEventListener('open', () => {
-        websocket.onmessage = () => {
-          if ((<any>self).Zone.current.name === 'webworker') {
-            (<any>self).postMessage('pass');
-          } else {
-            (<any>self).postMessage('fail');
-          }
-          websocket.close();
-        };
-        websocket.send('text');
+System.import('../lib/browser/api-util').then(() => {
+  System.import('../lib/browser/browser-legacy').then(() => {
+    System.import('../lib/browser/browser').then(() => {
+      const _global = typeof window !== 'undefined' ? window : self;
+      Zone.current.fork({name: 'webworker'}).run(() => {
+        const websocket = new WebSocket('ws://localhost:8001');
+        websocket.addEventListener('open', () => {
+          websocket.onmessage = () => {
+            if ((<any>self).Zone.current.name === 'webworker') {
+              (<any>self).postMessage('pass');
+            } else {
+              (<any>self).postMessage('fail');
+            }
+            websocket.close();
+          };
+          websocket.send('text');
+        });
       });
-    });
-  }, (e) => console.error(e));
+    }, (e) => (<any>self).postMessage(`error ${e.message}`));
+  });
 });


### PR DESCRIPTION
In `angular cli`, there is a file named `es2015-polyfill.js`, inside this file, all `polyfill` for `es5 legacy browsers` will be there, so with `zone evergreen bundle`, the most idle way to handle this is.

1. put a `zone-legacy.js` inside `es2015-polyfill.js`.
2. put `zone-evergreen.js` inside `polyfill.ts`.

So 
1. in `es5 legacy browser`, it will load `zone-legacy.js` + `zone-evergreen.js`.
2. in `modern browser`, it will only load `zone-evergreen.js`.


Before this PR, `zone-legacy.js` need to be loaded after `zone-evergreen.js`, because  the `zone-legacy` use a lot of `common logic` from `zone-evergreen.js`. So in this PR,

1. `zone-legacy.js` is a `lazy load module` which will only define a `factory function`.
2. When `zone-evergreen.js` loading, it will check whether this `lazy load module exist`, if exists, it will execute the `zone-legacy patch logic`. 