### PR TITLE
fix: fakeAsyncTest requestAnimationFrame should pass timestamp as parameter

### DIFF
--- a/lib/zone-spec/fake-async-test.ts
+++ b/lib/zone-spec/fake-async-test.ts
@@ -143,7 +143,8 @@ class Scheduler {
         if (doTick) {
           doTick(this._currentTime - lastCurrentTime);
         }
-        let retval = current.func.apply(global, current.args);
+        let retval = current.func.apply(
+            global, current.isRequestAnimationFrame ? [this._currentTime] : current.args);
         if (!retval) {
           // Uncaught exception in the current scheduled function. Stop processing the queue.
           break;

--- a/test/zone-spec/fake-async-test.spec.ts
+++ b/test/zone-spec/fake-async-test.spec.ts
@@ -741,6 +741,24 @@ describe('FakeAsyncTestZoneSpec', () => {
                      expect(ran).toEqual(true);
                    });
                  });
+                 it('should pass timestamp as parameter', () => {
+                   let timestamp = 0;
+                   let timestamp1 = 0;
+                   fakeAsyncTestZone.run(() => {
+                     requestAnimationFrame((ts) => {
+                       timestamp = ts;
+                       requestAnimationFrame(ts1 => {
+                         timestamp1 = ts1;
+                       });
+                     });
+                     const elapsed = testZoneSpec.flush(20, true);
+                     const elapsed1 = testZoneSpec.flush(20, true);
+                     expect(elapsed).toEqual(16);
+                     expect(elapsed1).toEqual(16);
+                     expect(timestamp).toEqual(16);
+                     expect(timestamp1).toEqual(32);
+                   });
+                 });
                }));
     });
   });


### PR DESCRIPTION
Close #1216