### PR TITLE
feat: add option to disable jasmine clock patch, also rename the flag of auto jump in FakeAsyncTest

### DIFF
--- a/test/browser-zone-setup.ts
+++ b/test/browser-zone-setup.ts
@@ -7,7 +7,7 @@
  */
 if (typeof window !== 'undefined') {
   (window as any)['__Zone_enable_cross_context_check'] = true;
-  (window as any)['__zone_symbol__fakeAsyncPatchLock'] = true;
+  (window as any)['__zone_symbol__fakeAsyncAutoFakeAsyncWhenClockPatched'] = true;
 }
 import '../lib/common/to-string';
 import '../lib/browser/api-util';

--- a/test/node_entry_point.ts
+++ b/test/node_entry_point.ts
@@ -8,8 +8,8 @@
 
 // Must be loaded before zone loads, so that zone can detect WTF.
 if (typeof global !== 'undefined' &&
-    (global as any)['__zone_symbol__fakeAsyncPatchLock'] !== false) {
-  (global as any)['__zone_symbol__fakeAsyncPatchLock'] = true;
+    (global as any)['__zone_symbol__fakeAsyncAutoFakeAsyncWhenClockPatched'] !== false) {
+  (global as any)['__zone_symbol__fakeAsyncAutoFakeAsyncWhenClockPatched'] = true;
 }
 import './wtf_mock';
 import './test_fake_polyfill';

--- a/test/test-env-setup-jasmine-no-patch-clock.ts
+++ b/test/test-env-setup-jasmine-no-patch-clock.ts
@@ -5,4 +5,4 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-(global as any)['__zone_symbol__fakeAsyncPatchLock'] = false;
+(global as any)['__zone_symbol__fakeAsyncAutoFakeAsyncWhenClockPatched'] = false;

--- a/test/zone-spec/fake-async-test.spec.ts
+++ b/test/zone-spec/fake-async-test.spec.ts
@@ -22,7 +22,8 @@ function supportNode() {
 
 function supportClock() {
   const _global: any = typeof window === 'undefined' ? global : window;
-  return typeof jasmine.clock === 'function' && _global['__zone_symbol__fakeAsyncPatchLock'];
+  return typeof jasmine.clock === 'function' &&
+      _global['__zone_symbol__fakeAsyncAutoFakeAsyncWhenClockPatched'];
 }
 
 (supportClock as any).message = 'support patch clock';


### PR DESCRIPTION
1. add an option `fakeAsyncDisablePatchingClock` to be able to disable `jasmine.clock patch`.
2. rename `fakeAsyncPatchLock` to `fakeAsyncAutoFakeAsyncWhenClockPatched` because the original name is confused.
3. if `fakeAsyncDisablePatchingClock` is true, should also make `fakeAsyncAutoFakeAsyncWhenClockPatched` to be `false`.

@vikerman, please review, thanks!