### PR TITLE
Ensure that EventTarget is patched prior to legacy property descriptor patch

### DIFF
--- a/lib/browser/event-target-legacy.ts
+++ b/lib/browser/event-target-legacy.ts
@@ -101,7 +101,7 @@ export function eventTargetLegacyPatch(_global: any, api: _ZonePrivate) {
   // vh is validateHandler to check event handler
   // is valid or not(for security check)
   api.patchEventTarget(_global, apiTypes, {vh: checkIEAndCrossContext});
-  (Zone as any)[api.symbol('patchEventTarget')] = true;
+  (Zone as any)[api.symbol('patchEventTarget')] = !!_global[EVENT_TARGET];
   return true;
 }
 

--- a/lib/browser/event-target-legacy.ts
+++ b/lib/browser/event-target-legacy.ts
@@ -101,7 +101,7 @@ export function eventTargetLegacyPatch(_global: any, api: _ZonePrivate) {
   // vh is validateHandler to check event handler
   // is valid or not(for security check)
   api.patchEventTarget(_global, apiTypes, {vh: checkIEAndCrossContext});
-
+  (Zone as any)[api.symbol('patchEventTarget')] = true;
   return true;
 }
 

--- a/lib/browser/event-target-legacy.ts
+++ b/lib/browser/event-target-legacy.ts
@@ -24,7 +24,7 @@ export function eventTargetLegacyPatch(_global: any, api: _ZonePrivate) {
     // Workaround for: https://github.com/google/tracing-framework/issues/555
     apis = WTF_ISSUE_555_ARRAY.map((v) => 'HTML' + v + 'Element').concat(NO_EVENT_TARGET);
   } else if (_global[EVENT_TARGET]) {
-    // EventTarget is already patched in browser.ts
+    apis.push(EVENT_TARGET);
   } else {
     // Note: EventTarget is not available in all browsers,
     // if it's not available, we instead patch the APIs in the IDL that inherit from EventTarget

--- a/lib/browser/event-target.ts
+++ b/lib/browser/event-target.ts
@@ -7,6 +7,10 @@
  */
 
 export function eventTargetPatch(_global: any, api: _ZonePrivate) {
+  if ((Zone as any)[api.symbol('patchEventTarget')]) {
+    // EventTarget is already patched.
+    return;
+  }
   const {eventNames, zoneSymbolEventNames, TRUE_STR, FALSE_STR, ZONE_SYMBOL_PREFIX} =
       api.getGlobalObjects()!;
   //  predefine all __zone_symbol__ + eventName + true/false string


### PR DESCRIPTION
If the event that EventTarget is defined on a device that also does not support patch via property descriptor, the result is that the XMLHttpRequest class would be patched prior to the event target being patched (due to returning in event-target-legacy if EventTarget is defined). This results in the wrapper that replaces XMLHttpRequest missing the patched listener fields. E.g. __zone_symbol__addEventListener and __zone_symbol__removeEventListener
event-target-legacy.

The result is that for any attempted http requests, a type error occurs in scheduleTask in browse.ts -> patchXhr, due to attempting call to non-existent __zone_symbol__addEventListener and  __zone_symbol__removeEventListener, causing the requests to fail.

Ensuring that patching of event target for legacy path takes place before legacy property descriptor patch eliminates this problem.