### PR TITLE
fix: move property patch to legacy

### DIFF
--- a/file-size-limit.json
+++ b/file-size-limit.json
@@ -8,7 +8,7 @@
     {
       "path": "dist/zone.min.js",
       "checkTarget": true,
-      "limit": 44000
+      "limit": 44500
     }
   ]
 }

--- a/lib/browser/browser-legacy.ts
+++ b/lib/browser/browser-legacy.ts
@@ -10,6 +10,7 @@
  * @suppress {missingRequire}
  */
 
+import {propertyPatch} from './define-property';
 import {eventTargetLegacyPatch} from './event-target-legacy';
 import {propertyDescriptorLegacyPatch} from './property-descriptor-legacy';
 import {registerElementPatch} from './register-element';
@@ -17,6 +18,9 @@ import {registerElementPatch} from './register-element';
 (function(_global: any) {
 _global['__zone_symbol__legacyPatch'] = function() {
   const Zone = _global['Zone'];
+  Zone.__load_patch('defineProperty', () => {
+    propertyPatch();
+  });
   Zone.__load_patch('registerElement', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
     registerElementPatch(global, api);
   });

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -15,7 +15,6 @@ import {patchTimer} from '../common/timers';
 import {patchClass, patchMethod, patchPrototype, scheduleMacroTaskWithCurrentZone, ZONE_SYMBOL_ADD_EVENT_LISTENER, ZONE_SYMBOL_REMOVE_EVENT_LISTENER, zoneSymbol} from '../common/utils';
 
 import {patchCustomElements} from './custom-elements';
-import {propertyPatch} from './define-property';
 import {eventTargetPatch, patchEvent} from './event-target';
 import {propertyDescriptorPatch} from './property-descriptor';
 
@@ -68,7 +67,6 @@ Zone.__load_patch('EventTarget', (global: any, Zone: ZoneType, api: _ZonePrivate
 
 Zone.__load_patch('on_property', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
   propertyDescriptorPatch(api, global);
-  propertyPatch();
 });
 
 Zone.__load_patch('customElements', (global: any, Zone: ZoneType, api: _ZonePrivate) => {

--- a/test/browser/define-property.spec.ts
+++ b/test/browser/define-property.spec.ts
@@ -13,15 +13,27 @@ describe('defineProperty', function() {
         .not.toThrow();
   });
 
-  it('should not throw error when try to defineProperty with a frozen desc', function() {
+  it('should not be able to change a frozen desc', function() {
     const obj = {};
     const desc = Object.freeze({value: null, writable: true});
     Object.defineProperty(obj, 'prop', desc);
+    let objDesc: any = Object.getOwnPropertyDescriptor(obj, 'prop');
+    expect(objDesc.writable).toBeTruthy();
+    try {
+      Object.defineProperty(obj, 'prop', {configurable: true, writable: true, value: 'test'});
+    } catch (err) {
+    }
+    objDesc = Object.getOwnPropertyDescriptor(obj, 'prop');
+    expect(objDesc.configurable).toBeFalsy();
   });
 
   it('should not throw error when try to defineProperty with a frozen obj', function() {
     const obj = {};
     Object.freeze(obj);
-    Object.defineProperty(obj, 'prop', {configurable: true, writable: true, value: 'value'});
+    try {
+      Object.defineProperty(obj, 'prop', {configurable: true, writable: true, value: 'value'});
+    } catch (err) {
+    }
+    expect((obj as any).prop).toBeFalsy();
   });
 });


### PR DESCRIPTION
Close #1224

Should not try to override `Object.defineProperty` in `evergreen browser`, because this property patch seems for some old browser (chrome mobile for customElement createdCallback).