### PR TITLE
electron: fix #1200, handle electron 4 API changes

### DIFF
--- a/lib/extra/electron.ts
+++ b/lib/extra/electron.ts
@@ -11,7 +11,7 @@ Zone.__load_patch('electron', (global: any, Zone: ZoneType, api: _ZonePrivate) =
       return delegate && delegate.apply(self, api.bindArguments(args, source));
     });
   }
-  const {desktopCapturer, shell, CallbacksRegistry} = require('electron');
+  const {desktopCapturer, shell, CallbacksRegistry, ipcRenderer} = require('electron');
   // patch api in renderer process directly
   // desktopCapturer
   if (desktopCapturer) {
@@ -24,6 +24,8 @@ Zone.__load_patch('electron', (global: any, Zone: ZoneType, api: _ZonePrivate) =
 
   // patch api in main process through CallbackRegistry
   if (!CallbacksRegistry) {
+    // from Electron 4, the CallbackRegistry is not exposed, we need to patch ipcRenderer
+    patchArguments(ipcRenderer, 'on', 'ipcRenderer.on');
     return;
   }
 


### PR DESCRIPTION
from electron 4, the `CallbacksRegistry` will not be exposed, so we need to patch `ipcRenderer.on` to handle `main<->Renderer` Process event handler patch.